### PR TITLE
feat: placeholder for v1 subcommands

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -50,6 +50,7 @@ var app = cli.App{
 		newDashboardsCommand(),
 		newExportCmd(),
 		newSecretCommand(),
+		newV1SubCommand(),
 	},
 }
 

--- a/cmd/influx/v1_commands.go
+++ b/cmd/influx/v1_commands.go
@@ -1,0 +1,13 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+func newV1SubCommand() *cli.Command {
+	return &cli.Command{
+		Name:  "v1",
+		Usage: "InfluxDB v1 management commands",
+		Subcommands: []*cli.Command{
+			newV1DBRPCmd(),
+		},
+	}
+}

--- a/cmd/influx/v1_commands.go
+++ b/cmd/influx/v1_commands.go
@@ -8,6 +8,7 @@ func newV1SubCommand() *cli.Command {
 		Usage: "InfluxDB v1 management commands",
 		Subcommands: []*cli.Command{
 			newV1DBRPCmd(),
+			// etc
 		},
 	}
 }

--- a/cmd/influx/v1_dbrp.go
+++ b/cmd/influx/v1_dbrp.go
@@ -1,0 +1,19 @@
+package main
+
+import "github.com/urfave/cli/v2"
+
+func newV1DBRPCmd() *cli.Command {
+	return &cli.Command{
+		Name:        "dbrp",
+		Usage:       "Commands to manage database and retention policy mappings for v1 APIs",
+		Subcommands: []*cli.Command{
+			// newV1DBRPListCmd(),
+			// newV1DBRPCreateCmd(),
+			// newV1DBRPDeleteCmd(),
+			// newV1DBRPUpdateCmd(),
+		},
+	}
+}
+
+// commands will be implemented below, with business logic residing in their
+// respective client package, like "v1_dbrp"


### PR DESCRIPTION
Part of #23 & #24

This PR adds a placeholder for `v1` subcommands. They can be linked into the CLI via the `newV1SubCommand` function.

If the `newV1SubCommand` function needs to be in its own folder could be discussed - I started with it there since that is how it is in the `influxdb` codebase: https://github.com/influxdata/influxdb/blob/master/cmd/influx/v1_commands.go