### PR TITLE
feat(write): warn about standalone CR characters in header lines

### DIFF
--- a/pkg/csv2lp/csv2lp.go
+++ b/pkg/csv2lp/csv2lp.go
@@ -149,7 +149,7 @@ func (state *CsvToLineReader) Read(p []byte) (n int, err error) {
 			for _, col := range row {
 				if idx := strings.Index(col, "\r"); idx >= 0 && idx+1 < len(col) && col[idx+1] != '\n' {
 					log.Println(
-						fmt.Sprintf("WARNING: %v. Neither CRLF nor LF line endings?",
+						fmt.Sprintf("WARNING: %v. Only CRLF and LF line endings are supported.",
 							CsvLineError{state.LineNumber, errors.New("standalone CR character found")},
 						),
 					)

--- a/pkg/csv2lp/csv2lp.go
+++ b/pkg/csv2lp/csv2lp.go
@@ -3,6 +3,7 @@ package csv2lp
 
 import (
 	"encoding/csv"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -144,6 +145,17 @@ func (state *CsvToLineReader) Read(p []byte) (n int, err error) {
 			state.buffer = append(state.buffer, '\n')
 			break
 		} else {
+			// detect non-standard line endings in header lines #106
+			for _, col := range row {
+				if idx := strings.Index(col, "\r"); idx >= 0 && idx+1 < len(col) && col[idx+1] != '\n' {
+					log.Println(
+						fmt.Sprintf("WARNING: %v. Neither CRLF nor LF line endings?",
+							CsvLineError{state.LineNumber, errors.New("standalone CR character found")},
+						),
+					)
+					break
+				}
+			}
 			state.dataRowAdded = false
 		}
 	}

--- a/pkg/csv2lp/csv2lp_test.go
+++ b/pkg/csv2lp/csv2lp_test.go
@@ -451,7 +451,7 @@ func Test_CsvToLineProtocol_LineEndingWarning(t *testing.T) {
 	messages := strings.Count(out, prefix)
 	require.Equal(t, messages, 1)
 	require.Contains(t, out, "line 1")
-	require.Contains(t, out, "standalone CR character found. Neither CRLF nor LF line endings?")
+	require.Contains(t, out, "standalone CR character found. Only CRLF and LF line endings are supported.")
 	require.Empty(t, bytes)
 }
 


### PR DESCRIPTION
Closes #106 

A warning is printed if `influx write` processes a CSV header line with a CR character that is not followed by LF character:

```
2021/06/05 20:24:58 WARNING: line 1: standalone CR character found. Only CRLF and LF line endings are supported.
```

Such warning helps to quickly recognize an input file with exotic line endings (#106). `influx write` as well as golang's CSV parser recognizes properly only LF (unix) and CRLF (windows) line endings. The fix also applies to `influx write dryrun`.