### PR TITLE
refactor: move mock APIs and services into mock module

### DIFF
--- a/internal/mock/api_health.go
+++ b/internal/mock/api_health.go
@@ -1,0 +1,24 @@
+package mock
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/influxdata/influx-cli/v2/internal/api"
+)
+
+var _ api.HealthApi = (*HealthApi)(nil)
+
+type HealthApi struct {
+	GetHealthExecuteFn func(api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error)
+}
+
+func (p *HealthApi) GetHealth(context.Context) api.ApiGetHealthRequest {
+	return api.ApiGetHealthRequest{
+		ApiService: p,
+	}
+}
+
+func (p *HealthApi) GetHealthExecute(req api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
+	return p.GetHealthExecuteFn(req)
+}

--- a/internal/mock/api_setup.go
+++ b/internal/mock/api_setup.go
@@ -1,0 +1,32 @@
+package mock
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/influxdata/influx-cli/v2/internal/api"
+)
+
+var _ api.SetupApi = (*SetupApi)(nil)
+
+type SetupApi struct {
+	GetSetupExecuteFn  func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error)
+	PostSetupExecuteFn func(api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error)
+}
+
+func (s *SetupApi) GetSetup(context.Context) api.ApiGetSetupRequest {
+	return api.ApiGetSetupRequest{
+		ApiService: s,
+	}
+}
+func (s *SetupApi) GetSetupExecute(req api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
+	return s.GetSetupExecuteFn(req)
+}
+func (s *SetupApi) PostSetup(context.Context) api.ApiPostSetupRequest {
+	return api.ApiPostSetupRequest{
+		ApiService: s,
+	}
+}
+func (s *SetupApi) PostSetupExecute(req api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error) {
+	return s.PostSetupExecuteFn(req)
+}

--- a/internal/mock/config.go
+++ b/internal/mock/config.go
@@ -1,0 +1,33 @@
+package mock
+
+import "github.com/influxdata/influx-cli/v2/internal/config"
+
+var _ config.Service = (*ConfigService)(nil)
+
+type ConfigService struct {
+	CreateConfigFn func(config.Config) (config.Config, error)
+	DeleteConfigFn func(string) (config.Config, error)
+	UpdateConfigFn func(config.Config) (config.Config, error)
+	SwitchActiveFn func(string) (config.Config, error)
+	ActiveFn       func() (config.Config, error)
+	ListConfigsFn  func() (config.Configs, error)
+}
+
+func (c *ConfigService) CreateConfig(cfg config.Config) (config.Config, error) {
+	return c.CreateConfigFn(cfg)
+}
+func (c *ConfigService) DeleteConfig(name string) (config.Config, error) {
+	return c.DeleteConfigFn(name)
+}
+func (c *ConfigService) UpdateConfig(cfg config.Config) (config.Config, error) {
+	return c.UpdateConfigFn(cfg)
+}
+func (c *ConfigService) SwitchActive(name string) (config.Config, error) {
+	return c.SwitchActiveFn(name)
+}
+func (c *ConfigService) Active() (config.Config, error) {
+	return c.ActiveFn()
+}
+func (c *ConfigService) ListConfigs() (config.Configs, error) {
+	return c.ListConfigsFn()
+}

--- a/internal/setup_test.go
+++ b/internal/setup_test.go
@@ -17,68 +17,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type setupTestConfigSvc struct {
-	CreateConfigFn func(config.Config) (config.Config, error)
-	DeleteConfigFn func(string) (config.Config, error)
-	UpdateConfigFn func(config.Config) (config.Config, error)
-	SwitchActiveFn func(string) (config.Config, error)
-	ActiveFn       func() (config.Config, error)
-	ListConfigsFn  func() (config.Configs, error)
-}
-
-func (ts *setupTestConfigSvc) CreateConfig(cfg config.Config) (config.Config, error) {
-	return ts.CreateConfigFn(cfg)
-}
-func (ts *setupTestConfigSvc) DeleteConfig(name string) (config.Config, error) {
-	return ts.DeleteConfigFn(name)
-}
-func (ts *setupTestConfigSvc) UpdateConfig(cfg config.Config) (config.Config, error) {
-	return ts.UpdateConfigFn(cfg)
-}
-func (ts *setupTestConfigSvc) SwitchActive(name string) (config.Config, error) {
-	return ts.SwitchActiveFn(name)
-}
-func (ts *setupTestConfigSvc) Active() (config.Config, error) {
-	return ts.ActiveFn()
-}
-func (ts *setupTestConfigSvc) ListConfigs() (config.Configs, error) {
-	return ts.ListConfigsFn()
-}
-
-type setupTestClient struct {
-	GetSetupExecuteFn  func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error)
-	PostSetupExecuteFn func(api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error)
-}
-
-func (tc *setupTestClient) GetSetup(context.Context) api.ApiGetSetupRequest {
-	return api.ApiGetSetupRequest{
-		ApiService: tc,
-	}
-}
-func (tc *setupTestClient) GetSetupExecute(req api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-	return tc.GetSetupExecuteFn(req)
-}
-func (tc *setupTestClient) PostSetup(context.Context) api.ApiPostSetupRequest {
-	return api.ApiPostSetupRequest{
-		ApiService: tc,
-	}
-}
-func (tc *setupTestClient) PostSetupExecute(req api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error) {
-	return tc.PostSetupExecuteFn(req)
-}
-
 func Test_SetupConfigNameCollision(t *testing.T) {
 	t.Parallel()
 
 	cfg := "foo"
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return map[string]config.Config{cfg: {}}, nil
 		},
 	}
 	cli := &internal.CLI{ConfigService: configSvc}
 
-	err := cli.Setup(context.Background(), &setupTestClient{}, &internal.SetupParams{ConfigName: cfg})
+	err := cli.Setup(context.Background(), &mock.SetupApi{}, &internal.SetupParams{ConfigName: cfg})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), cfg)
 	require.Contains(t, err.Error(), "already exists")
@@ -87,14 +37,14 @@ func Test_SetupConfigNameCollision(t *testing.T) {
 func Test_SetupConfigNameRequired(t *testing.T) {
 	t.Parallel()
 
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return map[string]config.Config{"foo": {}}, nil
 		},
 	}
 	cli := &internal.CLI{ConfigService: configSvc}
 
-	err := cli.Setup(context.Background(), &setupTestClient{}, &internal.SetupParams{})
+	err := cli.Setup(context.Background(), &mock.SetupApi{}, &internal.SetupParams{})
 	require.Error(t, err)
 	require.Equal(t, internal.ErrConfigNameRequired, err)
 }
@@ -102,13 +52,13 @@ func Test_SetupConfigNameRequired(t *testing.T) {
 func Test_SetupAlreadySetup(t *testing.T) {
 	t.Parallel()
 
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			return api.InlineResponse200{Allowed: api.PtrBool(false)}, nil, nil
 		},
 	}
 
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},
@@ -124,13 +74,13 @@ func Test_SetupCheckFailed(t *testing.T) {
 	t.Parallel()
 
 	e := "oh no"
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			return api.InlineResponse200{}, nil, errors.New(e)
 		},
 	}
 
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},
@@ -162,7 +112,7 @@ func Test_SetupSuccessNoninteractive(t *testing.T) {
 		User:   &api.UserResponse{Name: params.Username},
 		Bucket: &api.Bucket{Name: params.Bucket},
 	}
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
 		},
@@ -179,7 +129,7 @@ func Test_SetupSuccessNoninteractive(t *testing.T) {
 	}
 
 	host := "fake-host"
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},
@@ -223,7 +173,7 @@ func Test_SetupSuccessNoninteractiveWithTracing(t *testing.T) {
 		User:   &api.UserResponse{Name: params.Username},
 		Bucket: &api.Bucket{Name: params.Bucket},
 	}
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(req api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			require.Equal(t, traceId, *req.GetZapTraceSpan())
 			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
@@ -242,7 +192,7 @@ func Test_SetupSuccessNoninteractiveWithTracing(t *testing.T) {
 	}
 
 	host := "fake-host"
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},
@@ -282,7 +232,7 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 		User:   &api.UserResponse{Name: username},
 		Bucket: &api.Bucket{Name: bucket},
 	}
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
 		},
@@ -299,7 +249,7 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 	}
 
 	host := "fake-host"
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},
@@ -342,14 +292,14 @@ func Test_SetupPasswordParamToShort(t *testing.T) {
 		Retention: fmt.Sprintf("%ds", retentionSecs),
 		Force:     false,
 	}
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
 		},
 	}
 
 	host := "fake-host"
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},
@@ -373,14 +323,14 @@ func Test_SetupCancelAtConfirmation(t *testing.T) {
 		Retention: fmt.Sprintf("%ds", retentionSecs),
 		Force:     false,
 	}
-	client := &setupTestClient{
+	client := &mock.SetupApi{
 		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
 			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
 		},
 	}
 
 	host := "fake-host"
-	configSvc := &setupTestConfigSvc{
+	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return nil, nil
 		},


### PR DESCRIPTION
I made this cleanup when I first started working on #25 and thought there would be a lot of mocks needed for it. It turned out to not be the case, but I still think this is an improvement in the repo's organization.