### PR TITLE
refactor: improve codegen to support `influx query` rewrite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,11 @@ openapi:
 	./etc/generate-openapi.sh
 
 fmt: $(SOURCES_NO_VENDOR)
+	# Format everything, but the import-format doesn't match our desired pattern.
 	gofmt -w -s $^
+	# Remove unused imports.
+	go run golang.org/x/tools/cmd/goimports -w $^
+	# Format imports.
 	go run github.com/daixiang0/gci -w $^
 
 bin/$(GOOS)/influx: $(SOURCES)

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/text v0.3.3
+	golang.org/x/tools v0.1.0
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	honnef.co/go/tools v0.1.3
 )

--- a/internal/api/api_buckets.gen.go
+++ b/internal/api/api_buckets.gen.go
@@ -12,7 +12,9 @@ package api
 
 import (
 	"bytes"
+	_gzip "compress/gzip"
 	_context "context"
+	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -92,6 +94,22 @@ type BucketsApi interface {
 	 * @return Bucket
 	 */
 	PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error)
+}
+
+// bucketsApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
+type bucketsApiGzipReadCloser struct {
+	underlying _io.ReadCloser
+	gzip       _io.ReadCloser
+}
+
+func (gzrc *bucketsApiGzipReadCloser) Read(p []byte) (int, error) {
+	return gzrc.gzip.Read(p)
+}
+func (gzrc *bucketsApiGzipReadCloser) Close() error {
+	if err := gzrc.gzip.Close(); err != nil {
+		return err
+	}
+	return gzrc.underlying.Close()
 }
 
 // BucketsApiService BucketsApi service
@@ -192,9 +210,19 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 		return localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarHTTPResponse, err
+		}
+		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarHTTPResponse, err
@@ -395,9 +423,19 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -416,8 +454,8 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
@@ -531,9 +569,19 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -552,8 +600,8 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
@@ -681,9 +729,19 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -702,8 +760,8 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
@@ -819,9 +877,19 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -850,8 +918,8 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err

--- a/internal/api/api_buckets.gen.go
+++ b/internal/api/api_buckets.gen.go
@@ -192,14 +192,13 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -396,14 +395,13 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -418,6 +416,12 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
@@ -527,14 +531,13 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -549,6 +552,12 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
@@ -672,14 +681,13 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -694,6 +702,12 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
@@ -805,14 +819,13 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -837,6 +850,12 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{

--- a/internal/api/api_buckets.gen.go
+++ b/internal/api/api_buckets.gen.go
@@ -11,7 +11,6 @@
 package api
 
 import (
-	"bytes"
 	_gzip "compress/gzip"
 	_context "context"
 	_io "io"
@@ -39,7 +38,7 @@ type BucketsApi interface {
 	/*
 	 * DeleteBucketsIDExecute executes the request
 	 */
-	DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) (*_nethttp.Response, error)
+	DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) error
 
 	/*
 	 * GetBuckets List all buckets
@@ -52,7 +51,7 @@ type BucketsApi interface {
 	 * GetBucketsExecute executes the request
 	 * @return Buckets
 	 */
-	GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, *_nethttp.Response, error)
+	GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, error)
 
 	/*
 	 * GetBucketsID Retrieve a bucket
@@ -66,7 +65,7 @@ type BucketsApi interface {
 	 * GetBucketsIDExecute executes the request
 	 * @return Bucket
 	 */
-	GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, *_nethttp.Response, error)
+	GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, error)
 
 	/*
 	 * PatchBucketsID Update a bucket
@@ -80,7 +79,7 @@ type BucketsApi interface {
 	 * PatchBucketsIDExecute executes the request
 	 * @return Bucket
 	 */
-	PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, *_nethttp.Response, error)
+	PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, error)
 
 	/*
 	 * PostBuckets Create a bucket
@@ -93,7 +92,7 @@ type BucketsApi interface {
 	 * PostBucketsExecute executes the request
 	 * @return Bucket
 	 */
-	PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error)
+	PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, error)
 }
 
 // bucketsApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
@@ -138,7 +137,7 @@ func (r ApiDeleteBucketsIDRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiDeleteBucketsIDRequest) Execute() (*_nethttp.Response, error) {
+func (r ApiDeleteBucketsIDRequest) Execute() error {
 	return r.ApiService.DeleteBucketsIDExecute(r)
 }
 
@@ -159,7 +158,7 @@ func (a *BucketsApiService) DeleteBucketsID(ctx _context.Context, bucketID strin
 /*
  * Execute executes the request
  */
-func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) (*_nethttp.Response, error) {
+func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) error {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -170,7 +169,7 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.DeleteBucketsID")
 	if err != nil {
-		return nil, GenericOpenAPIError{error: err.Error()}
+		return GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}"
@@ -202,12 +201,12 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarHTTPResponse, err
+		return err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -215,7 +214,7 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarHTTPResponse, err
+			return err
 		}
 		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -223,9 +222,8 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarHTTPResponse, err
+			return err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -236,22 +234,22 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
+				return newErr
 			}
 			newErr.model = &v
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		newErr.model = &v
-		return localVarHTTPResponse, newErr
+		return newErr
 	}
 
-	return localVarHTTPResponse, nil
+	return nil
 }
 
 type ApiGetBucketsRequest struct {
@@ -331,7 +329,7 @@ func (r ApiGetBucketsRequest) GetId() *string {
 	return r.id
 }
 
-func (r ApiGetBucketsRequest) Execute() (Buckets, *_nethttp.Response, error) {
+func (r ApiGetBucketsRequest) Execute() (Buckets, error) {
 	return r.ApiService.GetBucketsExecute(r)
 }
 
@@ -351,7 +349,7 @@ func (a *BucketsApiService) GetBuckets(ctx _context.Context) ApiGetBucketsReques
  * Execute executes the request
  * @return Buckets
  */
-func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, *_nethttp.Response, error) {
+func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -363,7 +361,7 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.GetBuckets")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets"
@@ -415,12 +413,12 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -428,7 +426,7 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -436,9 +434,8 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -448,17 +445,16 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -466,10 +462,10 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }
 
 type ApiGetBucketsIDRequest struct {
@@ -495,7 +491,7 @@ func (r ApiGetBucketsIDRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiGetBucketsIDRequest) Execute() (Bucket, *_nethttp.Response, error) {
+func (r ApiGetBucketsIDRequest) Execute() (Bucket, error) {
 	return r.ApiService.GetBucketsIDExecute(r)
 }
 
@@ -517,7 +513,7 @@ func (a *BucketsApiService) GetBucketsID(ctx _context.Context, bucketID string) 
  * Execute executes the request
  * @return Bucket
  */
-func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, *_nethttp.Response, error) {
+func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -529,7 +525,7 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.GetBucketsID")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}"
@@ -561,12 +557,12 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -574,7 +570,7 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -582,9 +578,8 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -594,17 +589,16 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -612,10 +606,10 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }
 
 type ApiPatchBucketsIDRequest struct {
@@ -650,7 +644,7 @@ func (r ApiPatchBucketsIDRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiPatchBucketsIDRequest) Execute() (Bucket, *_nethttp.Response, error) {
+func (r ApiPatchBucketsIDRequest) Execute() (Bucket, error) {
 	return r.ApiService.PatchBucketsIDExecute(r)
 }
 
@@ -672,7 +666,7 @@ func (a *BucketsApiService) PatchBucketsID(ctx _context.Context, bucketID string
  * Execute executes the request
  * @return Bucket
  */
-func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, *_nethttp.Response, error) {
+func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -684,7 +678,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.PatchBucketsID")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}"
@@ -694,7 +688,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.patchBucketRequest == nil {
-		return localVarReturnValue, nil, reportError("patchBucketRequest is required and must be specified")
+		return localVarReturnValue, reportError("patchBucketRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -721,12 +715,12 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 	localVarPostBody = r.patchBucketRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -734,7 +728,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -742,9 +736,8 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -754,17 +747,16 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -772,10 +764,10 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }
 
 type ApiPostBucketsRequest struct {
@@ -801,7 +793,7 @@ func (r ApiPostBucketsRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiPostBucketsRequest) Execute() (Bucket, *_nethttp.Response, error) {
+func (r ApiPostBucketsRequest) Execute() (Bucket, error) {
 	return r.ApiService.PostBucketsExecute(r)
 }
 
@@ -821,7 +813,7 @@ func (a *BucketsApiService) PostBuckets(ctx _context.Context) ApiPostBucketsRequ
  * Execute executes the request
  * @return Bucket
  */
-func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error) {
+func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -833,7 +825,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.PostBuckets")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets"
@@ -842,7 +834,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.postBucketRequest == nil {
-		return localVarReturnValue, nil, reportError("postBucketRequest is required and must be specified")
+		return localVarReturnValue, reportError("postBucketRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -869,12 +861,12 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 	localVarPostBody = r.postBucketRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -882,7 +874,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &bucketsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -890,9 +882,8 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -903,26 +894,25 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
+				return localVarReturnValue, newErr
 			}
 			newErr.model = &v
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -930,8 +920,8 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }

--- a/internal/api/api_health.gen.go
+++ b/internal/api/api_health.gen.go
@@ -11,7 +11,6 @@
 package api
 
 import (
-	"bytes"
 	_gzip "compress/gzip"
 	_context "context"
 	_io "io"
@@ -38,7 +37,7 @@ type HealthApi interface {
 	 * GetHealthExecute executes the request
 	 * @return HealthCheck
 	 */
-	GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, *_nethttp.Response, error)
+	GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, error)
 }
 
 // healthApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
@@ -74,7 +73,7 @@ func (r ApiGetHealthRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiGetHealthRequest) Execute() (HealthCheck, *_nethttp.Response, error) {
+func (r ApiGetHealthRequest) Execute() (HealthCheck, error) {
 	return r.ApiService.GetHealthExecute(r)
 }
 
@@ -94,7 +93,7 @@ func (a *HealthApiService) GetHealth(ctx _context.Context) ApiGetHealthRequest {
  * Execute executes the request
  * @return HealthCheck
  */
-func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, *_nethttp.Response, error) {
+func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -106,7 +105,7 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "HealthApiService.GetHealth")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/health"
@@ -137,12 +136,12 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -150,7 +149,7 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &healthApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -158,9 +157,8 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -171,26 +169,25 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarReturnValue, localVarHTTPResponse, newErr
+				return localVarReturnValue, newErr
 			}
 			newErr.model = &v
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -198,8 +195,8 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }

--- a/internal/api/api_health.gen.go
+++ b/internal/api/api_health.gen.go
@@ -127,14 +127,13 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -159,6 +158,12 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{

--- a/internal/api/api_organizations.gen.go
+++ b/internal/api/api_organizations.gen.go
@@ -212,14 +212,13 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -234,6 +233,12 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
@@ -345,14 +350,13 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -367,6 +371,12 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{

--- a/internal/api/api_organizations.gen.go
+++ b/internal/api/api_organizations.gen.go
@@ -12,7 +12,9 @@ package api
 
 import (
 	"bytes"
+	_gzip "compress/gzip"
 	_context "context"
+	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -50,6 +52,22 @@ type OrganizationsApi interface {
 	 * @return Organization
 	 */
 	PostOrgsExecute(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error)
+}
+
+// organizationsApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
+type organizationsApiGzipReadCloser struct {
+	underlying _io.ReadCloser
+	gzip       _io.ReadCloser
+}
+
+func (gzrc *organizationsApiGzipReadCloser) Read(p []byte) (int, error) {
+	return gzrc.gzip.Read(p)
+}
+func (gzrc *organizationsApiGzipReadCloser) Close() error {
+	if err := gzrc.gzip.Close(); err != nil {
+		return err
+	}
+	return gzrc.underlying.Close()
 }
 
 // OrganizationsApiService OrganizationsApi service
@@ -212,9 +230,19 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &organizationsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -233,8 +261,8 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
@@ -350,9 +378,19 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &organizationsApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -371,8 +409,8 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err

--- a/internal/api/api_organizations.gen.go
+++ b/internal/api/api_organizations.gen.go
@@ -11,7 +11,6 @@
 package api
 
 import (
-	"bytes"
 	_gzip "compress/gzip"
 	_context "context"
 	_io "io"
@@ -38,7 +37,7 @@ type OrganizationsApi interface {
 	 * GetOrgsExecute executes the request
 	 * @return Organizations
 	 */
-	GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, *_nethttp.Response, error)
+	GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, error)
 
 	/*
 	 * PostOrgs Create an organization
@@ -51,7 +50,7 @@ type OrganizationsApi interface {
 	 * PostOrgsExecute executes the request
 	 * @return Organization
 	 */
-	PostOrgsExecute(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error)
+	PostOrgsExecute(r ApiPostOrgsRequest) (Organization, error)
 }
 
 // organizationsApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
@@ -141,7 +140,7 @@ func (r ApiGetOrgsRequest) GetUserID() *string {
 	return r.userID
 }
 
-func (r ApiGetOrgsRequest) Execute() (Organizations, *_nethttp.Response, error) {
+func (r ApiGetOrgsRequest) Execute() (Organizations, error) {
 	return r.ApiService.GetOrgsExecute(r)
 }
 
@@ -161,7 +160,7 @@ func (a *OrganizationsApiService) GetOrgs(ctx _context.Context) ApiGetOrgsReques
  * Execute executes the request
  * @return Organizations
  */
-func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, *_nethttp.Response, error) {
+func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -173,7 +172,7 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.GetOrgs")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs"
@@ -222,12 +221,12 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -235,7 +234,7 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &organizationsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -243,9 +242,8 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -255,17 +253,16 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -273,10 +270,10 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }
 
 type ApiPostOrgsRequest struct {
@@ -302,7 +299,7 @@ func (r ApiPostOrgsRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiPostOrgsRequest) Execute() (Organization, *_nethttp.Response, error) {
+func (r ApiPostOrgsRequest) Execute() (Organization, error) {
 	return r.ApiService.PostOrgsExecute(r)
 }
 
@@ -322,7 +319,7 @@ func (a *OrganizationsApiService) PostOrgs(ctx _context.Context) ApiPostOrgsRequ
  * Execute executes the request
  * @return Organization
  */
-func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error) {
+func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organization, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -334,7 +331,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.PostOrgs")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs"
@@ -343,7 +340,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.organization == nil {
-		return localVarReturnValue, nil, reportError("organization is required and must be specified")
+		return localVarReturnValue, reportError("organization is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -370,12 +367,12 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 	localVarPostBody = r.organization
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -383,7 +380,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &organizationsApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -391,9 +388,8 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -403,17 +399,16 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -421,8 +416,8 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }

--- a/internal/api/api_setup.gen.go
+++ b/internal/api/api_setup.gen.go
@@ -11,7 +11,6 @@
 package api
 
 import (
-	"bytes"
 	_gzip "compress/gzip"
 	_context "context"
 	_io "io"
@@ -39,7 +38,7 @@ type SetupApi interface {
 	 * GetSetupExecute executes the request
 	 * @return InlineResponse200
 	 */
-	GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, *_nethttp.Response, error)
+	GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, error)
 
 	/*
 	 * PostSetup Set up initial user, org and bucket
@@ -53,7 +52,7 @@ type SetupApi interface {
 	 * PostSetupExecute executes the request
 	 * @return OnboardingResponse
 	 */
-	PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error)
+	PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, error)
 }
 
 // setupApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
@@ -89,7 +88,7 @@ func (r ApiGetSetupRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiGetSetupRequest) Execute() (InlineResponse200, *_nethttp.Response, error) {
+func (r ApiGetSetupRequest) Execute() (InlineResponse200, error) {
 	return r.ApiService.GetSetupExecute(r)
 }
 
@@ -110,7 +109,7 @@ func (a *SetupApiService) GetSetup(ctx _context.Context) ApiGetSetupRequest {
  * Execute executes the request
  * @return InlineResponse200
  */
-func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, *_nethttp.Response, error) {
+func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -122,7 +121,7 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SetupApiService.GetSetup")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/setup"
@@ -153,12 +152,12 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -166,7 +165,7 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &setupApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -174,22 +173,20 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -197,10 +194,10 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }
 
 type ApiPostSetupRequest struct {
@@ -226,7 +223,7 @@ func (r ApiPostSetupRequest) GetZapTraceSpan() *string {
 	return r.zapTraceSpan
 }
 
-func (r ApiPostSetupRequest) Execute() (OnboardingResponse, *_nethttp.Response, error) {
+func (r ApiPostSetupRequest) Execute() (OnboardingResponse, error) {
 	return r.ApiService.PostSetupExecute(r)
 }
 
@@ -247,7 +244,7 @@ func (a *SetupApiService) PostSetup(ctx _context.Context) ApiPostSetupRequest {
  * Execute executes the request
  * @return OnboardingResponse
  */
-func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error) {
+func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -259,7 +256,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SetupApiService.PostSetup")
 	if err != nil {
-		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/setup"
@@ -268,7 +265,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.onboardingRequest == nil {
-		return localVarReturnValue, nil, reportError("onboardingRequest is required and must be specified")
+		return localVarReturnValue, reportError("onboardingRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -295,12 +292,12 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 	localVarPostBody = r.onboardingRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, nil, err
+		return localVarReturnValue, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -308,7 +305,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		body = &setupApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -316,9 +313,8 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarReturnValue, localVarHTTPResponse, err
+			return localVarReturnValue, err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -328,17 +324,16 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarReturnValue, localVarHTTPResponse, newErr
+			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
+		return localVarReturnValue, err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -346,8 +341,8 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return localVarReturnValue, localVarHTTPResponse, newErr
+		return localVarReturnValue, newErr
 	}
 
-	return localVarReturnValue, localVarHTTPResponse, nil
+	return localVarReturnValue, nil
 }

--- a/internal/api/api_setup.gen.go
+++ b/internal/api/api_setup.gen.go
@@ -143,14 +143,13 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -158,6 +157,12 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
@@ -270,14 +275,13 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarReturnValue, localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -292,6 +296,12 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return localVarReturnValue, localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{

--- a/internal/api/api_setup.gen.go
+++ b/internal/api/api_setup.gen.go
@@ -12,7 +12,9 @@ package api
 
 import (
 	"bytes"
+	_gzip "compress/gzip"
 	_context "context"
+	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -52,6 +54,22 @@ type SetupApi interface {
 	 * @return OnboardingResponse
 	 */
 	PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error)
+}
+
+// setupApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
+type setupApiGzipReadCloser struct {
+	underlying _io.ReadCloser
+	gzip       _io.ReadCloser
+}
+
+func (gzrc *setupApiGzipReadCloser) Read(p []byte) (int, error) {
+	return gzrc.gzip.Read(p)
+}
+func (gzrc *setupApiGzipReadCloser) Close() error {
+	if err := gzrc.gzip.Close(); err != nil {
+		return err
+	}
+	return gzrc.underlying.Close()
 }
 
 // SetupApiService SetupApi service
@@ -143,9 +161,19 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &setupApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -157,8 +185,8 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err
@@ -275,9 +303,19 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return localVarReturnValue, localVarHTTPResponse, err
+		}
+		body = &setupApiGzipReadCloser{underlying: body, gzip: gzr}
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return localVarReturnValue, localVarHTTPResponse, err
@@ -296,8 +334,8 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return localVarReturnValue, localVarHTTPResponse, err

--- a/internal/api/api_write.gen.go
+++ b/internal/api/api_write.gen.go
@@ -11,7 +11,6 @@
 package api
 
 import (
-	"bytes"
 	_gzip "compress/gzip"
 	_context "context"
 	_io "io"
@@ -37,7 +36,7 @@ type WriteApi interface {
 	/*
 	 * PostWriteExecute executes the request
 	 */
-	PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Response, error)
+	PostWriteExecute(r ApiPostWriteRequest) error
 }
 
 // writeApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
@@ -154,7 +153,7 @@ func (r ApiPostWriteRequest) GetPrecision() *WritePrecision {
 	return r.precision
 }
 
-func (r ApiPostWriteRequest) Execute() (*_nethttp.Response, error) {
+func (r ApiPostWriteRequest) Execute() error {
 	return r.ApiService.PostWriteExecute(r)
 }
 
@@ -173,7 +172,7 @@ func (a *WriteApiService) PostWrite(ctx _context.Context) ApiPostWriteRequest {
 /*
  * Execute executes the request
  */
-func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Response, error) {
+func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -184,7 +183,7 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WriteApiService.PostWrite")
 	if err != nil {
-		return nil, GenericOpenAPIError{error: err.Error()}
+		return GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/write"
@@ -193,13 +192,13 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.org == nil {
-		return nil, reportError("org is required and must be specified")
+		return reportError("org is required and must be specified")
 	}
 	if r.bucket == nil {
-		return nil, reportError("bucket is required and must be specified")
+		return reportError("bucket is required and must be specified")
 	}
 	if r.body == nil {
-		return nil, reportError("body is required and must be specified")
+		return reportError("body is required and must be specified")
 	}
 
 	localVarQueryParams.Add("org", parameterToString(*r.org, ""))
@@ -246,12 +245,12 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarHTTPResponse, err
+		return err
 	}
 
 	var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -259,7 +258,7 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 		gzr, err := _gzip.NewReader(body)
 		if err != nil {
 			body.Close()
-			return localVarHTTPResponse, err
+			return err
 		}
 		body = &writeApiGzipReadCloser{underlying: body, gzip: gzr}
 	}
@@ -267,9 +266,8 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return localVarHTTPResponse, err
+			return err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -280,50 +278,50 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
+				return newErr
 			}
 			newErr.model = &v
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
+				return newErr
 			}
 			newErr.model = &v
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
+				return newErr
 			}
 			newErr.model = &v
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		if localVarHTTPResponse.StatusCode == 413 {
 			var v LineProtocolLengthError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return localVarHTTPResponse, newErr
+				return newErr
 			}
 			newErr.model = &v
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = err.Error()
-			return localVarHTTPResponse, newErr
+			return newErr
 		}
 		newErr.model = &v
-		return localVarHTTPResponse, newErr
+		return newErr
 	}
 
-	return localVarHTTPResponse, nil
+	return nil
 }

--- a/internal/api/api_write.gen.go
+++ b/internal/api/api_write.gen.go
@@ -236,14 +236,13 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) (*_nethttp.Res
 		return localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,

--- a/internal/api/templates/README.md
+++ b/internal/api/templates/README.md
@@ -17,7 +17,7 @@ multiple locations.
 * Update creation of `GenericOpenAPIError` to track sub-error models by reference
 * Add checks for `isResponseBinary` to directly return the response-body-reader, instead of
   pulling the entire body into memory and transforming it into an `*os.File`
-  
+* GUnzip response bodies when `Content-Encoding: gzip` is set
 
 `client.mustache`
 * Removed use of `golang.org/x/oauth2` to avoid its heavy dependencies

--- a/internal/api/templates/README.md
+++ b/internal/api/templates/README.md
@@ -15,6 +15,9 @@ multiple locations.
 * Add `GetX()` methods for each request parameter `X`, for use in unit tests
 * Add checks for `isByteArray` to generate `[]byte` request fields instead of `*string`
 * Update creation of `GenericOpenAPIError` to track sub-error models by reference
+* Add checks for `isResponseBinary` to directly return the response-body-reader, instead of
+  pulling the entire body into memory and transforming it into an `*os.File`
+  
 
 `client.mustache`
 * Removed use of `golang.org/x/oauth2` to avoid its heavy dependencies

--- a/internal/api/templates/README.md
+++ b/internal/api/templates/README.md
@@ -18,6 +18,7 @@ multiple locations.
 * Add checks for `isResponseBinary` to directly return the response-body-reader, instead of
   pulling the entire body into memory and transforming it into an `*os.File`
 * GUnzip response bodies when `Content-Encoding: gzip` is set
+* Remove `*http.Response`s from the return values of generated operations
 
 `client.mustache`
 * Removed use of `golang.org/x/oauth2` to avoid its heavy dependencies

--- a/internal/api/templates/api.mustache
+++ b/internal/api/templates/api.mustache
@@ -38,7 +38,7 @@ type {{classname}} interface {
 	 * {{nickname}}Execute executes the request{{#returnType}}
 	 * @return {{{.}}}{{/returnType}}
 	 */
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error)
+	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}_io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -83,7 +83,7 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 
 {{/allParams}}
 
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error) {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{#isResponseBinary}}_io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -110,7 +110,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * Execute executes the request{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}error) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}_io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
@@ -119,7 +119,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		localVarFileBytes    []byte
 		{{#returnType}}
 		{{#isResponseBinary}}
-		localVarReturnValue  io.ReadCloser
+		localVarReturnValue  _io.ReadCloser
 		{{/isResponseBinary}}
 		{{^isResponseBinary}}
 		localVarReturnValue  {{{returnType}}}

--- a/internal/api/templates/api.mustache
+++ b/internal/api/templates/api.mustache
@@ -4,9 +4,9 @@ package {{packageName}}
 {{#operations}}
 import (
 	"bytes"
-    _gzip "compress/gzip"
+	_gzip "compress/gzip"
 	_context "context"
-    _io "io"
+	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -45,17 +45,17 @@ type {{classname}} interface {
 
 // {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser supports streaming gzip response-bodies directly from the server.
 type {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser struct {
-    underlying _io.ReadCloser
-    gzip _io.ReadCloser
+	underlying _io.ReadCloser
+	gzip _io.ReadCloser
 }
 func (gzrc *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser) Read(p []byte) (int, error) {
-    return gzrc.gzip.Read(p)
+	return gzrc.gzip.Read(p)
 }
 func (gzrc *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser) Close() error {
-    if err := gzrc.gzip.Close(); err != nil {
-        return err
-    }
-    return gzrc.underlying.Close()
+	if err := gzrc.gzip.Close(); err != nil {
+		return err
+	}
+	return gzrc.underlying.Close()
 }
 
 // {{classname}}Service {{classname}} service
@@ -350,15 +350,15 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		return {{#returnType}}localVarReturnValue, {{/returnType}}err
 	}
 
-    var body _io.ReadCloser = localVarHTTPResponse.Body
-    if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
-        gzr, err := _gzip.NewReader(body)
-        if err != nil {
-            body.Close()
-            return {{#returnType}}localVarReturnValue, {{/returnType}}err
-        }
-        body = &{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser{underlying: body, gzip: gzr}
-    }
+	var body _io.ReadCloser = localVarHTTPResponse.Body
+	if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+		gzr, err := _gzip.NewReader(body)
+		if err != nil {
+			body.Close()
+			return {{#returnType}}localVarReturnValue, {{/returnType}}err
+		}
+		body = &{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser{underlying: body, gzip: gzr}
+	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)

--- a/internal/api/templates/api.mustache
+++ b/internal/api/templates/api.mustache
@@ -38,7 +38,7 @@ type {{classname}} interface {
 	 * {{nickname}}Execute executes the request{{#returnType}}
 	 * @return {{{.}}}{{/returnType}}
 	 */
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error)
+	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -83,7 +83,7 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 
 {{/allParams}}
 
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -110,7 +110,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * Execute executes the request{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
@@ -129,7 +129,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
+		return {{#returnType}}localVarReturnValue, {{/returnType}}GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
@@ -142,27 +142,27 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{#required}}
 	{{^isPathParam}}
 	if r.{{paramName}} == nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} is required and must be specified")
 	}
 	{{/isPathParam}}
 	{{#minItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minItems}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxItems}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minLength}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxLength}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
@@ -173,7 +173,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} < {{minimum}} {
 	{{/isString}}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
@@ -184,7 +184,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} > {{maximum}} {
 	{{/isString}}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must be less than {{maximum}}")
 	}
 	{{/maximum}}
 	{{/required}}
@@ -287,7 +287,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if r.{{paramName}} != nil {
 		paramJson, err := parameterToJson(*r.{{paramName}})
 		if err != nil {
-			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
+			return {{#returnType}}localVarReturnValue, {{/returnType}}err
 		}
 		localVarFormParams.Add("{{baseName}}", paramJson)
 	}
@@ -342,12 +342,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{/authMethods}}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
+		return {{#returnType}}localVarReturnValue, {{/returnType}}err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+		return {{#returnType}}localVarReturnValue, {{/returnType}}err
 	}
 
     var body _io.ReadCloser = localVarHTTPResponse.Body
@@ -355,7 +355,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
         gzr, err := _gzip.NewReader(body)
         if err != nil {
             body.Close()
-            return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+            return {{#returnType}}localVarReturnValue, {{/returnType}}err
         }
         body = &{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser{underlying: body, gzip: gzr}
     }
@@ -363,9 +363,8 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if localVarHTTPResponse.StatusCode >= 300 {
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
-		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
-			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+			return {{#returnType}}localVarReturnValue, {{/returnType}}err
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -382,11 +381,11 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
-				return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
+				return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
 			}
 			newErr.model = &v
 			{{^-last}}
-			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
+			return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
 			{{/-last}}
 		{{^wildcard}}
 		}
@@ -395,7 +394,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		{{/is1xx}}
 		{{/dataType}}
 		{{/responses}}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
+		return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
 	}
 
 	{{#returnType}}
@@ -405,9 +404,8 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isResponseBinary}}
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+		return {{#returnType}}localVarReturnValue, {{/returnType}}err
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -415,12 +413,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 			body:  localVarBody,
 			error: err.Error(),
 		}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
+		return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
 	}
 	{{/isResponseBinary}}
 
 	{{/returnType}}
-	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, nil
+	return {{#returnType}}localVarReturnValue, {{/returnType}}nil
 }
 {{/operation}}
 {{/operations}}

--- a/internal/api/templates/api.mustache
+++ b/internal/api/templates/api.mustache
@@ -10,6 +10,11 @@ import (
 	_neturl "net/url"
 {{#imports}}	"{{import}}"
 {{/imports}}
+	{{#operation}}
+	{{#isResponseBinary}}
+	"io"
+	{{/isResponseBinary}}
+	{{/operation}}
 )
 
 // Linger please
@@ -36,7 +41,7 @@ type {{classname}} interface {
 	 * {{nickname}}Execute executes the request{{#returnType}}
 	 * @return {{{.}}}{{/returnType}}
 	 */
-	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error)
+	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error)
 	{{/operation}}
 }
 {{/generateInterfaces}}
@@ -61,12 +66,12 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 	return r
 }
 func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Get{{vendorExtensions.x-export-param-name}}() {{#isByteArray}}[]byte{{/isByteArray}}{{^isByteArray}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isByteArray}} {
-    return r.{{paramName}}
+	return r.{{paramName}}
 }
 
 {{/allParams}}
 
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Execute() ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
@@ -93,7 +98,7 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * Execute executes the request{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
-func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{{.}}}, {{/returnType}}*_nethttp.Response, error) {
+func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}io.ReadCloser{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
@@ -101,7 +106,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		localVarFileName     string
 		localVarFileBytes    []byte
 		{{#returnType}}
-		localVarReturnValue  {{{.}}}
+		{{#isResponseBinary}}
+		localVarReturnValue  io.ReadCloser
+		{{/isResponseBinary}}
+		{{^isResponseBinary}}
+		localVarReturnValue  {{{returnType}}}
+		{{/isResponseBinary}}
 		{{/returnType}}
 	)
 
@@ -328,14 +338,13 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
-	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
-	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
-	}
-
 	if localVarHTTPResponse.StatusCode >= 300 {
+		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+		localVarHTTPResponse.Body.Close()
+		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+		if err != nil {
+			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: localVarHTTPResponse.Status,
@@ -368,6 +377,16 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	{{#returnType}}
+	{{#isResponseBinary}}
+	localVarReturnValue = localVarHTTPResponse.Body
+	{{/isResponseBinary}}
+	{{^isResponseBinary}}
+	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
+	localVarHTTPResponse.Body.Close()
+	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
+	if err != nil {
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
@@ -376,6 +395,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		}
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 	}
+	{{/isResponseBinary}}
 
 	{{/returnType}}
 	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, nil

--- a/internal/api/templates/api.mustache
+++ b/internal/api/templates/api.mustache
@@ -4,17 +4,14 @@ package {{packageName}}
 {{#operations}}
 import (
 	"bytes"
+    _gzip "compress/gzip"
 	_context "context"
+    _io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
 {{#imports}}	"{{import}}"
 {{/imports}}
-	{{#operation}}
-	{{#isResponseBinary}}
-	"io"
-	{{/isResponseBinary}}
-	{{/operation}}
 )
 
 // Linger please
@@ -45,6 +42,21 @@ type {{classname}} interface {
 	{{/operation}}
 }
 {{/generateInterfaces}}
+
+// {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser supports streaming gzip response-bodies directly from the server.
+type {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser struct {
+    underlying _io.ReadCloser
+    gzip _io.ReadCloser
+}
+func (gzrc *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser) Read(p []byte) (int, error) {
+    return gzrc.gzip.Read(p)
+}
+func (gzrc *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser) Close() error {
+    if err := gzrc.gzip.Close(); err != nil {
+        return err
+    }
+    return gzrc.underlying.Close()
+}
 
 // {{classname}}Service {{classname}} service
 type {{classname}}Service service
@@ -338,9 +350,19 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
+    var body _io.ReadCloser = localVarHTTPResponse.Body
+    if localVarHTTPResponse.Header.Get("Content-Encoding") == "gzip" {
+        gzr, err := _gzip.NewReader(body)
+        if err != nil {
+            body.Close()
+            return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
+        }
+        body = &{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser{underlying: body, gzip: gzr}
+    }
+
 	if localVarHTTPResponse.StatusCode >= 300 {
-		localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-		localVarHTTPResponse.Body.Close()
+		localVarBody, err := _ioutil.ReadAll(body)
+		body.Close()
 		localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 		if err != nil {
 			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
@@ -378,11 +400,11 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 	{{#returnType}}
 	{{#isResponseBinary}}
-	localVarReturnValue = localVarHTTPResponse.Body
+	localVarReturnValue = body
 	{{/isResponseBinary}}
 	{{^isResponseBinary}}
-	localVarBody, err := _ioutil.ReadAll(localVarHTTPResponse.Body)
-	localVarHTTPResponse.Body.Close()
+	localVarBody, err := _ioutil.ReadAll(body)
+	body.Close()
 	localVarHTTPResponse.Body = _ioutil.NopCloser(bytes.NewBuffer(localVarBody))
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err

--- a/internal/bucket.go
+++ b/internal/bucket.go
@@ -77,7 +77,7 @@ func (c *CLI) BucketsCreate(ctx context.Context, clients *BucketsClients, params
 		if name == "" {
 			name = c.ActiveConfig.Org
 		}
-		resp, _, err := clients.OrgApi.GetOrgs(ctx).Org(name).Execute()
+		resp, err := clients.OrgApi.GetOrgs(ctx).Org(name).Execute()
 		if err != nil {
 			return fmt.Errorf("failed to lookup ID of org %q: %w", name, err)
 		}
@@ -88,7 +88,7 @@ func (c *CLI) BucketsCreate(ctx context.Context, clients *BucketsClients, params
 		reqBody.OrgID = orgs[0].GetId()
 	}
 
-	bucket, _, err := clients.BucketApi.PostBuckets(ctx).PostBucketRequest(reqBody).Execute()
+	bucket, err := clients.BucketApi.PostBuckets(ctx).PostBucketRequest(reqBody).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to create bucket: %w", err)
 	}
@@ -125,7 +125,7 @@ func (c *CLI) BucketsList(ctx context.Context, client api.BucketsApi, params *Bu
 		req = req.Id(params.ID)
 	}
 
-	buckets, _, err := req.Execute()
+	buckets, err := req.Execute()
 	if err != nil {
 		return fmt.Errorf("failed to list buckets: %w", err)
 	}
@@ -172,7 +172,7 @@ func (c *CLI) BucketsUpdate(ctx context.Context, client api.BucketsApi, params *
 		reqBody.SetRetentionRules([]api.PatchRetentionRule{*patchRule})
 	}
 
-	bucket, _, err := client.PatchBucketsID(ctx, params.ID).PatchBucketRequest(reqBody).Execute()
+	bucket, err := client.PatchBucketsID(ctx, params.ID).PatchBucketRequest(reqBody).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to update bucket %q: %w", params.ID, err)
 	}
@@ -217,7 +217,7 @@ func (c *CLI) BucketsDelete(ctx context.Context, client api.BucketsApi, params *
 		displayId = params.Name
 	}
 
-	resp, _, err := getReq.Execute()
+	resp, err := getReq.Execute()
 	if err != nil {
 		return fmt.Errorf("failed to find bucket %q: %w", displayId, err)
 	}
@@ -227,7 +227,7 @@ func (c *CLI) BucketsDelete(ctx context.Context, client api.BucketsApi, params *
 	}
 	bucket = buckets[0]
 
-	if _, err := client.DeleteBucketsID(ctx, bucket.GetId()).Execute(); err != nil {
+	if err := client.DeleteBucketsID(ctx, bucket.GetId()).Execute(); err != nil {
 		return fmt.Errorf("failed to delete bucket %q: %w", displayId, err)
 	}
 

--- a/internal/bucket_test.go
+++ b/internal/bucket_test.go
@@ -130,13 +130,13 @@ func TestBucketsCreate(t *testing.T) {
 				Retention:  "24h",
 				SchemaType: api.SCHEMATYPE_EXPLICIT,
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-					return api.Organizations{}, nil, errors.New("unexpected org lookup call")
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+					return api.Organizations{}, errors.New("unexpected org lookup call")
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
 					body := req.GetPostBucketRequest()
 					require.NotNil(t, body)
 					require.Equal(t, "123", body.OrgID)
@@ -149,7 +149,7 @@ func TestBucketsCreate(t *testing.T) {
 						Name:           "my-bucket",
 						RetentionRules: body.RetentionRules,
 						SchemaType:     api.SCHEMATYPE_EXPLICIT.Ptr(),
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: `456\s+my-bucket\s+24h0m0s\s+n/a\s+123\s+explicit`,
@@ -440,8 +440,8 @@ func TestBucketsList(t *testing.T) {
 				OrgName: "my-org",
 			},
 			configOrgName: "my-default-org",
-			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "my-org", *req.GetOrg())
 					require.Nil(t, req.GetId())
 					require.Nil(t, req.GetName())
@@ -475,7 +475,7 @@ func TestBucketsList(t *testing.T) {
 								SchemaType: api.SCHEMATYPE_EXPLICIT.Ptr(),
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPatterns: []string{

--- a/internal/bucket_test.go
+++ b/internal/bucket_test.go
@@ -3,7 +3,6 @@ package internal_test
 import (
 	"context"
 	"errors"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -22,8 +21,8 @@ func TestBucketsCreate(t *testing.T) {
 		name                  string
 		configOrgName         string
 		params                internal.BucketsCreateParams
-		buildOrgLookupFn      func(*testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error)
-		buildBucketCreateFn   func(*testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error)
+		buildOrgLookupFn      func(*testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error)
+		buildBucketCreateFn   func(*testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error)
 		expectedStdoutPattern string
 		expectedInErr         string
 	}{
@@ -33,13 +32,13 @@ func TestBucketsCreate(t *testing.T) {
 				OrgID: "123",
 				Name:  "my-bucket",
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-					return api.Organizations{}, nil, errors.New("unexpected org lookup call")
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+					return api.Organizations{}, errors.New("unexpected org lookup call")
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
 					body := req.GetPostBucketRequest()
 					require.NotNil(t, body)
 					require.Equal(t, "123", body.OrgID)
@@ -51,7 +50,7 @@ func TestBucketsCreate(t *testing.T) {
 						OrgID:          api.PtrString("123"),
 						Name:           "my-bucket",
 						RetentionRules: nil,
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "456\\s+my-bucket\\s+infinite\\s+n/a\\s+123",
@@ -65,13 +64,13 @@ func TestBucketsCreate(t *testing.T) {
 				Retention:          "24h",
 				ShardGroupDuration: "1h",
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-					return api.Organizations{}, nil, errors.New("unexpected org lookup call")
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+					return api.Organizations{}, errors.New("unexpected org lookup call")
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
 					body := req.GetPostBucketRequest()
 					require.NotNil(t, body)
 					require.Equal(t, "123", body.OrgID)
@@ -86,7 +85,7 @@ func TestBucketsCreate(t *testing.T) {
 						OrgID:          api.PtrString("123"),
 						Name:           "my-bucket",
 						RetentionRules: body.RetentionRules,
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "456\\s+my-bucket\\s+24h0m0s\\s+1h0m0s\\s+123",
@@ -98,13 +97,13 @@ func TestBucketsCreate(t *testing.T) {
 				Name:      "my-bucket",
 				Retention: "24h",
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-					return api.Organizations{}, nil, errors.New("unexpected org lookup call")
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+					return api.Organizations{}, errors.New("unexpected org lookup call")
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
 					body := req.GetPostBucketRequest()
 					require.NotNil(t, body)
 					require.Equal(t, "123", body.OrgID)
@@ -119,7 +118,7 @@ func TestBucketsCreate(t *testing.T) {
 						OrgID:          api.PtrString("123"),
 						Name:           "my-bucket",
 						RetentionRules: body.RetentionRules,
-					}, nil, nil
+					}, nil
 				}
 			},
 		},
@@ -164,16 +163,16 @@ func TestBucketsCreate(t *testing.T) {
 				Retention:          "24h",
 				ShardGroupDuration: "1h",
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(req api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(req api.ApiGetOrgsRequest) (api.Organizations, error) {
 					require.Equal(t, "my-org", *req.GetOrg())
 					return api.Organizations{
 						Orgs: &[]api.Organization{{Id: api.PtrString("123")}},
-					}, nil, nil
+					}, nil
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
 					body := req.GetPostBucketRequest()
 					require.NotNil(t, body)
 					require.Equal(t, "123", body.OrgID)
@@ -188,7 +187,7 @@ func TestBucketsCreate(t *testing.T) {
 						OrgID:          api.PtrString("123"),
 						Name:           "my-bucket",
 						RetentionRules: body.RetentionRules,
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "456\\s+my-bucket\\s+24h0m0s\\s+1h0m0s\\s+123",
@@ -202,16 +201,16 @@ func TestBucketsCreate(t *testing.T) {
 				ShardGroupDuration: "1h",
 			},
 			configOrgName: "my-org",
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(req api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(req api.ApiGetOrgsRequest) (api.Organizations, error) {
 					require.Equal(t, "my-org", *req.GetOrg())
 					return api.Organizations{
 						Orgs: &[]api.Organization{{Id: api.PtrString("123")}},
-					}, nil, nil
+					}, nil
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
 					body := req.GetPostBucketRequest()
 					require.NotNil(t, body)
 					require.Equal(t, "123", body.OrgID)
@@ -226,7 +225,7 @@ func TestBucketsCreate(t *testing.T) {
 						OrgID:          api.PtrString("123"),
 						Name:           "my-bucket",
 						RetentionRules: body.RetentionRules,
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "456\\s+my-bucket\\s+24h0m0s\\s+1h0m0s\\s+123",
@@ -239,14 +238,14 @@ func TestBucketsCreate(t *testing.T) {
 				Retention:          "24h",
 				ShardGroupDuration: "1h",
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(req api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-					return api.Organizations{}, nil, errors.New("shouldn't be called")
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(req api.ApiGetOrgsRequest) (api.Organizations, error) {
+					return api.Organizations{}, errors.New("shouldn't be called")
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-					return api.Bucket{}, nil, errors.New("shouldn't be called")
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
+					return api.Bucket{}, errors.New("shouldn't be called")
 				}
 			},
 			expectedInErr: "must specify org ID or org name",
@@ -260,14 +259,14 @@ func TestBucketsCreate(t *testing.T) {
 				Retention:          "24h",
 				ShardGroupDuration: "1h",
 			},
-			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-				return func(req api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
-					return api.Organizations{}, nil, nil
+			buildOrgLookupFn: func(t *testing.T) func(api.ApiGetOrgsRequest) (api.Organizations, error) {
+				return func(req api.ApiGetOrgsRequest) (api.Organizations, error) {
+					return api.Organizations{}, nil
 				}
 			},
-			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
-					return api.Bucket{}, nil, errors.New("shouldn't be called")
+			buildBucketCreateFn: func(t *testing.T) func(api.ApiPostBucketsRequest) (api.Bucket, error) {
+				return func(req api.ApiPostBucketsRequest) (api.Bucket, error) {
+					return api.Bucket{}, errors.New("shouldn't be called")
 				}
 			},
 			expectedInErr: "no organization found",
@@ -316,7 +315,7 @@ func TestBucketsList(t *testing.T) {
 		name                   string
 		configOrgName          string
 		params                 internal.BucketsListParams
-		buildBucketLookupFn    func(*testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error)
+		buildBucketLookupFn    func(*testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error)
 		expectedStdoutPatterns []string
 		expectedInErr          string
 	}{
@@ -326,8 +325,8 @@ func TestBucketsList(t *testing.T) {
 				ID: "123",
 			},
 			configOrgName: "my-default-org",
-			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "123", *req.GetId())
 					require.Equal(t, "my-default-org", *req.GetOrg())
 					require.Nil(t, req.GetName())
@@ -343,7 +342,7 @@ func TestBucketsList(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPatterns: []string{
@@ -356,8 +355,8 @@ func TestBucketsList(t *testing.T) {
 				Name: "my-bucket",
 			},
 			configOrgName: "my-default-org",
-			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "my-bucket", *req.GetName())
 					require.Equal(t, "my-default-org", *req.GetOrg())
 					require.Nil(t, req.GetId())
@@ -373,7 +372,7 @@ func TestBucketsList(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPatterns: []string{
@@ -386,13 +385,13 @@ func TestBucketsList(t *testing.T) {
 				OrgID: "456",
 			},
 			configOrgName: "my-default-org",
-			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "456", *req.GetOrgID())
 					require.Nil(t, req.GetId())
 					require.Nil(t, req.GetOrg())
 					require.Nil(t, req.GetOrg())
-					return api.Buckets{}, nil, nil
+					return api.Buckets{}, nil
 				}
 			},
 		},
@@ -402,8 +401,8 @@ func TestBucketsList(t *testing.T) {
 				OrgName: "my-org",
 			},
 			configOrgName: "my-default-org",
-			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "my-org", *req.GetOrg())
 					require.Nil(t, req.GetId())
 					require.Nil(t, req.GetName())
@@ -427,7 +426,7 @@ func TestBucketsList(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPatterns: []string{
@@ -488,9 +487,9 @@ func TestBucketsList(t *testing.T) {
 		{
 			name:          "no org specified",
 			expectedInErr: "must specify org ID or org name",
-			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-					return api.Buckets{}, nil, errors.New("shouldn't be called")
+			buildBucketLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+					return api.Buckets{}, errors.New("shouldn't be called")
 				}
 			},
 		},
@@ -534,7 +533,7 @@ func TestBucketsUpdate(t *testing.T) {
 	var testCases = []struct {
 		name                  string
 		params                internal.BucketsUpdateParams
-		buildBucketUpdateFn   func(*testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error)
+		buildBucketUpdateFn   func(*testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, error)
 		expectedStdoutPattern string
 	}{
 		{
@@ -543,8 +542,8 @@ func TestBucketsUpdate(t *testing.T) {
 				ID:   "123",
 				Name: "cold-storage",
 			},
-			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
+				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
 					require.Equal(t, "123", req.GetBucketID())
 					body := req.GetPatchBucketRequest()
 					require.Equal(t, "cold-storage", body.GetName())
@@ -555,7 +554,7 @@ func TestBucketsUpdate(t *testing.T) {
 						Id:    api.PtrString("123"),
 						Name:  "cold-storage",
 						OrgID: api.PtrString("456"),
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+cold-storage\\s+infinite\\s+n/a\\s+456",
@@ -566,8 +565,8 @@ func TestBucketsUpdate(t *testing.T) {
 				ID:          "123",
 				Description: "a very useful description",
 			},
-			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
+				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
 					require.Equal(t, "123", req.GetBucketID())
 					body := req.GetPatchBucketRequest()
 					require.Equal(t, "a very useful description", body.GetDescription())
@@ -579,7 +578,7 @@ func TestBucketsUpdate(t *testing.T) {
 						Name:        "my-bucket",
 						Description: api.PtrString("a very useful description"),
 						OrgID:       api.PtrString("456"),
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+infinite\\s+n/a\\s+456",
@@ -590,8 +589,8 @@ func TestBucketsUpdate(t *testing.T) {
 				ID:        "123",
 				Retention: "3w",
 			},
-			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
+				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
 					require.Equal(t, "123", req.GetBucketID())
 					body := req.GetPatchBucketRequest()
 					require.Len(t, body.GetRetentionRules(), 1)
@@ -608,7 +607,7 @@ func TestBucketsUpdate(t *testing.T) {
 						RetentionRules: []api.RetentionRule{
 							{EverySeconds: rule.GetEverySeconds()},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+504h0m0s\\s+n/a\\s+456",
@@ -619,8 +618,8 @@ func TestBucketsUpdate(t *testing.T) {
 				ID:                 "123",
 				ShardGroupDuration: "10h30m",
 			},
-			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
-				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+			buildBucketUpdateFn: func(t *testing.T) func(api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
+				return func(req api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
 					require.Equal(t, "123", req.GetBucketID())
 					body := req.GetPatchBucketRequest()
 					require.Len(t, body.GetRetentionRules(), 1)
@@ -637,7 +636,7 @@ func TestBucketsUpdate(t *testing.T) {
 						RetentionRules: []api.RetentionRule{
 							{ShardGroupDurationSeconds: rule.ShardGroupDurationSeconds},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+infinite\\s+10h30m0s\\s+456",
@@ -675,8 +674,8 @@ func TestBucketsDelete(t *testing.T) {
 		name                  string
 		configOrgName         string
 		params                internal.BucketsDeleteParams
-		buildBucketsLookupFn  func(*testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error)
-		buildBucketDeleteFn   func(*testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error)
+		buildBucketsLookupFn  func(*testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error)
+		buildBucketDeleteFn   func(*testing.T) func(api.ApiDeleteBucketsIDRequest) error
 		expectedStdoutPattern string
 		expectedInErr         string
 	}{
@@ -686,8 +685,8 @@ func TestBucketsDelete(t *testing.T) {
 			params: internal.BucketsDeleteParams{
 				ID: "123",
 			},
-			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "123", *req.GetId())
 					require.Nil(t, req.GetName())
 					require.Nil(t, req.GetOrgID())
@@ -704,13 +703,13 @@ func TestBucketsDelete(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
-			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-				return func(req api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) error {
+				return func(req api.ApiDeleteBucketsIDRequest) error {
 					assert.Equal(t, "123", req.GetBucketID())
-					return nil, nil
+					return nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+1h0m0s\\s+n/a\\s+456\\s+implicit",
@@ -722,8 +721,8 @@ func TestBucketsDelete(t *testing.T) {
 				Name:  "my-bucket",
 				OrgID: "456",
 			},
-			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "my-bucket", *req.GetName())
 					require.Equal(t, "456", *req.GetOrgID())
 					require.Nil(t, req.GetId())
@@ -740,13 +739,13 @@ func TestBucketsDelete(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
-			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-				return func(req api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) error {
+				return func(req api.ApiDeleteBucketsIDRequest) error {
 					assert.Equal(t, "123", req.GetBucketID())
-					return nil, nil
+					return nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+1h0m0s\\s+n/a\\s+456\\s+implicit",
@@ -758,8 +757,8 @@ func TestBucketsDelete(t *testing.T) {
 				Name:    "my-bucket",
 				OrgName: "my-org",
 			},
-			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "my-bucket", *req.GetName())
 					require.Equal(t, "my-org", *req.GetOrg())
 					require.Nil(t, req.GetId())
@@ -776,13 +775,13 @@ func TestBucketsDelete(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
-			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-				return func(req api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) error {
+				return func(req api.ApiDeleteBucketsIDRequest) error {
 					assert.Equal(t, "123", req.GetBucketID())
-					return nil, nil
+					return nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+1h0m0s\\s+n/a\\s+456\\s+implicit",
@@ -793,8 +792,8 @@ func TestBucketsDelete(t *testing.T) {
 			params: internal.BucketsDeleteParams{
 				Name: "my-bucket",
 			},
-			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(req api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(req api.ApiGetBucketsRequest) (api.Buckets, error) {
 					require.Equal(t, "my-bucket", *req.GetName())
 					require.Equal(t, "my-default-org", *req.GetOrg())
 					require.Nil(t, req.GetId())
@@ -811,13 +810,13 @@ func TestBucketsDelete(t *testing.T) {
 								},
 							},
 						},
-					}, nil, nil
+					}, nil
 				}
 			},
-			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-				return func(req api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) error {
+				return func(req api.ApiDeleteBucketsIDRequest) error {
 					assert.Equal(t, "123", req.GetBucketID())
-					return nil, nil
+					return nil
 				}
 			},
 			expectedStdoutPattern: "123\\s+my-bucket\\s+1h0m0s\\s+n/a\\s+456\\s+implicit",
@@ -827,14 +826,14 @@ func TestBucketsDelete(t *testing.T) {
 			params: internal.BucketsDeleteParams{
 				Name: "my-bucket",
 			},
-			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-					return api.Buckets{}, nil, errors.New("shouldn't be called")
+			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+					return api.Buckets{}, errors.New("shouldn't be called")
 				}
 			},
-			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-				return func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-					return nil, errors.New("shouldn't be called")
+			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) error {
+				return func(api.ApiDeleteBucketsIDRequest) error {
+					return errors.New("shouldn't be called")
 				}
 			},
 			expectedInErr: "must specify org ID or org name",
@@ -844,14 +843,14 @@ func TestBucketsDelete(t *testing.T) {
 			params: internal.BucketsDeleteParams{
 				ID: "123",
 			},
-			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-				return func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
-					return api.Buckets{}, nil, nil
+			buildBucketsLookupFn: func(t *testing.T) func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+				return func(api.ApiGetBucketsRequest) (api.Buckets, error) {
+					return api.Buckets{}, nil
 				}
 			},
-			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-				return func(api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
-					return nil, errors.New("shouldn't be called")
+			buildBucketDeleteFn: func(t *testing.T) func(api.ApiDeleteBucketsIDRequest) error {
+				return func(api.ApiDeleteBucketsIDRequest) error {
+					return errors.New("shouldn't be called")
 				}
 			},
 			expectedInErr: "not found",

--- a/internal/cmd/bucket_schema/client.go
+++ b/internal/cmd/bucket_schema/client.go
@@ -24,7 +24,7 @@ type orgBucketID struct {
 }
 
 func (c Client) resolveMeasurement(ctx context.Context, ids orgBucketID, name string) (string, error) {
-	res, _, err := c.BucketSchemasApi.
+	res, err := c.BucketSchemasApi.
 		GetMeasurementSchemas(ctx, ids.BucketID).
 		OrgID(ids.OrgID).
 		Name(name).
@@ -62,7 +62,7 @@ func (c Client) resolveOrgBucketIds(ctx context.Context, params internal.OrgBuck
 		req = req.Org(c.CLI.ActiveConfig.Org)
 	}
 
-	resp, _, err := req.Execute()
+	resp, err := req.Execute()
 	if err != nil {
 		return nil, fmt.Errorf("failed to find bucket %q: %w", params.BucketName, err)
 	}
@@ -120,7 +120,7 @@ func (c Client) Create(ctx context.Context, params CreateParams) error {
 		return err
 	}
 
-	res, _, err := c.BucketSchemasApi.
+	res, err := c.BucketSchemasApi.
 		CreateMeasurementSchema(ctx, ids.BucketID).
 		OrgID(ids.OrgID).
 		MeasurementSchemaCreateRequest(api.MeasurementSchemaCreateRequest{
@@ -169,7 +169,7 @@ func (c Client) Update(ctx context.Context, params UpdateParams) error {
 		}
 	}
 
-	res, _, err := c.BucketSchemasApi.
+	res, err := c.BucketSchemasApi.
 		UpdateMeasurementSchema(ctx, ids.BucketID, id).
 		OrgID(ids.OrgID).
 		MeasurementSchemaUpdateRequest(api.MeasurementSchemaUpdateRequest{
@@ -204,7 +204,7 @@ func (c Client) List(ctx context.Context, params ListParams) error {
 		req = req.Name(params.Name)
 	}
 
-	res, _, err := req.Execute()
+	res, err := req.Execute()
 	if err != nil {
 		return fmt.Errorf("failed to list measurement schemas: %w", err)
 	}

--- a/internal/cmd/bucket_schema/client_test.go
+++ b/internal/cmd/bucket_schema/client_test.go
@@ -112,7 +112,7 @@ func TestClient_Create(t *testing.T) {
 				GetBucketsExecute(tmock.MatchedBy(func(in api.ApiGetBucketsRequest) bool {
 					return cmp.Equal(in.GetOrg(), &a.params.OrgName) && cmp.Equal(in.GetName(), &a.params.BucketName)
 				})).
-				Return(api.Buckets{Buckets: &buckets}, nil, nil)
+				Return(api.Buckets{Buckets: &buckets}, nil)
 		}
 	}
 
@@ -150,7 +150,7 @@ func TestClient_Create(t *testing.T) {
 					Columns:   a.cols,
 					CreatedAt: createdAt,
 					UpdatedAt: createdAt,
-				}, nil, nil)
+				}, nil)
 		}
 	}
 
@@ -354,7 +354,7 @@ func TestClient_Update(t *testing.T) {
 					return (in.GetOrg() != nil && *in.GetOrg() == a.params.OrgName) &&
 						(in.GetName() != nil && *in.GetName() == a.params.BucketName)
 				})).
-				Return(api.Buckets{Buckets: &buckets}, nil, nil)
+				Return(api.Buckets{Buckets: &buckets}, nil)
 		}
 	}
 
@@ -398,7 +398,7 @@ func TestClient_Update(t *testing.T) {
 							UpdatedAt: updatedAt,
 						},
 					},
-				}, nil, nil)
+				}, nil)
 		}
 	}
 
@@ -425,7 +425,7 @@ func TestClient_Update(t *testing.T) {
 					Columns:   a.cols,
 					CreatedAt: createdAt,
 					UpdatedAt: updatedAt,
-				}, nil, nil)
+				}, nil)
 		}
 	}
 
@@ -595,7 +595,7 @@ func TestClient_List(t *testing.T) {
 					return (in.GetOrg() != nil && *in.GetOrg() == a.params.OrgName) &&
 						(in.GetName() != nil && *in.GetName() == a.params.BucketName)
 				})).
-				Return(api.Buckets{Buckets: &buckets}, nil, nil)
+				Return(api.Buckets{Buckets: &buckets}, nil)
 		}
 	}
 
@@ -639,7 +639,7 @@ func TestClient_List(t *testing.T) {
 							UpdatedAt: updatedAt,
 						},
 					},
-				}, nil, nil)
+				}, nil)
 		}
 	}
 

--- a/internal/mock/api_bucket_schemas.gen.go
+++ b/internal/mock/api_bucket_schemas.gen.go
@@ -6,7 +6,6 @@ package mock
 
 import (
 	context "context"
-	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -51,13 +50,12 @@ func (mr *MockBucketSchemasApiMockRecorder) CreateMeasurementSchema(arg0, arg1 i
 }
 
 // CreateMeasurementSchemaExecute mocks base method.
-func (m *MockBucketSchemasApi) CreateMeasurementSchemaExecute(arg0 api.ApiCreateMeasurementSchemaRequest) (api.MeasurementSchema, *http.Response, error) {
+func (m *MockBucketSchemasApi) CreateMeasurementSchemaExecute(arg0 api.ApiCreateMeasurementSchemaRequest) (api.MeasurementSchema, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateMeasurementSchemaExecute", arg0)
 	ret0, _ := ret[0].(api.MeasurementSchema)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // CreateMeasurementSchemaExecute indicates an expected call of CreateMeasurementSchemaExecute.
@@ -81,13 +79,12 @@ func (mr *MockBucketSchemasApiMockRecorder) GetMeasurementSchema(arg0, arg1, arg
 }
 
 // GetMeasurementSchemaExecute mocks base method.
-func (m *MockBucketSchemasApi) GetMeasurementSchemaExecute(arg0 api.ApiGetMeasurementSchemaRequest) (api.MeasurementSchema, *http.Response, error) {
+func (m *MockBucketSchemasApi) GetMeasurementSchemaExecute(arg0 api.ApiGetMeasurementSchemaRequest) (api.MeasurementSchema, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMeasurementSchemaExecute", arg0)
 	ret0, _ := ret[0].(api.MeasurementSchema)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetMeasurementSchemaExecute indicates an expected call of GetMeasurementSchemaExecute.
@@ -111,13 +108,12 @@ func (mr *MockBucketSchemasApiMockRecorder) GetMeasurementSchemas(arg0, arg1 int
 }
 
 // GetMeasurementSchemasExecute mocks base method.
-func (m *MockBucketSchemasApi) GetMeasurementSchemasExecute(arg0 api.ApiGetMeasurementSchemasRequest) (api.MeasurementSchemaList, *http.Response, error) {
+func (m *MockBucketSchemasApi) GetMeasurementSchemasExecute(arg0 api.ApiGetMeasurementSchemasRequest) (api.MeasurementSchemaList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMeasurementSchemasExecute", arg0)
 	ret0, _ := ret[0].(api.MeasurementSchemaList)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetMeasurementSchemasExecute indicates an expected call of GetMeasurementSchemasExecute.
@@ -141,13 +137,12 @@ func (mr *MockBucketSchemasApiMockRecorder) UpdateMeasurementSchema(arg0, arg1, 
 }
 
 // UpdateMeasurementSchemaExecute mocks base method.
-func (m *MockBucketSchemasApi) UpdateMeasurementSchemaExecute(arg0 api.ApiUpdateMeasurementSchemaRequest) (api.MeasurementSchema, *http.Response, error) {
+func (m *MockBucketSchemasApi) UpdateMeasurementSchemaExecute(arg0 api.ApiUpdateMeasurementSchemaRequest) (api.MeasurementSchema, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateMeasurementSchemaExecute", arg0)
 	ret0, _ := ret[0].(api.MeasurementSchema)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // UpdateMeasurementSchemaExecute indicates an expected call of UpdateMeasurementSchemaExecute.

--- a/internal/mock/api_buckets.gen.go
+++ b/internal/mock/api_buckets.gen.go
@@ -6,7 +6,6 @@ package mock
 
 import (
 	context "context"
-	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -51,12 +50,11 @@ func (mr *MockBucketsApiMockRecorder) DeleteBucketsID(arg0, arg1 interface{}) *g
 }
 
 // DeleteBucketsIDExecute mocks base method.
-func (m *MockBucketsApi) DeleteBucketsIDExecute(arg0 api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+func (m *MockBucketsApi) DeleteBucketsIDExecute(arg0 api.ApiDeleteBucketsIDRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteBucketsIDExecute", arg0)
-	ret0, _ := ret[0].(*http.Response)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // DeleteBucketsIDExecute indicates an expected call of DeleteBucketsIDExecute.
@@ -80,13 +78,12 @@ func (mr *MockBucketsApiMockRecorder) GetBuckets(arg0 interface{}) *gomock.Call 
 }
 
 // GetBucketsExecute mocks base method.
-func (m *MockBucketsApi) GetBucketsExecute(arg0 api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+func (m *MockBucketsApi) GetBucketsExecute(arg0 api.ApiGetBucketsRequest) (api.Buckets, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBucketsExecute", arg0)
 	ret0, _ := ret[0].(api.Buckets)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetBucketsExecute indicates an expected call of GetBucketsExecute.
@@ -110,13 +107,12 @@ func (mr *MockBucketsApiMockRecorder) GetBucketsID(arg0, arg1 interface{}) *gomo
 }
 
 // GetBucketsIDExecute mocks base method.
-func (m *MockBucketsApi) GetBucketsIDExecute(arg0 api.ApiGetBucketsIDRequest) (api.Bucket, *http.Response, error) {
+func (m *MockBucketsApi) GetBucketsIDExecute(arg0 api.ApiGetBucketsIDRequest) (api.Bucket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBucketsIDExecute", arg0)
 	ret0, _ := ret[0].(api.Bucket)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetBucketsIDExecute indicates an expected call of GetBucketsIDExecute.
@@ -140,13 +136,12 @@ func (mr *MockBucketsApiMockRecorder) PatchBucketsID(arg0, arg1 interface{}) *go
 }
 
 // PatchBucketsIDExecute mocks base method.
-func (m *MockBucketsApi) PatchBucketsIDExecute(arg0 api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+func (m *MockBucketsApi) PatchBucketsIDExecute(arg0 api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PatchBucketsIDExecute", arg0)
 	ret0, _ := ret[0].(api.Bucket)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PatchBucketsIDExecute indicates an expected call of PatchBucketsIDExecute.
@@ -170,13 +165,12 @@ func (mr *MockBucketsApiMockRecorder) PostBuckets(arg0 interface{}) *gomock.Call
 }
 
 // PostBucketsExecute mocks base method.
-func (m *MockBucketsApi) PostBucketsExecute(arg0 api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+func (m *MockBucketsApi) PostBucketsExecute(arg0 api.ApiPostBucketsRequest) (api.Bucket, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PostBucketsExecute", arg0)
 	ret0, _ := ret[0].(api.Bucket)
-	ret1, _ := ret[1].(*http.Response)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // PostBucketsExecute indicates an expected call of PostBucketsExecute.

--- a/internal/mock/api_buckets.go
+++ b/internal/mock/api_buckets.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/influxdata/influx-cli/v2/internal/api"
 )
@@ -10,18 +9,18 @@ import (
 var _ api.BucketsApi = (*BucketsApi)(nil)
 
 type BucketsApi struct {
-	DeleteBucketsIDExecuteFn func(api.ApiDeleteBucketsIDRequest) (*http.Response, error)
-	GetBucketsExecuteFn      func(api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error)
-	GetBucketsIDExecuteFn    func(api.ApiGetBucketsIDRequest) (api.Bucket, *http.Response, error)
-	PatchBucketsIDExecuteFn  func(api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error)
-	PostBucketsExecuteFn     func(api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error)
+	DeleteBucketsIDExecuteFn func(api.ApiDeleteBucketsIDRequest) error
+	GetBucketsExecuteFn      func(api.ApiGetBucketsRequest) (api.Buckets, error)
+	GetBucketsIDExecuteFn    func(api.ApiGetBucketsIDRequest) (api.Bucket, error)
+	PatchBucketsIDExecuteFn  func(api.ApiPatchBucketsIDRequest) (api.Bucket, error)
+	PostBucketsExecuteFn     func(api.ApiPostBucketsRequest) (api.Bucket, error)
 }
 
 func (b *BucketsApi) DeleteBucketsID(_ context.Context, bucketID string) api.ApiDeleteBucketsIDRequest {
 	return api.ApiDeleteBucketsIDRequest{ApiService: b}.BucketID(bucketID)
 }
 
-func (b *BucketsApi) DeleteBucketsIDExecute(r api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+func (b *BucketsApi) DeleteBucketsIDExecute(r api.ApiDeleteBucketsIDRequest) error {
 	return b.DeleteBucketsIDExecuteFn(r)
 }
 
@@ -29,7 +28,7 @@ func (b *BucketsApi) GetBuckets(context.Context) api.ApiGetBucketsRequest {
 	return api.ApiGetBucketsRequest{ApiService: b}
 }
 
-func (b *BucketsApi) GetBucketsExecute(r api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+func (b *BucketsApi) GetBucketsExecute(r api.ApiGetBucketsRequest) (api.Buckets, error) {
 	return b.GetBucketsExecuteFn(r)
 }
 
@@ -37,7 +36,7 @@ func (b *BucketsApi) GetBucketsID(_ context.Context, bucketID string) api.ApiGet
 	return api.ApiGetBucketsIDRequest{ApiService: b}.BucketID(bucketID)
 }
 
-func (b *BucketsApi) GetBucketsIDExecute(r api.ApiGetBucketsIDRequest) (api.Bucket, *http.Response, error) {
+func (b *BucketsApi) GetBucketsIDExecute(r api.ApiGetBucketsIDRequest) (api.Bucket, error) {
 	return b.GetBucketsIDExecuteFn(r)
 }
 
@@ -45,7 +44,7 @@ func (b *BucketsApi) PatchBucketsID(_ context.Context, bucketID string) api.ApiP
 	return api.ApiPatchBucketsIDRequest{ApiService: b}.BucketID(bucketID)
 }
 
-func (b *BucketsApi) PatchBucketsIDExecute(r api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+func (b *BucketsApi) PatchBucketsIDExecute(r api.ApiPatchBucketsIDRequest) (api.Bucket, error) {
 	return b.PatchBucketsIDExecuteFn(r)
 }
 
@@ -53,6 +52,6 @@ func (b *BucketsApi) PostBuckets(context.Context) api.ApiPostBucketsRequest {
 	return api.ApiPostBucketsRequest{ApiService: b}
 }
 
-func (b *BucketsApi) PostBucketsExecute(r api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+func (b *BucketsApi) PostBucketsExecute(r api.ApiPostBucketsRequest) (api.Bucket, error) {
 	return b.PostBucketsExecuteFn(r)
 }

--- a/internal/mock/api_health.go
+++ b/internal/mock/api_health.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/influxdata/influx-cli/v2/internal/api"
 )
@@ -10,7 +9,7 @@ import (
 var _ api.HealthApi = (*HealthApi)(nil)
 
 type HealthApi struct {
-	GetHealthExecuteFn func(api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error)
+	GetHealthExecuteFn func(api.ApiGetHealthRequest) (api.HealthCheck, error)
 }
 
 func (p *HealthApi) GetHealth(context.Context) api.ApiGetHealthRequest {
@@ -19,6 +18,6 @@ func (p *HealthApi) GetHealth(context.Context) api.ApiGetHealthRequest {
 	}
 }
 
-func (p *HealthApi) GetHealthExecute(req api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
+func (p *HealthApi) GetHealthExecute(req api.ApiGetHealthRequest) (api.HealthCheck, error) {
 	return p.GetHealthExecuteFn(req)
 }

--- a/internal/mock/api_organizations.go
+++ b/internal/mock/api_organizations.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/influxdata/influx-cli/v2/internal/api"
 )
@@ -10,15 +9,15 @@ import (
 var _ api.OrganizationsApi = (*OrganizationsApi)(nil)
 
 type OrganizationsApi struct {
-	GetOrgsExecuteFn  func(api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error)
-	PostOrgsExecuteFn func(api.ApiPostOrgsRequest) (api.Organization, *http.Response, error)
+	GetOrgsExecuteFn  func(api.ApiGetOrgsRequest) (api.Organizations, error)
+	PostOrgsExecuteFn func(api.ApiPostOrgsRequest) (api.Organization, error)
 }
 
 func (o *OrganizationsApi) GetOrgs(context.Context) api.ApiGetOrgsRequest {
 	return api.ApiGetOrgsRequest{ApiService: o}
 }
 
-func (o *OrganizationsApi) GetOrgsExecute(r api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
+func (o *OrganizationsApi) GetOrgsExecute(r api.ApiGetOrgsRequest) (api.Organizations, error) {
 	return o.GetOrgsExecuteFn(r)
 }
 
@@ -26,6 +25,6 @@ func (o *OrganizationsApi) PostOrgs(context.Context) api.ApiPostOrgsRequest {
 	return api.ApiPostOrgsRequest{ApiService: o}
 }
 
-func (o *OrganizationsApi) PostOrgsExecute(r api.ApiPostOrgsRequest) (api.Organization, *http.Response, error) {
+func (o *OrganizationsApi) PostOrgsExecute(r api.ApiPostOrgsRequest) (api.Organization, error) {
 	return o.PostOrgsExecuteFn(r)
 }

--- a/internal/mock/api_setup.go
+++ b/internal/mock/api_setup.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/influxdata/influx-cli/v2/internal/api"
 )
@@ -10,8 +9,8 @@ import (
 var _ api.SetupApi = (*SetupApi)(nil)
 
 type SetupApi struct {
-	GetSetupExecuteFn  func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error)
-	PostSetupExecuteFn func(api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error)
+	GetSetupExecuteFn  func(api.ApiGetSetupRequest) (api.InlineResponse200, error)
+	PostSetupExecuteFn func(api.ApiPostSetupRequest) (api.OnboardingResponse, error)
 }
 
 func (s *SetupApi) GetSetup(context.Context) api.ApiGetSetupRequest {
@@ -19,7 +18,7 @@ func (s *SetupApi) GetSetup(context.Context) api.ApiGetSetupRequest {
 		ApiService: s,
 	}
 }
-func (s *SetupApi) GetSetupExecute(req api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
+func (s *SetupApi) GetSetupExecute(req api.ApiGetSetupRequest) (api.InlineResponse200, error) {
 	return s.GetSetupExecuteFn(req)
 }
 func (s *SetupApi) PostSetup(context.Context) api.ApiPostSetupRequest {
@@ -27,6 +26,6 @@ func (s *SetupApi) PostSetup(context.Context) api.ApiPostSetupRequest {
 		ApiService: s,
 	}
 }
-func (s *SetupApi) PostSetupExecute(req api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error) {
+func (s *SetupApi) PostSetupExecute(req api.ApiPostSetupRequest) (api.OnboardingResponse, error) {
 	return s.PostSetupExecuteFn(req)
 }

--- a/internal/mock/api_write.go
+++ b/internal/mock/api_write.go
@@ -2,7 +2,6 @@ package mock
 
 import (
 	"context"
-	"net/http"
 
 	"github.com/influxdata/influx-cli/v2/internal/api"
 )
@@ -10,7 +9,7 @@ import (
 var _ api.WriteApi = (*WriteApi)(nil)
 
 type WriteApi struct {
-	PostWriteExecuteFn func(api.ApiPostWriteRequest) (*http.Response, error)
+	PostWriteExecuteFn func(api.ApiPostWriteRequest) error
 }
 
 func (w *WriteApi) PostWrite(context.Context) api.ApiPostWriteRequest {
@@ -18,6 +17,6 @@ func (w *WriteApi) PostWrite(context.Context) api.ApiPostWriteRequest {
 		ApiService: w,
 	}
 }
-func (w *WriteApi) PostWriteExecute(req api.ApiPostWriteRequest) (*http.Response, error) {
+func (w *WriteApi) PostWriteExecute(req api.ApiPostWriteRequest) error {
 	return w.PostWriteExecuteFn(req)
 }

--- a/internal/ping.go
+++ b/internal/ping.go
@@ -8,7 +8,7 @@ import (
 
 // Ping checks the health of a remote InfluxDB instance.
 func (c *CLI) Ping(ctx context.Context, client api.HealthApi) error {
-	if _, _, err := client.GetHealth(ctx).Execute(); err != nil {
+	if _, err := client.GetHealth(ctx).Execute(); err != nil {
 		return err
 	}
 	_, err := c.StdIO.Write([]byte("OK\n"))

--- a/internal/ping_test.go
+++ b/internal/ping_test.go
@@ -3,7 +3,6 @@ package internal_test
 import (
 	"context"
 	"errors"
-	"net/http"
 	"testing"
 
 	"github.com/influxdata/influx-cli/v2/internal"
@@ -16,8 +15,8 @@ func Test_PingSuccess(t *testing.T) {
 	t.Parallel()
 
 	client := &mock.HealthApi{
-		GetHealthExecuteFn: func(req api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
-			return api.HealthCheck{Status: api.HEALTHCHECKSTATUS_PASS}, nil, nil
+		GetHealthExecuteFn: func(req api.ApiGetHealthRequest) (api.HealthCheck, error) {
+			return api.HealthCheck{Status: api.HEALTHCHECKSTATUS_PASS}, nil
 		},
 	}
 
@@ -33,8 +32,8 @@ func Test_PingFailedRequest(t *testing.T) {
 
 	e := "the internet is down"
 	client := &mock.HealthApi{
-		GetHealthExecuteFn: func(api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
-			return api.HealthCheck{}, nil, errors.New(e)
+		GetHealthExecuteFn: func(api.ApiGetHealthRequest) (api.HealthCheck, error) {
+			return api.HealthCheck{}, errors.New(e)
 		},
 	}
 
@@ -49,8 +48,8 @@ func Test_PingFailedStatus(t *testing.T) {
 
 	e := "I broke"
 	client := &mock.HealthApi{
-		GetHealthExecuteFn: func(api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
-			return api.HealthCheck{}, nil, &api.HealthCheck{Status: api.HEALTHCHECKSTATUS_FAIL, Message: &e}
+		GetHealthExecuteFn: func(api.ApiGetHealthRequest) (api.HealthCheck, error) {
+			return api.HealthCheck{}, &api.HealthCheck{Status: api.HEALTHCHECKSTATUS_FAIL, Message: &e}
 		},
 	}
 
@@ -65,8 +64,8 @@ func Test_PingFailedStatusNoMessage(t *testing.T) {
 
 	name := "foo"
 	client := &mock.HealthApi{
-		GetHealthExecuteFn: func(api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
-			return api.HealthCheck{}, nil, &api.HealthCheck{Status: api.HEALTHCHECKSTATUS_FAIL, Name: name}
+		GetHealthExecuteFn: func(api.ApiGetHealthRequest) (api.HealthCheck, error) {
+			return api.HealthCheck{}, &api.HealthCheck{Status: api.HEALTHCHECKSTATUS_FAIL, Name: name}
 		},
 	}
 

--- a/internal/setup.go
+++ b/internal/setup.go
@@ -35,7 +35,7 @@ const MinPasswordLen = 8
 
 func (c *CLI) Setup(ctx context.Context, client api.SetupApi, params *SetupParams) error {
 	// Check if setup is even allowed.
-	checkResp, _, err := client.GetSetup(ctx).Execute()
+	checkResp, err := client.GetSetup(ctx).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to check if already set up: %w", err)
 	}
@@ -54,7 +54,7 @@ func (c *CLI) Setup(ctx context.Context, client api.SetupApi, params *SetupParam
 	if err != nil {
 		return err
 	}
-	resp, _, err := client.PostSetup(ctx).OnboardingRequest(setupBody).Execute()
+	resp, err := client.PostSetup(ctx).OnboardingRequest(setupBody).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to setup instance: %w", err)
 	}

--- a/internal/setup_test.go
+++ b/internal/setup_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"strconv"
 	"strings"
 	"testing"
@@ -21,8 +20,8 @@ func Test_SetupConfigNameCollision(t *testing.T) {
 	t.Parallel()
 
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil
 		},
 	}
 
@@ -44,8 +43,8 @@ func Test_SetupConfigNameRequired(t *testing.T) {
 	t.Parallel()
 
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil
 		},
 	}
 
@@ -65,8 +64,8 @@ func Test_SetupAlreadySetup(t *testing.T) {
 	t.Parallel()
 
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(false)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(false)}, nil
 		},
 	}
 
@@ -87,8 +86,8 @@ func Test_SetupCheckFailed(t *testing.T) {
 
 	e := "oh no"
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{}, nil, errors.New(e)
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{}, errors.New(e)
 		},
 	}
 
@@ -125,10 +124,10 @@ func Test_SetupSuccessNoninteractive(t *testing.T) {
 		Bucket: &api.Bucket{Name: params.Bucket},
 	}
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil
 		},
-		PostSetupExecuteFn: func(req api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error) {
+		PostSetupExecuteFn: func(req api.ApiPostSetupRequest) (api.OnboardingResponse, error) {
 			body := req.GetOnboardingRequest()
 			require.Equal(t, params.Username, body.Username)
 			require.Equal(t, params.Password, *body.Password)
@@ -136,7 +135,7 @@ func Test_SetupSuccessNoninteractive(t *testing.T) {
 			require.Equal(t, params.Org, body.Org)
 			require.Equal(t, params.Bucket, body.Bucket)
 			require.Equal(t, retentionSecs, *body.RetentionPeriodSeconds)
-			return resp, nil, nil
+			return resp, nil
 		},
 	}
 
@@ -182,10 +181,10 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 		Bucket: &api.Bucket{Name: bucket},
 	}
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil
 		},
-		PostSetupExecuteFn: func(req api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error) {
+		PostSetupExecuteFn: func(req api.ApiPostSetupRequest) (api.OnboardingResponse, error) {
 			body := req.GetOnboardingRequest()
 			require.Equal(t, username, body.Username)
 			require.Equal(t, password, *body.Password)
@@ -193,7 +192,7 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 			require.Equal(t, org, body.Org)
 			require.Equal(t, bucket, body.Bucket)
 			require.Equal(t, retentionSecs, *body.RetentionPeriodSeconds)
-			return resp, nil, nil
+			return resp, nil
 		},
 	}
 
@@ -242,8 +241,8 @@ func Test_SetupPasswordParamToShort(t *testing.T) {
 		Force:     false,
 	}
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil
 		},
 	}
 
@@ -273,8 +272,8 @@ func Test_SetupCancelAtConfirmation(t *testing.T) {
 		Force:     false,
 	}
 	client := &mock.SetupApi{
-		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
-			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil, nil
+		GetSetupExecuteFn: func(api.ApiGetSetupRequest) (api.InlineResponse200, error) {
+			return api.InlineResponse200{Allowed: api.PtrBool(true)}, nil
 		},
 	}
 

--- a/internal/write.go
+++ b/internal/write.go
@@ -69,7 +69,7 @@ func (c *CLI) Write(ctx context.Context, clients *WriteClients, params *WritePar
 			req = req.Org(c.ActiveConfig.Org)
 		}
 
-		if _, err := req.Execute(); err != nil {
+		if err := req.Execute(); err != nil {
 			return err
 		}
 

--- a/internal/write_test.go
+++ b/internal/write_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -69,7 +68,7 @@ func TestWriteByIDs(t *testing.T) {
 
 	var writtenLines []string
 	client := mock.WriteApi{
-		PostWriteExecuteFn: func(req api.ApiPostWriteRequest) (*http.Response, error) {
+		PostWriteExecuteFn: func(req api.ApiPostWriteRequest) error {
 			// Make sure query params are set.
 			require.Equal(t, params.OrgID, *req.GetOrg())
 			require.Equal(t, params.BucketID, *req.GetBucket())
@@ -78,7 +77,7 @@ func TestWriteByIDs(t *testing.T) {
 			// Make sure the body is properly marked for compression, and record what was sent.
 			require.Equal(t, "gzip", *req.GetContentEncoding())
 			writtenLines = append(writtenLines, string(req.GetBody()))
-			return nil, nil
+			return nil
 		},
 	}
 
@@ -113,7 +112,7 @@ func TestWriteByNames(t *testing.T) {
 
 	var writtenLines []string
 	client := mock.WriteApi{
-		PostWriteExecuteFn: func(req api.ApiPostWriteRequest) (*http.Response, error) {
+		PostWriteExecuteFn: func(req api.ApiPostWriteRequest) error {
 			// Make sure query params are set.
 			require.Equal(t, params.OrgName, *req.GetOrg())
 			require.Equal(t, params.BucketName, *req.GetBucket())
@@ -122,7 +121,7 @@ func TestWriteByNames(t *testing.T) {
 			// Make sure the body is properly marked for compression, and record what was sent.
 			require.Equal(t, "gzip", *req.GetContentEncoding())
 			writtenLines = append(writtenLines, string(req.GetBody()))
-			return nil, nil
+			return nil
 		},
 	}
 
@@ -156,7 +155,7 @@ func TestWriteOrgFromConfig(t *testing.T) {
 
 	var writtenLines []string
 	client := mock.WriteApi{
-		PostWriteExecuteFn: func(req api.ApiPostWriteRequest) (*http.Response, error) {
+		PostWriteExecuteFn: func(req api.ApiPostWriteRequest) error {
 			// Make sure query params are set.
 			require.Equal(t, cli.ActiveConfig.Org, *req.GetOrg())
 			require.Equal(t, params.BucketName, *req.GetBucket())
@@ -165,7 +164,7 @@ func TestWriteOrgFromConfig(t *testing.T) {
 			// Make sure the body is properly marked for compression, and record what was sent.
 			require.Equal(t, "gzip", *req.GetContentEncoding())
 			writtenLines = append(writtenLines, string(req.GetBody()))
-			return nil, nil
+			return nil
 		},
 	}
 

--- a/tools.go
+++ b/tools.go
@@ -11,5 +11,6 @@ package influxcli
 
 import (
 	_ "github.com/daixiang0/gci"
+	_ "golang.org/x/tools/cmd/goimports"
 	_ "honnef.co/go/tools/cmd/staticcheck"
 )


### PR DESCRIPTION
Part of #14

It's hard to see the full picture without adding the `/query` endpoint, but these changes include:
1. When `Content-Encoding: gzip` is set on a response, gunzip the request body before attempting any processing
2. When a request has `format: binary` in its top-level response schema, bypass the logic that pulls the full response into memory
   * Instead return the `io.ReadCloser` from the `http.Response` (or the gunzip-wrapped body) directly
3. Remove the `*http.Response` from the set of return values generated for every operation
   * Prevents a confusing "which do I use?" situation where we return both the HTTP response body as an `io.ReadCloser` and the `*http.Response` containing a reference to the same body
   * Cleans up a lot of code, because we were never using the raw return value but had to include it in mocks etc. to match the interface