### PR TITLE
refactor: split CLI commands into separate files

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -85,14 +85,6 @@ var commonFlagsNoToken = []cli.Flag{
 	},
 }
 
-// Most commands use this form of the token flag.
-//var commonFlags = append(commonFlagsNoToken, &cli.StringFlag{
-//	Name:    tokenFlag,
-//	Usage:   "Authentication token",
-//	Aliases: []string{"t"},
-//	EnvVars: []string{"INFLUX_TOKEN"},
-//})
-
 // newCli builds a CLI core that reads from stdin, writes to stdout/stderr, manages a local config store,
 // and optionally tracks a trace ID specified over the CLI.
 func newCli(ctx *cli.Context) (*internal.CLI, error) {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -86,12 +86,12 @@ var commonFlagsNoToken = []cli.Flag{
 }
 
 // Most commands use this form of the token flag.
-var commonFlags = append(commonFlagsNoToken, &cli.StringFlag{
-	Name:    tokenFlag,
-	Usage:   "Authentication token",
-	Aliases: []string{"t"},
-	EnvVars: []string{"INFLUX_TOKEN"},
-})
+//var commonFlags = append(commonFlagsNoToken, &cli.StringFlag{
+//	Name:    tokenFlag,
+//	Usage:   "Authentication token",
+//	Aliases: []string{"t"},
+//	EnvVars: []string{"INFLUX_TOKEN"},
+//})
 
 // newCli builds a CLI core that reads from stdin, writes to stdout/stderr, manages a local config store,
 // and optionally tracks a trace ID specified over the CLI.

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -1,0 +1,20 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+var pingCmd = cli.Command{
+	Name:  "ping",
+	Usage: "Check the InfluxDB /health endpoint",
+	Flags: commonFlagsNoToken,
+	Action: func(ctx *cli.Context) error {
+		cli, err := newCli(ctx)
+		if err != nil {
+			return err
+		}
+		client, err := newApiClient(ctx, cli, false)
+		if err != nil {
+			return err
+		}
+		return cli.Ping(standardCtx(ctx), client.HealthApi)
+	},
+}

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"github.com/influxdata/influx-cli/v2/internal"
+	"github.com/urfave/cli/v2"
+)
+
+var setupCmd = cli.Command{
+	Name:  "setup",
+	Usage: "Setup instance with initial user, org, bucket",
+	Flags: append(
+		commonFlagsNoToken,
+		&cli.StringFlag{
+			Name:    "username",
+			Usage:   "Name of initial user to create",
+			Aliases: []string{"u"},
+		},
+		&cli.StringFlag{
+			Name:    "password",
+			Usage:   "Password to set on initial user",
+			Aliases: []string{"p"},
+		},
+		&cli.StringFlag{
+			Name:        tokenFlag,
+			Usage:       "Auth token to set on the initial user",
+			Aliases:     []string{"t"},
+			EnvVars:     []string{"INFLUX_TOKEN"},
+			DefaultText: "auto-generated",
+		},
+		&cli.StringFlag{
+			Name:    "org",
+			Usage:   "Name of initial organization to create",
+			Aliases: []string{"o"},
+		},
+		&cli.StringFlag{
+			Name:    "bucket",
+			Usage:   "Name of initial bucket to create",
+			Aliases: []string{"b"},
+		},
+		&cli.StringFlag{
+			Name:        "retention",
+			Usage:       "Duration initial bucket will retain data, or 0 for infinite",
+			Aliases:     []string{"r"},
+			DefaultText: "infinite",
+		},
+		&cli.BoolFlag{
+			Name:    "force",
+			Usage:   "Skip confirmation prompt",
+			Aliases: []string{"f"},
+		},
+		&cli.StringFlag{
+			Name:    "name",
+			Usage:   "Name to set on CLI config generated for the InfluxDB instance, required if other configs exist",
+			Aliases: []string{"n"},
+		},
+		&cli.BoolFlag{
+			Name:    printJsonFlag,
+			Usage:   "Output data as JSON",
+			EnvVars: []string{"INFLUX_OUTPUT_JSON"},
+		},
+		&cli.BoolFlag{
+			Name:    hideHeadersFlag,
+			Usage:   "Hide the table headers in output data",
+			EnvVars: []string{"INFLUX_HIDE_HEADERS"},
+		},
+	),
+	Action: func(ctx *cli.Context) error {
+		cli, err := newCli(ctx)
+		if err != nil {
+			return err
+		}
+		client, err := newApiClient(ctx, cli, false)
+		if err != nil {
+			return err
+		}
+		return cli.Setup(standardCtx(ctx), client.SetupApi, &internal.SetupParams{
+			Username:   ctx.String("username"),
+			Password:   ctx.String("password"),
+			AuthToken:  ctx.String(tokenFlag),
+			Org:        ctx.String("org"),
+			Bucket:     ctx.String("bucket"),
+			Retention:  ctx.String("retention"),
+			Force:      ctx.Bool("force"),
+			ConfigName: ctx.String("name"),
+		})
+	},
+}

--- a/cmd/influx/version.go
+++ b/cmd/influx/version.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+)
+
+var versionCmd = cli.Command{
+	Name:  "version",
+	Usage: "Print the influx CLI version",
+	Action: func(*cli.Context) error {
+		fmt.Printf("Influx CLI %s (git: %s) build_date: %s\n", version, commit, date)
+		return nil
+	},
+}


### PR DESCRIPTION
Part of #25 

We're starting to port commands that take a large number of flags. Split to a file-per-command to (hopefully) make things more sustainable.