### PR TITLE
feat: port `export all` command from `influxdb`

### DIFF
--- a/clients/export/export.go
+++ b/clients/export/export.go
@@ -11,6 +11,7 @@ import (
 type Client struct {
 	clients.CLI
 	api.TemplatesApi
+	api.OrganizationsApi
 }
 
 type Params struct {
@@ -123,3 +124,80 @@ func (c Client) Export(ctx context.Context, params *Params) error {
 	return nil
 }
 
+type AllParams struct {
+	OutParams
+
+	OrgId   string
+	OrgName string
+
+	LabelFilters []string
+	KindFilters  []ResourceType
+}
+
+func (c Client) ExportAll(ctx context.Context, params *AllParams) error {
+	if params.OrgId == "" && params.OrgName == "" && c.ActiveConfig.Org == "" {
+		return clients.ErrMustSpecifyOrg
+	}
+
+	orgId := params.OrgId
+	if orgId == "" {
+		orgName := params.OrgName
+		if orgName == "" {
+			orgName = c.ActiveConfig.Org
+		}
+		res, err := c.GetOrgs(ctx).Org(orgName).Execute()
+		if err != nil {
+			return fmt.Errorf("failed to look up ID for org %q: %w", orgName, err)
+		}
+		if len(res.GetOrgs()) == 0 {
+			return fmt.Errorf("no org found with name %q", orgName)
+		}
+		orgId = res.GetOrgs()[0].GetId()
+	}
+
+	orgExport := api.TemplateExportOrgIDs{OrgID: &orgId}
+	if len(params.LabelFilters) > 0 || len(params.KindFilters) > 0 {
+		orgExport.ResourceFilters = &api.TemplateExportResourceFilters{}
+		if len(params.LabelFilters) > 0 {
+			orgExport.ResourceFilters.ByLabel = &params.LabelFilters
+		}
+		if len(params.KindFilters) > 0 {
+			kinds := make([]api.TemplateKind, len(params.KindFilters))
+			for i, kf := range params.KindFilters {
+				switch kf {
+				case TypeBucket:
+					kinds[i] = api.TEMPLATEKIND_BUCKET
+				case TypeCheck:
+					kinds[i] = api.TEMPLATEKIND_CHECK
+				case TypeDashboard:
+					kinds[i] = api.TEMPLATEKIND_DASHBOARD
+				case TypeLabel:
+					kinds[i] = api.TEMPLATEKIND_LABEL
+				case TypeNotificationEndpoint:
+					kinds[i] = api.TEMPLATEKIND_NOTIFICATION_ENDPOINT
+				case TypeNotificationRule:
+					kinds[i] = api.TEMPLATEKIND_NOTIFICATION_RULE
+				case TypeTask:
+					kinds[i] = api.TEMPLATEKIND_TASK
+				case TypeTelegraf:
+					kinds[i] = api.TEMPLATEKIND_TELEGRAF
+				case TypeVariable:
+					kinds[i] = api.TEMPLATEKIND_VARIABLE
+				default:
+					return fmt.Errorf("unsupported resourceKind filter %q", kf)
+				}
+			}
+			orgExport.ResourceFilters.ByResourceKind = &kinds
+		}
+	}
+
+	exportReq := api.TemplateExport{OrgIDs: &[]api.TemplateExportOrgIDs{orgExport}}
+	tmpl, err := c.ExportTemplate(ctx).TemplateExport(exportReq).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to export template: %w", err)
+	}
+	if err := params.OutParams.writeTemplate(tmpl); err != nil {
+		return fmt.Errorf("failed to write exported template: %w", err)
+	}
+	return nil
+}

--- a/clients/export/out.go
+++ b/clients/export/out.go
@@ -1,0 +1,41 @@
+package export
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/influxdata/influx-cli/v2/api"
+	"gopkg.in/yaml.v3"
+)
+
+type OutEncoding int
+
+const (
+	YamlEncoding OutEncoding = iota
+	JsonEncoding
+)
+
+type OutParams struct {
+	Out      io.Writer
+	Encoding OutEncoding
+}
+
+func (o OutParams) writeTemplate(template []api.TemplateEntry) error {
+	switch o.Encoding {
+	case JsonEncoding:
+		enc := json.NewEncoder(o.Out)
+		enc.SetIndent("", "\t")
+		return enc.Encode(template)
+	case YamlEncoding:
+		enc := yaml.NewEncoder(o.Out)
+		for _, entry := range template {
+			if err := enc.Encode(entry); err != nil {
+				return err
+			}
+		}
+	default:
+		return fmt.Errorf("encoding %q is not recognized", o.Encoding)
+	}
+	return nil
+}

--- a/clients/export/resource.go
+++ b/clients/export/resource.go
@@ -1,0 +1,99 @@
+package export
+
+import (
+	"fmt"
+	"strings"
+)
+
+type ResourceType int
+
+const (
+	TypeUnset ResourceType = iota
+	TypeBucket
+	TypeCheck
+	TypeCheckDeadman
+	TypeCheckThreshold
+	TypeDashboard
+	TypeLabel
+	TypeNotificationEndpoint
+	TypeNotificationEndpointHTTP
+	TypeNotificationEndpointPagerDuty
+	TypeNotificationEndpointSlack
+	TypeNotificationRule
+	TypeTask
+	TypeTelegraf
+	TypeVariable
+)
+
+func (r ResourceType) String() string {
+	switch r {
+	case TypeBucket:
+		return "bucket"
+	case TypeCheck:
+		return "check"
+	case TypeCheckDeadman:
+		return "checkDeadman"
+	case TypeCheckThreshold:
+		return "checkThreshold"
+	case TypeDashboard:
+		return "dashboard"
+	case TypeLabel:
+		return "label"
+	case TypeNotificationEndpoint:
+		return "notificationEndpoint"
+	case TypeNotificationEndpointHTTP:
+		return "notificationEndpointHTTP"
+	case TypeNotificationEndpointPagerDuty:
+		return "notificationEndpointPagerDuty"
+	case TypeNotificationEndpointSlack:
+		return "notificationEndpointSlack"
+	case TypeNotificationRule:
+		return "notificationRule"
+	case TypeTask:
+		return "task"
+	case TypeTelegraf:
+		return "telegraf"
+	case TypeVariable:
+		return "variable"
+	case TypeUnset:
+		fallthrough
+	default:
+		return "unset"
+	}
+}
+
+func (r *ResourceType) Set(v string) error {
+	switch strings.ToLower(v) {
+	case "bucket":
+		*r = TypeBucket
+	case "check":
+		*r = TypeCheck
+	case "checkdeadman":
+		*r = TypeCheckDeadman
+	case "checkthreshold":
+		*r = TypeCheckThreshold
+	case "dashboard":
+		*r = TypeDashboard
+	case "label":
+		*r = TypeLabel
+	case "notificationendpoint":
+		*r = TypeNotificationEndpoint
+	case "notificationendpointhttp":
+		*r = TypeNotificationEndpointHTTP
+	case "notificationendpointpagerduty":
+		*r = TypeNotificationEndpointPagerDuty
+	case "notificationendpointslack":
+		*r = TypeNotificationEndpointSlack
+	case "notificationrule":
+		*r = TypeNotificationRule
+	case "task":
+		*r = TypeTask
+	case "telegraf":
+		*r = TypeTelegraf
+	case "variable":
+		*r = TypeVariable
+	default:
+		return fmt.Errorf("unknown resource type: %s", v)
+	}
+	return nil
+}

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -64,6 +64,9 @@ resource flag and then provide the IDs.
 
 For information about exporting InfluxDB templates, see
 https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/`,
+		Subcommands: []*cli.Command{
+			newExportAllCmd(),
+		},
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.StringFlag{
@@ -266,6 +269,138 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/`,
 				TemplatesApi: getAPI(ctx).TemplatesApi,
 			}
 			return client.Export(ctx.Context, &parsedParams)
+		},
+	}
+}
+
+func newExportAllCmd() *cli.Command {
+	var params struct {
+		out     string
+		orgId   string
+		orgName string
+		filters cli.StringSlice
+	}
+	return &cli.Command{
+		Name:  "all",
+		Usage: "Export all existing resources for an organization as a template",
+		Description: `The export all command will export all resources for an organization. The
+command also provides a mechanism to filter by label name or resource kind.
+
+Examples:
+	# Export all resources for an organization
+	influx export all --org $ORG_NAME
+
+	# Export all bucket resources
+	influx export all --org $ORG_NAME --filter=kind=Bucket
+
+	# Export all resources associated with label Foo
+	influx export all --org $ORG_NAME --filter=labelName=Foo
+
+	# Export all bucket resources and filter by label Foo
+	influx export all --org $ORG_NAME \
+		--filter kind=Bucket \
+		--filter labelName=Foo
+
+	# Export all bucket or dashboard resources and filter by label Foo.
+	# note: like filters are unioned and filter types are intersections.
+	#		This example will export a resource if it is a dashboard or
+	#		bucket and has an associated label of Foo.
+	influx export all --org $ORG_NAME \
+		--filter kind=Bucket \
+		--filter kind=Dashboard \
+		--filter labelName=Foo
+
+For information about exporting InfluxDB templates, see
+https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/
+and
+https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
+`,
+		Flags: append(
+			commonFlagsNoPrint(),
+			&cli.StringFlag{
+				Name:        "org-id",
+				Usage:       "The ID of the organization",
+				EnvVars:     []string{"INFLUX_ORG_ID"},
+				Destination: &params.orgId,
+			},
+			&cli.StringFlag{
+				Name:        "org",
+				Usage:       "The name of the organization",
+				Aliases:     []string{"o"},
+				EnvVars:     []string{"INFLUX_ORG"},
+				Destination: &params.orgName,
+			},
+			&cli.StringFlag{
+				Name:        "file",
+				Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
+				Aliases:     []string{"f"},
+				Destination: &params.out,
+			},
+			&cli.StringSliceFlag{
+				Name:        "filter",
+				Usage:       "Filter exported resources by labelName or resourceKind (format: labelName=example)",
+				Destination: &params.filters,
+			},
+		),
+		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
+		Action: func(ctx *cli.Context) error {
+			parsedParams := export.AllParams{
+				OrgId:   params.orgId,
+				OrgName: params.orgName,
+			}
+
+			for _, filter := range params.filters.Value() {
+				components := strings.Split(filter, "=")
+				if len(components) != 2 {
+					return fmt.Errorf("invalid filter %q, must have format `type=example`", filter)
+				}
+				switch key, val := components[0], components[1]; key {
+				case "labelName":
+					parsedParams.LabelFilters = append(parsedParams.LabelFilters, val)
+				case "kind", "resourceKind":
+					var resType export.ResourceType
+					if err := resType.Set(val); err != nil {
+						return err
+					}
+					switch resType {
+					// NOTE: The API doesn't support filtering by these resource subtypes,
+					// and instead converts them to the parent type. For example,
+					// `--resource-type notificationEndpointHTTP` gets translated to a filter
+					// on all notification endpoints on the server-side. I think this was
+					// intentional since the 2.0.x CLI didn't expose flags to filter on subtypes,
+					// but a bug/oversight in its parsing still allowed the subtypes through
+					// when passing IDs over stdin.
+					// Instead of allowing the type-filter to be silently converted by the server,
+					// we catch the previously-allowed subtypes here and return a (hopefully) useful
+					// error suggesting the correct flag to use.
+					case export.TypeCheckDeadman, export.TypeCheckThreshold:
+						return fmt.Errorf("filtering on resourceKind=%s is not supported by the API. Use resourceKind=%s instead", resType, export.TypeCheck)
+					case export.TypeNotificationEndpointSlack, export.TypeNotificationEndpointPagerDuty, export.TypeNotificationEndpointHTTP:
+						return fmt.Errorf("filtering on resourceKind=%s is not supported by the API. Use resourceKind=%s instead", resType, export.TypeNotificationEndpoint)
+					default:
+					}
+					parsedParams.KindFilters = append(parsedParams.KindFilters, resType)
+				default:
+					return fmt.Errorf("invalid filter provided %q; filter must be 1 in [labelName, resourceKind]", filter)
+				}
+			}
+
+			outParams, closer, err := parseOutParams(params.out)
+			if closer != nil {
+				defer closer()
+			}
+			if err != nil {
+				return err
+			}
+			parsedParams.OutParams = outParams
+
+			apiClient := getAPI(ctx)
+			client := export.Client{
+				CLI:              getCLI(ctx),
+				TemplatesApi:     apiClient.TemplatesApi,
+				OrganizationsApi: apiClient.OrganizationsApi,
+			}
+			return client.ExportAll(ctx.Context, &parsedParams)
 		},
 	}
 }


### PR DESCRIPTION
Part 2/3 of #12 

Most of the diff is moving around code from the top-level `export` command.