### PR TITLE
test: remove racy logic from backup test

### DIFF
--- a/clients/backup/backup_internal_test.go
+++ b/clients/backup/backup_internal_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -151,13 +150,8 @@ func TestBackup_DownloadMetadata(t *testing.T) {
 					return &res, nil
 				})
 
-			stdio := mock.NewMockStdIO(ctrl)
-			writtenBytes := bytes.Buffer{}
-			stdio.EXPECT().Write(gomock.Any()).DoAndReturn(writtenBytes.Write).AnyTimes()
-			log.SetOutput(stdio)
-
 			cli := Client{
-				CLI:       clients.CLI{StdIO: stdio},
+				CLI:       clients.CLI{},
 				BackupApi: backupApi,
 				baseName:  "test",
 			}
@@ -268,13 +262,8 @@ func TestBackup_DownloadShardData(t *testing.T) {
 					return &res, nil
 				})
 
-			stdio := mock.NewMockStdIO(ctrl)
-			writtenBytes := bytes.Buffer{}
-			stdio.EXPECT().Write(gomock.Any()).DoAndReturn(writtenBytes.Write).AnyTimes()
-			log.SetOutput(stdio)
-
 			cli := Client{
-				CLI:       clients.CLI{StdIO: stdio},
+				CLI:       clients.CLI{},
 				BackupApi: backupApi,
 				baseName:  "test",
 			}
@@ -318,13 +307,8 @@ func TestBackup_DownloadShardData(t *testing.T) {
 		backupApi.EXPECT().GetBackupShardId(gomock.Any(), gomock.Eq(req.GetShardID())).Return(req)
 		backupApi.EXPECT().GetBackupShardIdExecute(gomock.Any()).Return(nil, &notFoundErr{})
 
-		stdio := mock.NewMockStdIO(ctrl)
-		writtenBytes := bytes.Buffer{}
-		stdio.EXPECT().Write(gomock.Any()).DoAndReturn(writtenBytes.Write).AnyTimes()
-		log.SetOutput(stdio)
-
 		cli := Client{
-			CLI:       clients.CLI{StdIO: stdio},
+			CLI:       clients.CLI{},
 			BackupApi: backupApi,
 			baseName:  "test",
 		}
@@ -340,7 +324,6 @@ func TestBackup_DownloadShardData(t *testing.T) {
 		metadata, err := cli.downloadShardData(context.Background(), &params, req.GetShardID())
 		require.NoError(t, err)
 		require.Nil(t, metadata)
-		require.Contains(t, writtenBytes.String(), fmt.Sprintf("WARN: Shard %d removed during backup", req.GetShardID()))
 	})
 }
 


### PR DESCRIPTION
Parallel tests were calling `log.SetOutput`. I considered making the tests run sequentially, but I think there are suites in other packages that also modify the global `log` state and I didn't want to just push the problem down the road. Asserting on the log output is something I feel ok not doing.