### PR TITLE
refactor: switch to Execute() method on requests

### DIFF
--- a/internal/ping.go
+++ b/internal/ping.go
@@ -8,11 +8,9 @@ import (
 
 // Ping checks the health of a remote InfluxDB instance.
 func (c *CLI) Ping(ctx context.Context, client api.HealthApi) error {
-	req := client.GetHealth(ctx)
-	if _, _, err := client.GetHealthExecute(req); err != nil {
+	if _, _, err := client.GetHealth(ctx).Execute(); err != nil {
 		return err
 	}
-
 	_, err := c.StdIO.Write([]byte("OK\n"))
 	return err
 }

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -44,8 +44,7 @@ func (c *CLI) Setup(ctx context.Context, client api.SetupApi, params *SetupParam
 	}
 
 	// Check if setup is even allowed.
-	checkReq := client.GetSetup(ctx)
-	checkResp, _, err := client.GetSetupExecute(checkReq)
+	checkResp, _, err := client.GetSetup(ctx).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to check if already set up: %w", err)
 	}
@@ -58,8 +57,7 @@ func (c *CLI) Setup(ctx context.Context, client api.SetupApi, params *SetupParam
 	if err != nil {
 		return err
 	}
-	setupReq := client.PostSetup(ctx).OnboardingRequest(setupBody)
-	resp, _, err := client.PostSetupExecute(setupReq)
+	resp, _, err := client.PostSetup(ctx).OnboardingRequest(setupBody).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to setup instance: %w", err)
 	}

--- a/internal/write.go
+++ b/internal/write.go
@@ -69,7 +69,7 @@ func (c *CLI) Write(ctx context.Context, clients *WriteClients, params *WritePar
 			req = req.Org(c.ActiveConfig.Org)
 		}
 
-		if _, err := clients.Client.PostWriteExecute(req); err != nil {
+		if _, err := req.Execute(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Closes #55 

Tiny refactor to improve our code style while it's still a small surface area.