### PR TITLE
fix: check server status before local config to improve error message

### DIFF
--- a/internal/setup.go
+++ b/internal/setup.go
@@ -34,12 +34,6 @@ var (
 const MinPasswordLen = 8
 
 func (c *CLI) Setup(ctx context.Context, client api.SetupApi, params *SetupParams) error {
-	// Ensure we'll be able to write onboarding results to local config.
-	// Do this first so we catch any problems before modifying state on the server side.
-	if err := c.validateNoNameCollision(params.ConfigName); err != nil {
-		return err
-	}
-
 	// Check if setup is even allowed.
 	checkResp, _, err := client.GetSetup(ctx).Execute()
 	if err != nil {
@@ -47,6 +41,12 @@ func (c *CLI) Setup(ctx context.Context, client api.SetupApi, params *SetupParam
 	}
 	if checkResp.Allowed == nil || !*checkResp.Allowed {
 		return ErrAlreadySetUp
+	}
+
+	// Ensure we'll be able to write onboarding results to local config.
+	// Do this so we catch any problems before modifying state on the server side.
+	if err := c.validateNoNameCollision(params.ConfigName); err != nil {
+		return err
 	}
 
 	// Initialize the server.

--- a/internal/setup_test.go
+++ b/internal/setup_test.go
@@ -20,6 +20,12 @@ import (
 func Test_SetupConfigNameCollision(t *testing.T) {
 	t.Parallel()
 
+	client := &mock.SetupApi{
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		},
+	}
+
 	cfg := "foo"
 	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
@@ -28,7 +34,7 @@ func Test_SetupConfigNameCollision(t *testing.T) {
 	}
 	cli := &internal.CLI{ConfigService: configSvc}
 
-	err := cli.Setup(context.Background(), &mock.SetupApi{}, &internal.SetupParams{ConfigName: cfg})
+	err := cli.Setup(context.Background(), client, &internal.SetupParams{ConfigName: cfg})
 	require.Error(t, err)
 	require.Contains(t, err.Error(), cfg)
 	require.Contains(t, err.Error(), "already exists")
@@ -37,6 +43,12 @@ func Test_SetupConfigNameCollision(t *testing.T) {
 func Test_SetupConfigNameRequired(t *testing.T) {
 	t.Parallel()
 
+	client := &mock.SetupApi{
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		},
+	}
+
 	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
 			return map[string]config.Config{"foo": {}}, nil
@@ -44,7 +56,7 @@ func Test_SetupConfigNameRequired(t *testing.T) {
 	}
 	cli := &internal.CLI{ConfigService: configSvc}
 
-	err := cli.Setup(context.Background(), &mock.SetupApi{}, &internal.SetupParams{})
+	err := cli.Setup(context.Background(), client, &internal.SetupParams{})
 	require.Error(t, err)
 	require.Equal(t, internal.ErrConfigNameRequired, err)
 }

--- a/internal/setup_test.go
+++ b/internal/setup_test.go
@@ -60,7 +60,7 @@ func Test_SetupAlreadySetup(t *testing.T) {
 
 	configSvc := &mock.ConfigService{
 		ListConfigsFn: func() (config.Configs, error) {
-			return nil, nil
+			return map[string]config.Config{"foo": {}}, nil
 		},
 	}
 	cli := &internal.CLI{ConfigService: configSvc}


### PR DESCRIPTION
Before this change, if a user tried to double-setup their local server they'd see `config name is required if you already have existing configs`. That's technically correct, but IMO the more useful error to see is `instance has already been set up` (it's also the error they'd see in the old CLI).

Rearrange the validation performed by `setup` to make the server-side check run first.