### PR TITLE
refactor: use io.ReadCloser instead of **os.File for binary request params

### DIFF
--- a/api/api_backup.gen.go
+++ b/api/api_backup.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -53,22 +52,6 @@ type BackupApi interface {
 	 * @return *os.File
 	 */
 	GetBackupShardIdExecute(r ApiGetBackupShardIdRequest) (*_nethttp.Response, error)
-}
-
-// backupApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type backupApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *backupApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *backupApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // BackupApiService BackupApi service

--- a/api/api_bucket_schemas.gen.go
+++ b/api/api_bucket_schemas.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -83,22 +82,6 @@ type BucketSchemasApi interface {
 	 * @return MeasurementSchema
 	 */
 	UpdateMeasurementSchemaExecute(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, error)
-}
-
-// bucketSchemasApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type bucketSchemasApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *bucketSchemasApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *bucketSchemasApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // BucketSchemasApiService BucketSchemasApi service

--- a/api/api_buckets.gen.go
+++ b/api/api_buckets.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -92,22 +91,6 @@ type BucketsApi interface {
 	 * @return Bucket
 	 */
 	PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, error)
-}
-
-// bucketsApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type bucketsApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *bucketsApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *bucketsApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // BucketsApiService BucketsApi service

--- a/api/api_delete.gen.go
+++ b/api/api_delete.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -36,22 +35,6 @@ type DeleteApi interface {
 	 * PostDeleteExecute executes the request
 	 */
 	PostDeleteExecute(r ApiPostDeleteRequest) error
-}
-
-// deleteApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type deleteApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *deleteApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *deleteApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // DeleteApiService DeleteApi service

--- a/api/api_health.gen.go
+++ b/api/api_health.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -37,22 +36,6 @@ type HealthApi interface {
 	 * @return HealthCheck
 	 */
 	GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, error)
-}
-
-// healthApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type healthApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *healthApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *healthApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // HealthApiService HealthApi service

--- a/api/api_organizations.gen.go
+++ b/api/api_organizations.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -134,22 +133,6 @@ type OrganizationsApi interface {
 	 * @return ResourceMember
 	 */
 	PostOrgsIDMembersExecute(r ApiPostOrgsIDMembersRequest) (ResourceMember, error)
-}
-
-// organizationsApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type organizationsApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *organizationsApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *organizationsApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // OrganizationsApiService OrganizationsApi service

--- a/api/api_query.gen.go
+++ b/api/api_query.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -37,22 +36,6 @@ type QueryApi interface {
 	 * @return *os.File
 	 */
 	PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Response, error)
-}
-
-// queryApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type queryApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *queryApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *queryApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // QueryApiService QueryApi service

--- a/api/api_restore.gen.go
+++ b/api/api_restore.gen.go
@@ -16,7 +16,6 @@ import (
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
-	"os"
 	"strings"
 )
 
@@ -77,22 +76,6 @@ type RestoreApi interface {
 	 * PostRestoreShardIdExecute executes the request
 	 */
 	PostRestoreShardIdExecute(r ApiPostRestoreShardIdRequest) error
-}
-
-// restoreApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type restoreApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *restoreApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *restoreApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // RestoreApiService RestoreApi service
@@ -259,16 +242,16 @@ func (a *RestoreApiService) PostRestoreBucketMetadataIdExecute(r ApiPostRestoreB
 type ApiPostRestoreKVRequest struct {
 	ctx             _context.Context
 	ApiService      RestoreApi
-	body            **os.File
+	body            _io.ReadCloser
 	zapTraceSpan    *string
 	contentEncoding *string
 }
 
-func (r ApiPostRestoreKVRequest) Body(body *os.File) ApiPostRestoreKVRequest {
-	r.body = &body
+func (r ApiPostRestoreKVRequest) Body(body _io.ReadCloser) ApiPostRestoreKVRequest {
+	r.body = body
 	return r
 }
-func (r ApiPostRestoreKVRequest) GetBody() **os.File {
+func (r ApiPostRestoreKVRequest) GetBody() _io.ReadCloser {
 	return r.body
 }
 
@@ -396,16 +379,16 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) erro
 type ApiPostRestoreSQLRequest struct {
 	ctx             _context.Context
 	ApiService      RestoreApi
-	body            **os.File
+	body            _io.ReadCloser
 	zapTraceSpan    *string
 	contentEncoding *string
 }
 
-func (r ApiPostRestoreSQLRequest) Body(body *os.File) ApiPostRestoreSQLRequest {
-	r.body = &body
+func (r ApiPostRestoreSQLRequest) Body(body _io.ReadCloser) ApiPostRestoreSQLRequest {
+	r.body = body
 	return r
 }
-func (r ApiPostRestoreSQLRequest) GetBody() **os.File {
+func (r ApiPostRestoreSQLRequest) GetBody() _io.ReadCloser {
 	return r.body
 }
 
@@ -534,7 +517,7 @@ type ApiPostRestoreShardIdRequest struct {
 	ctx             _context.Context
 	ApiService      RestoreApi
 	shardID         string
-	body            **os.File
+	body            _io.ReadCloser
 	zapTraceSpan    *string
 	contentEncoding *string
 }
@@ -547,11 +530,11 @@ func (r ApiPostRestoreShardIdRequest) GetShardID() string {
 	return r.shardID
 }
 
-func (r ApiPostRestoreShardIdRequest) Body(body *os.File) ApiPostRestoreShardIdRequest {
-	r.body = &body
+func (r ApiPostRestoreShardIdRequest) Body(body _io.ReadCloser) ApiPostRestoreShardIdRequest {
+	r.body = body
 	return r
 }
-func (r ApiPostRestoreShardIdRequest) GetBody() **os.File {
+func (r ApiPostRestoreShardIdRequest) GetBody() _io.ReadCloser {
 	return r.body
 }
 

--- a/api/api_setup.gen.go
+++ b/api/api_setup.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -52,22 +51,6 @@ type SetupApi interface {
 	 * @return OnboardingResponse
 	 */
 	PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, error)
-}
-
-// setupApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type setupApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *setupApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *setupApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // SetupApiService SetupApi service

--- a/api/api_tasks.gen.go
+++ b/api/api_tasks.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -196,22 +195,6 @@ type TasksApi interface {
 	 * @return Run
 	 */
 	PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRetryRequest) (Run, error)
-}
-
-// tasksApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type tasksApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *tasksApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *tasksApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // TasksApiService TasksApi service

--- a/api/api_users.gen.go
+++ b/api/api_users.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -105,22 +104,6 @@ type UsersApi interface {
 	 * PostUsersIDPasswordExecute executes the request
 	 */
 	PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordRequest) error
-}
-
-// usersApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type usersApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *usersApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *usersApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // UsersApiService UsersApi service

--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -12,7 +12,6 @@ package api
 
 import (
 	_context "context"
-	_io "io"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -36,22 +35,6 @@ type WriteApi interface {
 	 * PostWriteExecute executes the request
 	 */
 	PostWriteExecute(r ApiPostWriteRequest) error
-}
-
-// writeApiGzipReadCloser supports streaming gzip response-bodies directly from the server.
-type writeApiGzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip       _io.ReadCloser
-}
-
-func (gzrc *writeApiGzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *writeApiGzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
 }
 
 // WriteApiService WriteApi service

--- a/api/templates/README.md
+++ b/api/templates/README.md
@@ -14,10 +14,11 @@ multiple locations.
 `api.mustache`
 * Add `GetX()` methods for each request parameter `X`, for use in unit tests
 * Add checks for `isByteArray` to generate `[]byte` request fields instead of `*string`
+* Add checks for `isBinary` to generate `io.ReadCloser` request fields instead of `**os.File`
 * Update creation of `GenericOpenAPIError` to track sub-error models by reference
 * Add checks for `isResponseBinary` to directly return the raw `*http.Response`, instead of
   pulling the entire body into memory and transforming it into an `*os.File`
-* GUnzip response bodies before unmarshalling when `Content-Encoding: gzip` is set
+* GUnzip non-binary response bodies before unmarshalling when `Content-Encoding: gzip` is set
 * Remove `*http.Response`s from the return values of generated operations
 
 `client.mustache`

--- a/api/templates/api.mustache
+++ b/api/templates/api.mustache
@@ -53,7 +53,7 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request s
 	ApiService *{{classname}}Service
 {{/generateInterfaces}}
 {{#allParams}}
-    {{paramName}} {{#isByteArray}}[]byte{{/isByteArray}}{{#isBinary}}_io.ReadCloser{{/isBinary}}{{^isByteArray}}{{^isBinary}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isBinary}}{{/isByteArray}}
+	{{paramName}} {{#isByteArray}}[]byte{{/isByteArray}}{{#isBinary}}_io.ReadCloser{{/isBinary}}{{^isByteArray}}{{^isBinary}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isBinary}}{{/isByteArray}}
 {{/allParams}}
 }
 {{#allParams}}
@@ -335,11 +335,11 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 
 	if localVarHTTPResponse.StatusCode >= 300 {
-        body, err := GunzipIfNeeded(localVarHTTPResponse)
-        if err != nil {
-            body.Close()
-            return {{#returnType}}localVarReturnValue, {{/returnType}}err
-        }
+		body, err := GunzipIfNeeded(localVarHTTPResponse)
+		if err != nil {
+			body.Close()
+			return {{#returnType}}localVarReturnValue, {{/returnType}}err
+		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
@@ -381,11 +381,11 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	localVarReturnValue = localVarHTTPResponse
 	{{/isResponseBinary}}
 	{{^isResponseBinary}}
-    body, err := GunzipIfNeeded(localVarHTTPResponse)
-    if err != nil {
-        body.Close()
-        return {{#returnType}}localVarReturnValue, {{/returnType}}err
-    }
+	body, err := GunzipIfNeeded(localVarHTTPResponse)
+	if err != nil {
+		body.Close()
+		return {{#returnType}}localVarReturnValue, {{/returnType}}err
+	}
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
 	if err != nil {

--- a/api/templates/api.mustache
+++ b/api/templates/api.mustache
@@ -42,21 +42,6 @@ type {{classname}} interface {
 }
 {{/generateInterfaces}}
 
-// {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser supports streaming gzip response-bodies directly from the server.
-type {{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser struct {
-	underlying _io.ReadCloser
-	gzip _io.ReadCloser
-}
-func (gzrc *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser) Read(p []byte) (int, error) {
-	return gzrc.gzip.Read(p)
-}
-func (gzrc *{{#lambda.camelcase}}{{classname}}{{/lambda.camelcase}}GzipReadCloser) Close() error {
-	if err := gzrc.gzip.Close(); err != nil {
-		return err
-	}
-	return gzrc.underlying.Close()
-}
-
 // {{classname}}Service {{classname}} service
 type {{classname}}Service service
 {{#operation}}
@@ -68,15 +53,15 @@ type {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request s
 	ApiService *{{classname}}Service
 {{/generateInterfaces}}
 {{#allParams}}
-	{{paramName}} {{#isByteArray}}[]byte{{/isByteArray}}{{^isByteArray}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isByteArray}}
+    {{paramName}} {{#isByteArray}}[]byte{{/isByteArray}}{{#isBinary}}_io.ReadCloser{{/isBinary}}{{^isByteArray}}{{^isBinary}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isBinary}}{{/isByteArray}}
 {{/allParams}}
 }
 {{#allParams}}
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{#isByteArray}}[]byte{{/isByteArray}}{{^isByteArray}}{{{dataType}}}{{/isByteArray}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
-	r.{{paramName}} = {{^isByteArray}}{{^isPathParam}}&{{/isPathParam}}{{/isByteArray}}{{paramName}}
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) {{vendorExtensions.x-export-param-name}}({{paramName}} {{#isByteArray}}[]byte{{/isByteArray}}{{#isBinary}}_io.ReadCloser{{/isBinary}}{{^isByteArray}}{{^isBinary}}{{{dataType}}}{{/isBinary}}{{/isByteArray}}) {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request {
+	r.{{paramName}} = {{^isByteArray}}{{^isBinary}}{{^isPathParam}}&{{/isPathParam}}{{/isBinary}}{{/isByteArray}}{{paramName}}
 	return r
 }
-func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Get{{vendorExtensions.x-export-param-name}}() {{#isByteArray}}[]byte{{/isByteArray}}{{^isByteArray}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isByteArray}} {
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) Get{{vendorExtensions.x-export-param-name}}() {{#isByteArray}}[]byte{{/isByteArray}}{{#isBinary}}_io.ReadCloser{{/isBinary}}{{^isByteArray}}{{^isBinary}}{{^isPathParam}}*{{/isPathParam}}{{{dataType}}}{{/isBinary}}{{/isByteArray}} {
 	return r.{{paramName}}
 }
 


### PR DESCRIPTION
This will make POST-ing files w/ gzip slightly more convenient, since we can plug a `ReadCloser` directly into the request instead of writing a temp file.