### PR TITLE
fix: add yaml tags to models so we can unmarshal camelCase

### DIFF
--- a/api/api_legacy_authorizations.gen.go
+++ b/api/api_legacy_authorizations.gen.go
@@ -12,6 +12,7 @@ package api
 
 import (
 	_context "context"
+	_fmt "fmt"
 	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
@@ -104,10 +105,30 @@ type LegacyAuthorizationsApi interface {
 	 * PostAuthorizationsIDPasswordExecute executes the request
 	 */
 	PostAuthorizationsIDPasswordExecute(r ApiPostAuthorizationsIDPasswordRequest) error
+
+	// Sets additional descriptive text in the error message if any request in
+	// this API fails, indicating that it is intended to be used only on OSS
+	// servers.
+	OnlyOSS() LegacyAuthorizationsApi
+
+	// Sets additional descriptive text in the error message if any request in
+	// this API fails, indicating that it is intended to be used only on cloud
+	// servers.
+	OnlyCloud() LegacyAuthorizationsApi
 }
 
 // LegacyAuthorizationsApiService LegacyAuthorizationsApi service
 type LegacyAuthorizationsApiService service
+
+func (a *LegacyAuthorizationsApiService) OnlyOSS() LegacyAuthorizationsApi {
+	a.isOnlyOSS = true
+	return a
+}
+
+func (a *LegacyAuthorizationsApiService) OnlyCloud() LegacyAuthorizationsApi {
+	a.isOnlyCloud = true
+	return a
+}
 
 type ApiDeleteAuthorizationsIDRequest struct {
 	ctx          _context.Context
@@ -204,28 +225,36 @@ func (a *LegacyAuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDele
 		return err
 	}
 
+	var errorPrefix string
+	if a.isOnlyOSS {
+		errorPrefix = "InfluxDB OSS-only command failed: "
+	} else if a.isOnlyCloud {
+		errorPrefix = "InfluxDB Cloud-only command failed: "
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return err
+			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return err
+			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
-			newErr.error = err.Error()
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 			return newErr
 		}
 		newErr.model = &v
+		newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 		return newErr
 	}
 
@@ -389,46 +418,54 @@ func (a *LegacyAuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthor
 		return localVarReturnValue, err
 	}
 
+	var errorPrefix string
+	if a.isOnlyOSS {
+		errorPrefix = "InfluxDB OSS-only command failed: "
+	} else if a.isOnlyCloud {
+		errorPrefix = "InfluxDB Cloud-only command failed: "
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
-			newErr.error = err.Error()
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
+		newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 		return localVarReturnValue, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: err.Error(),
+			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
 		return localVarReturnValue, newErr
 	}
@@ -533,46 +570,54 @@ func (a *LegacyAuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuth
 		return localVarReturnValue, err
 	}
 
+	var errorPrefix string
+	if a.isOnlyOSS {
+		errorPrefix = "InfluxDB OSS-only command failed: "
+	} else if a.isOnlyCloud {
+		errorPrefix = "InfluxDB Cloud-only command failed: "
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
-			newErr.error = err.Error()
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
+		newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 		return localVarReturnValue, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: err.Error(),
+			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
 		return localVarReturnValue, newErr
 	}
@@ -691,46 +736,54 @@ func (a *LegacyAuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatch
 		return localVarReturnValue, err
 	}
 
+	var errorPrefix string
+	if a.isOnlyOSS {
+		errorPrefix = "InfluxDB OSS-only command failed: "
+	} else if a.isOnlyCloud {
+		errorPrefix = "InfluxDB Cloud-only command failed: "
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
-			newErr.error = err.Error()
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
+		newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 		return localVarReturnValue, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: err.Error(),
+			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
 		return localVarReturnValue, newErr
 	}
@@ -837,56 +890,65 @@ func (a *LegacyAuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuth
 		return localVarReturnValue, err
 	}
 
+	var errorPrefix string
+	if a.isOnlyOSS {
+		errorPrefix = "InfluxDB OSS-only command failed: "
+	} else if a.isOnlyCloud {
+		errorPrefix = "InfluxDB Cloud-only command failed: "
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, err
+			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
 		if localVarHTTPResponse.StatusCode == 400 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
-				newErr.error = err.Error()
+				newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 				return localVarReturnValue, newErr
 			}
 			newErr.model = &v
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 			return localVarReturnValue, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
-			newErr.error = err.Error()
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 			return localVarReturnValue, newErr
 		}
 		newErr.model = &v
+		newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 		return localVarReturnValue, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _ioutil.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: err.Error(),
+			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
 		return localVarReturnValue, newErr
 	}
@@ -1003,28 +1065,36 @@ func (a *LegacyAuthorizationsApiService) PostAuthorizationsIDPasswordExecute(r A
 		return err
 	}
 
+	var errorPrefix string
+	if a.isOnlyOSS {
+		errorPrefix = "InfluxDB OSS-only command failed: "
+	} else if a.isOnlyCloud {
+		errorPrefix = "InfluxDB Cloud-only command failed: "
+	}
+
 	if localVarHTTPResponse.StatusCode >= 300 {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return err
+			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _ioutil.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return err
+			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
-			error: localVarHTTPResponse.Status,
+			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
-			newErr.error = err.Error()
+			newErr.error = _fmt.Sprintf("%s%v", errorPrefix, err.Error())
 			return newErr
 		}
 		newErr.model = &v
+		newErr.error = _fmt.Sprintf("%s%v", errorPrefix, v.Error())
 		return newErr
 	}
 

--- a/api/model_add_resource_member_request_body.gen.go
+++ b/api/model_add_resource_member_request_body.gen.go
@@ -16,8 +16,8 @@ import (
 
 // AddResourceMemberRequestBody struct for AddResourceMemberRequestBody
 type AddResourceMemberRequestBody struct {
-	Id   string  `json:"id"`
-	Name *string `json:"name,omitempty"`
+	Id   string  `json:"id" yaml:"id"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 // NewAddResourceMemberRequestBody instantiates a new AddResourceMemberRequestBody object

--- a/api/model_authorization.gen.go
+++ b/api/model_authorization.gen.go
@@ -18,25 +18,25 @@ import (
 // Authorization struct for Authorization
 type Authorization struct {
 	// If inactive the token is inactive and requests using the token will be rejected.
-	Status *string `json:"status,omitempty"`
+	Status *string `json:"status,omitempty" yaml:"status,omitempty"`
 	// A description of the token.
-	Description *string    `json:"description,omitempty"`
-	CreatedAt   *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt   *time.Time `json:"updatedAt,omitempty"`
+	Description *string    `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt   *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt   *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 	// ID of org that authorization is scoped to.
-	OrgID string `json:"orgID"`
+	OrgID string `json:"orgID" yaml:"orgID"`
 	// List of permissions for an auth.  An auth must have at least one Permission.
-	Permissions []Permission `json:"permissions"`
-	Id          *string      `json:"id,omitempty"`
+	Permissions []Permission `json:"permissions" yaml:"permissions"`
+	Id          *string      `json:"id,omitempty" yaml:"id,omitempty"`
 	// Passed via the Authorization Header and Token Authentication type.
-	Token *string `json:"token,omitempty"`
+	Token *string `json:"token,omitempty" yaml:"token,omitempty"`
 	// ID of user that created and owns the token.
-	UserID *string `json:"userID,omitempty"`
+	UserID *string `json:"userID,omitempty" yaml:"userID,omitempty"`
 	// Name of user that created and owns the token.
-	User *string `json:"user,omitempty"`
+	User *string `json:"user,omitempty" yaml:"user,omitempty"`
 	// Name of the org token is scoped to.
-	Org   *string                  `json:"org,omitempty"`
-	Links *AuthorizationAllOfLinks `json:"links,omitempty"`
+	Org   *string                  `json:"org,omitempty" yaml:"org,omitempty"`
+	Links *AuthorizationAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewAuthorization instantiates a new Authorization object

--- a/api/model_authorization_all_of.gen.go
+++ b/api/model_authorization_all_of.gen.go
@@ -17,22 +17,22 @@ import (
 
 // AuthorizationAllOf struct for AuthorizationAllOf
 type AuthorizationAllOf struct {
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 	// ID of org that authorization is scoped to.
-	OrgID *string `json:"orgID,omitempty"`
+	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	// List of permissions for an auth.  An auth must have at least one Permission.
-	Permissions *[]Permission `json:"permissions,omitempty"`
-	Id          *string       `json:"id,omitempty"`
+	Permissions *[]Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+	Id          *string       `json:"id,omitempty" yaml:"id,omitempty"`
 	// Passed via the Authorization Header and Token Authentication type.
-	Token *string `json:"token,omitempty"`
+	Token *string `json:"token,omitempty" yaml:"token,omitempty"`
 	// ID of user that created and owns the token.
-	UserID *string `json:"userID,omitempty"`
+	UserID *string `json:"userID,omitempty" yaml:"userID,omitempty"`
 	// Name of user that created and owns the token.
-	User *string `json:"user,omitempty"`
+	User *string `json:"user,omitempty" yaml:"user,omitempty"`
 	// Name of the org token is scoped to.
-	Org   *string                  `json:"org,omitempty"`
-	Links *AuthorizationAllOfLinks `json:"links,omitempty"`
+	Org   *string                  `json:"org,omitempty" yaml:"org,omitempty"`
+	Links *AuthorizationAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewAuthorizationAllOf instantiates a new AuthorizationAllOf object

--- a/api/model_authorization_all_of_links.gen.go
+++ b/api/model_authorization_all_of_links.gen.go
@@ -17,9 +17,9 @@ import (
 // AuthorizationAllOfLinks struct for AuthorizationAllOfLinks
 type AuthorizationAllOfLinks struct {
 	// URI of resource.
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 	// URI of resource.
-	User *string `json:"user,omitempty"`
+	User *string `json:"user,omitempty" yaml:"user,omitempty"`
 }
 
 // NewAuthorizationAllOfLinks instantiates a new AuthorizationAllOfLinks object

--- a/api/model_authorization_update_request.gen.go
+++ b/api/model_authorization_update_request.gen.go
@@ -17,9 +17,9 @@ import (
 // AuthorizationUpdateRequest struct for AuthorizationUpdateRequest
 type AuthorizationUpdateRequest struct {
 	// If inactive the token is inactive and requests using the token will be rejected.
-	Status *string `json:"status,omitempty"`
+	Status *string `json:"status,omitempty" yaml:"status,omitempty"`
 	// A description of the token.
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewAuthorizationUpdateRequest instantiates a new AuthorizationUpdateRequest object

--- a/api/model_authorizations.gen.go
+++ b/api/model_authorizations.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Authorizations struct for Authorizations
 type Authorizations struct {
-	Links          *Links           `json:"links,omitempty"`
-	Authorizations *[]Authorization `json:"authorizations,omitempty"`
+	Links          *Links           `json:"links,omitempty" yaml:"links,omitempty"`
+	Authorizations *[]Authorization `json:"authorizations,omitempty" yaml:"authorizations,omitempty"`
 }
 
 // NewAuthorizations instantiates a new Authorizations object

--- a/api/model_bucket.gen.go
+++ b/api/model_bucket.gen.go
@@ -17,19 +17,19 @@ import (
 
 // Bucket struct for Bucket
 type Bucket struct {
-	Links       *BucketLinks `json:"links,omitempty"`
-	Id          *string      `json:"id,omitempty"`
-	Type        *string      `json:"type,omitempty"`
-	Name        string       `json:"name"`
-	Description *string      `json:"description,omitempty"`
-	OrgID       *string      `json:"orgID,omitempty"`
-	Rp          *string      `json:"rp,omitempty"`
-	SchemaType  *SchemaType  `json:"schemaType,omitempty"`
-	CreatedAt   *time.Time   `json:"createdAt,omitempty"`
-	UpdatedAt   *time.Time   `json:"updatedAt,omitempty"`
+	Links       *BucketLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	Id          *string      `json:"id,omitempty" yaml:"id,omitempty"`
+	Type        *string      `json:"type,omitempty" yaml:"type,omitempty"`
+	Name        string       `json:"name" yaml:"name"`
+	Description *string      `json:"description,omitempty" yaml:"description,omitempty"`
+	OrgID       *string      `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Rp          *string      `json:"rp,omitempty" yaml:"rp,omitempty"`
+	SchemaType  *SchemaType  `json:"schemaType,omitempty" yaml:"schemaType,omitempty"`
+	CreatedAt   *time.Time   `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt   *time.Time   `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 	// Rules to expire or retain data.  No rules means data never expires.
-	RetentionRules []RetentionRule `json:"retentionRules"`
-	Labels         *[]Label        `json:"labels,omitempty"`
+	RetentionRules []RetentionRule `json:"retentionRules" yaml:"retentionRules"`
+	Labels         *[]Label        `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // NewBucket instantiates a new Bucket object

--- a/api/model_bucket_links.gen.go
+++ b/api/model_bucket_links.gen.go
@@ -17,17 +17,17 @@ import (
 // BucketLinks struct for BucketLinks
 type BucketLinks struct {
 	// URI of resource.
-	Labels *string `json:"labels,omitempty"`
+	Labels *string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// URI of resource.
-	Members *string `json:"members,omitempty"`
+	Members *string `json:"members,omitempty" yaml:"members,omitempty"`
 	// URI of resource.
-	Org *string `json:"org,omitempty"`
+	Org *string `json:"org,omitempty" yaml:"org,omitempty"`
 	// URI of resource.
-	Owners *string `json:"owners,omitempty"`
+	Owners *string `json:"owners,omitempty" yaml:"owners,omitempty"`
 	// URI of resource.
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 	// URI of resource.
-	Write *string `json:"write,omitempty"`
+	Write *string `json:"write,omitempty" yaml:"write,omitempty"`
 }
 
 // NewBucketLinks instantiates a new BucketLinks object

--- a/api/model_bucket_metadata_manifest.gen.go
+++ b/api/model_bucket_metadata_manifest.gen.go
@@ -16,13 +16,13 @@ import (
 
 // BucketMetadataManifest struct for BucketMetadataManifest
 type BucketMetadataManifest struct {
-	OrganizationID         string                    `json:"organizationID"`
-	OrganizationName       string                    `json:"organizationName"`
-	BucketID               string                    `json:"bucketID"`
-	BucketName             string                    `json:"bucketName"`
-	Description            *string                   `json:"description,omitempty"`
-	DefaultRetentionPolicy string                    `json:"defaultRetentionPolicy"`
-	RetentionPolicies      []RetentionPolicyManifest `json:"retentionPolicies"`
+	OrganizationID         string                    `json:"organizationID" yaml:"organizationID"`
+	OrganizationName       string                    `json:"organizationName" yaml:"organizationName"`
+	BucketID               string                    `json:"bucketID" yaml:"bucketID"`
+	BucketName             string                    `json:"bucketName" yaml:"bucketName"`
+	Description            *string                   `json:"description,omitempty" yaml:"description,omitempty"`
+	DefaultRetentionPolicy string                    `json:"defaultRetentionPolicy" yaml:"defaultRetentionPolicy"`
+	RetentionPolicies      []RetentionPolicyManifest `json:"retentionPolicies" yaml:"retentionPolicies"`
 }
 
 // NewBucketMetadataManifest instantiates a new BucketMetadataManifest object

--- a/api/model_bucket_shard_mapping.gen.go
+++ b/api/model_bucket_shard_mapping.gen.go
@@ -16,8 +16,8 @@ import (
 
 // BucketShardMapping struct for BucketShardMapping
 type BucketShardMapping struct {
-	OldId int64 `json:"oldId"`
-	NewId int64 `json:"newId"`
+	OldId int64 `json:"oldId" yaml:"oldId"`
+	NewId int64 `json:"newId" yaml:"newId"`
 }
 
 // NewBucketShardMapping instantiates a new BucketShardMapping object

--- a/api/model_buckets.gen.go
+++ b/api/model_buckets.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Buckets struct for Buckets
 type Buckets struct {
-	Links   *Links    `json:"links,omitempty"`
-	Buckets *[]Bucket `json:"buckets,omitempty"`
+	Links   *Links    `json:"links,omitempty" yaml:"links,omitempty"`
+	Buckets *[]Bucket `json:"buckets,omitempty" yaml:"buckets,omitempty"`
 }
 
 // NewBuckets instantiates a new Buckets object

--- a/api/model_cell.gen.go
+++ b/api/model_cell.gen.go
@@ -16,14 +16,14 @@ import (
 
 // Cell struct for Cell
 type Cell struct {
-	Id    *string    `json:"id,omitempty"`
-	Links *CellLinks `json:"links,omitempty"`
-	X     *int32     `json:"x,omitempty"`
-	Y     *int32     `json:"y,omitempty"`
-	W     *int32     `json:"w,omitempty"`
-	H     *int32     `json:"h,omitempty"`
+	Id    *string    `json:"id,omitempty" yaml:"id,omitempty"`
+	Links *CellLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	X     *int32     `json:"x,omitempty" yaml:"x,omitempty"`
+	Y     *int32     `json:"y,omitempty" yaml:"y,omitempty"`
+	W     *int32     `json:"w,omitempty" yaml:"w,omitempty"`
+	H     *int32     `json:"h,omitempty" yaml:"h,omitempty"`
 	// The reference to a view from the views API.
-	ViewID *string `json:"viewID,omitempty"`
+	ViewID *string `json:"viewID,omitempty" yaml:"viewID,omitempty"`
 }
 
 // NewCell instantiates a new Cell object

--- a/api/model_cell_links.gen.go
+++ b/api/model_cell_links.gen.go
@@ -16,8 +16,8 @@ import (
 
 // CellLinks struct for CellLinks
 type CellLinks struct {
-	Self *string `json:"self,omitempty"`
-	View *string `json:"view,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
+	View *string `json:"view,omitempty" yaml:"view,omitempty"`
 }
 
 // NewCellLinks instantiates a new CellLinks object

--- a/api/model_create_dashboard_request.gen.go
+++ b/api/model_create_dashboard_request.gen.go
@@ -17,11 +17,11 @@ import (
 // CreateDashboardRequest struct for CreateDashboardRequest
 type CreateDashboardRequest struct {
 	// The ID of the organization that owns the dashboard.
-	OrgID string `json:"orgID"`
+	OrgID string `json:"orgID" yaml:"orgID"`
 	// The user-facing name of the dashboard.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// The user-facing description of the dashboard.
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewCreateDashboardRequest instantiates a new CreateDashboardRequest object

--- a/api/model_dashboard.gen.go
+++ b/api/model_dashboard.gen.go
@@ -17,16 +17,16 @@ import (
 // Dashboard struct for Dashboard
 type Dashboard struct {
 	// The ID of the organization that owns the dashboard.
-	OrgID string `json:"orgID"`
+	OrgID string `json:"orgID" yaml:"orgID"`
 	// The user-facing name of the dashboard.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// The user-facing description of the dashboard.
-	Description *string              `json:"description,omitempty"`
-	Links       *DashboardAllOfLinks `json:"links,omitempty"`
-	Id          *string              `json:"id,omitempty"`
-	Meta        *DashboardAllOfMeta  `json:"meta,omitempty"`
-	Cells       *[]Cell              `json:"cells,omitempty"`
-	Labels      *[]Label             `json:"labels,omitempty"`
+	Description *string              `json:"description,omitempty" yaml:"description,omitempty"`
+	Links       *DashboardAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	Id          *string              `json:"id,omitempty" yaml:"id,omitempty"`
+	Meta        *DashboardAllOfMeta  `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Cells       *[]Cell              `json:"cells,omitempty" yaml:"cells,omitempty"`
+	Labels      *[]Label             `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // NewDashboard instantiates a new Dashboard object

--- a/api/model_dashboard_all_of.gen.go
+++ b/api/model_dashboard_all_of.gen.go
@@ -16,11 +16,11 @@ import (
 
 // DashboardAllOf struct for DashboardAllOf
 type DashboardAllOf struct {
-	Links  *DashboardAllOfLinks `json:"links,omitempty"`
-	Id     *string              `json:"id,omitempty"`
-	Meta   *DashboardAllOfMeta  `json:"meta,omitempty"`
-	Cells  *[]Cell              `json:"cells,omitempty"`
-	Labels *[]Label             `json:"labels,omitempty"`
+	Links  *DashboardAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	Id     *string              `json:"id,omitempty" yaml:"id,omitempty"`
+	Meta   *DashboardAllOfMeta  `json:"meta,omitempty" yaml:"meta,omitempty"`
+	Cells  *[]Cell              `json:"cells,omitempty" yaml:"cells,omitempty"`
+	Labels *[]Label             `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // NewDashboardAllOf instantiates a new DashboardAllOf object

--- a/api/model_dashboard_all_of_links.gen.go
+++ b/api/model_dashboard_all_of_links.gen.go
@@ -17,17 +17,17 @@ import (
 // DashboardAllOfLinks struct for DashboardAllOfLinks
 type DashboardAllOfLinks struct {
 	// URI of resource.
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 	// URI of resource.
-	Cells *string `json:"cells,omitempty"`
+	Cells *string `json:"cells,omitempty" yaml:"cells,omitempty"`
 	// URI of resource.
-	Members *string `json:"members,omitempty"`
+	Members *string `json:"members,omitempty" yaml:"members,omitempty"`
 	// URI of resource.
-	Owners *string `json:"owners,omitempty"`
+	Owners *string `json:"owners,omitempty" yaml:"owners,omitempty"`
 	// URI of resource.
-	Labels *string `json:"labels,omitempty"`
+	Labels *string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// URI of resource.
-	Org *string `json:"org,omitempty"`
+	Org *string `json:"org,omitempty" yaml:"org,omitempty"`
 }
 
 // NewDashboardAllOfLinks instantiates a new DashboardAllOfLinks object

--- a/api/model_dashboard_all_of_meta.gen.go
+++ b/api/model_dashboard_all_of_meta.gen.go
@@ -17,8 +17,8 @@ import (
 
 // DashboardAllOfMeta struct for DashboardAllOfMeta
 type DashboardAllOfMeta struct {
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 }
 
 // NewDashboardAllOfMeta instantiates a new DashboardAllOfMeta object

--- a/api/model_dashboards.gen.go
+++ b/api/model_dashboards.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Dashboards struct for Dashboards
 type Dashboards struct {
-	Links      *Links       `json:"links,omitempty"`
-	Dashboards *[]Dashboard `json:"dashboards,omitempty"`
+	Links      *Links       `json:"links,omitempty" yaml:"links,omitempty"`
+	Dashboards *[]Dashboard `json:"dashboards,omitempty" yaml:"dashboards,omitempty"`
 }
 
 // NewDashboards instantiates a new Dashboards object

--- a/api/model_dbrp.gen.go
+++ b/api/model_dbrp.gen.go
@@ -17,18 +17,18 @@ import (
 // DBRP struct for DBRP
 type DBRP struct {
 	// the mapping identifier
-	Id string `json:"id"`
+	Id string `json:"id" yaml:"id"`
 	// the organization ID that owns this mapping.
-	OrgID string `json:"orgID"`
+	OrgID string `json:"orgID" yaml:"orgID"`
 	// the bucket ID used as target for the translation.
-	BucketID string `json:"bucketID"`
+	BucketID string `json:"bucketID" yaml:"bucketID"`
 	// InfluxDB v1 database
-	Database string `json:"database"`
+	Database string `json:"database" yaml:"database"`
 	// InfluxDB v1 retention policy
-	RetentionPolicy string `json:"retention_policy"`
+	RetentionPolicy string `json:"retention_policy" yaml:"retention_policy"`
 	// Specify if this mapping represents the default retention policy for the database specificed.
-	Default bool   `json:"default"`
-	Links   *Links `json:"links,omitempty"`
+	Default bool   `json:"default" yaml:"default"`
+	Links   *Links `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewDBRP instantiates a new DBRP object

--- a/api/model_dbrp_create.gen.go
+++ b/api/model_dbrp_create.gen.go
@@ -17,17 +17,17 @@ import (
 // DBRPCreate struct for DBRPCreate
 type DBRPCreate struct {
 	// the organization ID that owns this mapping.
-	OrgID *string `json:"orgID,omitempty"`
+	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	// the organization that owns this mapping.
-	Org *string `json:"org,omitempty"`
+	Org *string `json:"org,omitempty" yaml:"org,omitempty"`
 	// the bucket ID used as target for the translation.
-	BucketID string `json:"bucketID"`
+	BucketID string `json:"bucketID" yaml:"bucketID"`
 	// InfluxDB v1 database
-	Database string `json:"database"`
+	Database string `json:"database" yaml:"database"`
 	// InfluxDB v1 retention policy
-	RetentionPolicy string `json:"retention_policy"`
+	RetentionPolicy string `json:"retention_policy" yaml:"retention_policy"`
 	// Specify if this mapping represents the default retention policy for the database specificed.
-	Default *bool `json:"default,omitempty"`
+	Default *bool `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
 // NewDBRPCreate instantiates a new DBRPCreate object

--- a/api/model_dbrp_get.gen.go
+++ b/api/model_dbrp_get.gen.go
@@ -16,7 +16,7 @@ import (
 
 // DBRPGet struct for DBRPGet
 type DBRPGet struct {
-	Content *DBRP `json:"content,omitempty"`
+	Content *DBRP `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 // NewDBRPGet instantiates a new DBRPGet object

--- a/api/model_dbrp_update.gen.go
+++ b/api/model_dbrp_update.gen.go
@@ -17,8 +17,8 @@ import (
 // DBRPUpdate struct for DBRPUpdate
 type DBRPUpdate struct {
 	// InfluxDB v1 retention policy
-	RetentionPolicy *string `json:"retention_policy,omitempty"`
-	Default         *bool   `json:"default,omitempty"`
+	RetentionPolicy *string `json:"retention_policy,omitempty" yaml:"retention_policy,omitempty"`
+	Default         *bool   `json:"default,omitempty" yaml:"default,omitempty"`
 }
 
 // NewDBRPUpdate instantiates a new DBRPUpdate object

--- a/api/model_dbrps.gen.go
+++ b/api/model_dbrps.gen.go
@@ -16,7 +16,7 @@ import (
 
 // DBRPs struct for DBRPs
 type DBRPs struct {
-	Content *[]DBRP `json:"content,omitempty"`
+	Content *[]DBRP `json:"content,omitempty" yaml:"content,omitempty"`
 }
 
 // NewDBRPs instantiates a new DBRPs object

--- a/api/model_delete_predicate_request.gen.go
+++ b/api/model_delete_predicate_request.gen.go
@@ -18,11 +18,11 @@ import (
 // DeletePredicateRequest The delete predicate request.
 type DeletePredicateRequest struct {
 	// RFC3339Nano
-	Start time.Time `json:"start"`
+	Start time.Time `json:"start" yaml:"start"`
 	// RFC3339Nano
-	Stop time.Time `json:"stop"`
+	Stop time.Time `json:"stop" yaml:"stop"`
 	// InfluxQL-like delete statement
-	Predicate *string `json:"predicate,omitempty"`
+	Predicate *string `json:"predicate,omitempty" yaml:"predicate,omitempty"`
 }
 
 // NewDeletePredicateRequest instantiates a new DeletePredicateRequest object

--- a/api/model_dialect.gen.go
+++ b/api/model_dialect.gen.go
@@ -17,15 +17,15 @@ import (
 // Dialect Dialect are options to change the default CSV output format; https://www.w3.org/TR/2015/REC-tabular-metadata-20151217/#dialect-descriptions
 type Dialect struct {
 	// If true, the results will contain a header row
-	Header *bool `json:"header,omitempty"`
+	Header *bool `json:"header,omitempty" yaml:"header,omitempty"`
 	// Separator between cells; the default is ,
-	Delimiter *string `json:"delimiter,omitempty"`
+	Delimiter *string `json:"delimiter,omitempty" yaml:"delimiter,omitempty"`
 	// https://www.w3.org/TR/2015/REC-tabular-data-model-20151217/#columns
-	Annotations *[]string `json:"annotations,omitempty"`
+	Annotations *[]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
 	// Character prefixed to comment strings
-	CommentPrefix *string `json:"commentPrefix,omitempty"`
+	CommentPrefix *string `json:"commentPrefix,omitempty" yaml:"commentPrefix,omitempty"`
 	// Format of timestamps
-	DateTimeFormat *string `json:"dateTimeFormat,omitempty"`
+	DateTimeFormat *string `json:"dateTimeFormat,omitempty" yaml:"dateTimeFormat,omitempty"`
 }
 
 // NewDialect instantiates a new Dialect object

--- a/api/model_error.gen.go
+++ b/api/model_error.gen.go
@@ -16,13 +16,13 @@ import (
 
 // Error struct for Error
 type Error struct {
-	Code ErrorCode `json:"code"`
+	Code ErrorCode `json:"code" yaml:"code"`
 	// message is a human-readable message.
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 	// op describes the logical code operation during error. Useful for debugging.
-	Op *string `json:"op,omitempty"`
+	Op *string `json:"op,omitempty" yaml:"op,omitempty"`
 	// err is a stack of errors that occurred during processing of the request. Useful for debugging.
-	Err *string `json:"err,omitempty"`
+	Err *string `json:"err,omitempty" yaml:"err,omitempty"`
 }
 
 // NewError instantiates a new Error object

--- a/api/model_extern.gen.go
+++ b/api/model_extern.gen.go
@@ -16,7 +16,7 @@ import (
 
 // Extern Free-form Flux AST to prepend to query requests
 type Extern struct {
-	Type                 *string `json:"type,omitempty"`
+	Type                 *string `json:"type,omitempty" yaml:"type,omitempty"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/api/model_health_check.gen.go
+++ b/api/model_health_check.gen.go
@@ -16,12 +16,12 @@ import (
 
 // HealthCheck struct for HealthCheck
 type HealthCheck struct {
-	Name    string            `json:"name"`
-	Message *string           `json:"message,omitempty"`
-	Checks  *[]HealthCheck    `json:"checks,omitempty"`
-	Status  HealthCheckStatus `json:"status"`
-	Version *string           `json:"version,omitempty"`
-	Commit  *string           `json:"commit,omitempty"`
+	Name    string            `json:"name" yaml:"name"`
+	Message *string           `json:"message,omitempty" yaml:"message,omitempty"`
+	Checks  *[]HealthCheck    `json:"checks,omitempty" yaml:"checks,omitempty"`
+	Status  HealthCheckStatus `json:"status" yaml:"status"`
+	Version *string           `json:"version,omitempty" yaml:"version,omitempty"`
+	Commit  *string           `json:"commit,omitempty" yaml:"commit,omitempty"`
 }
 
 // NewHealthCheck instantiates a new HealthCheck object

--- a/api/model_inline_response_200.gen.go
+++ b/api/model_inline_response_200.gen.go
@@ -17,7 +17,7 @@ import (
 // InlineResponse200 struct for InlineResponse200
 type InlineResponse200 struct {
 	// True means that the influxdb instance has NOT had initial setup; false means that the database has been setup.
-	Allowed *bool `json:"allowed,omitempty"`
+	Allowed *bool `json:"allowed,omitempty" yaml:"allowed,omitempty"`
 }
 
 // NewInlineResponse200 instantiates a new InlineResponse200 object

--- a/api/model_label.gen.go
+++ b/api/model_label.gen.go
@@ -16,11 +16,11 @@ import (
 
 // Label struct for Label
 type Label struct {
-	Id    *string `json:"id,omitempty"`
-	OrgID *string `json:"orgID,omitempty"`
-	Name  *string `json:"name,omitempty"`
+	Id    *string `json:"id,omitempty" yaml:"id,omitempty"`
+	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Name  *string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
-	Properties *map[string]string `json:"properties,omitempty"`
+	Properties *map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
 }
 
 // NewLabel instantiates a new Label object

--- a/api/model_legacy_authorization_post_request.gen.go
+++ b/api/model_legacy_authorization_post_request.gen.go
@@ -17,17 +17,17 @@ import (
 // LegacyAuthorizationPostRequest struct for LegacyAuthorizationPostRequest
 type LegacyAuthorizationPostRequest struct {
 	// If inactive the token is inactive and requests using the token will be rejected.
-	Status *string `json:"status,omitempty"`
+	Status *string `json:"status,omitempty" yaml:"status,omitempty"`
 	// A description of the token.
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	// ID of org that authorization is scoped to.
-	OrgID string `json:"orgID"`
+	OrgID string `json:"orgID" yaml:"orgID"`
 	// ID of user that authorization is scoped to.
-	UserID *string `json:"userID,omitempty"`
+	UserID *string `json:"userID,omitempty" yaml:"userID,omitempty"`
 	// Token (name) of the authorization
-	Token *string `json:"token,omitempty"`
+	Token *string `json:"token,omitempty" yaml:"token,omitempty"`
 	// List of permissions for an auth.  An auth must have at least one Permission.
-	Permissions []Permission `json:"permissions"`
+	Permissions []Permission `json:"permissions" yaml:"permissions"`
 }
 
 // NewLegacyAuthorizationPostRequest instantiates a new LegacyAuthorizationPostRequest object

--- a/api/model_legacy_authorization_post_request_all_of.gen.go
+++ b/api/model_legacy_authorization_post_request_all_of.gen.go
@@ -17,13 +17,13 @@ import (
 // LegacyAuthorizationPostRequestAllOf struct for LegacyAuthorizationPostRequestAllOf
 type LegacyAuthorizationPostRequestAllOf struct {
 	// ID of org that authorization is scoped to.
-	OrgID *string `json:"orgID,omitempty"`
+	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	// ID of user that authorization is scoped to.
-	UserID *string `json:"userID,omitempty"`
+	UserID *string `json:"userID,omitempty" yaml:"userID,omitempty"`
 	// Token (name) of the authorization
-	Token *string `json:"token,omitempty"`
+	Token *string `json:"token,omitempty" yaml:"token,omitempty"`
 	// List of permissions for an auth.  An auth must have at least one Permission.
-	Permissions *[]Permission `json:"permissions,omitempty"`
+	Permissions *[]Permission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
 }
 
 // NewLegacyAuthorizationPostRequestAllOf instantiates a new LegacyAuthorizationPostRequestAllOf object

--- a/api/model_line_protocol_error.gen.go
+++ b/api/model_line_protocol_error.gen.go
@@ -16,15 +16,15 @@ import (
 
 // LineProtocolError struct for LineProtocolError
 type LineProtocolError struct {
-	Code LineProtocolErrorCode `json:"code"`
+	Code LineProtocolErrorCode `json:"code" yaml:"code"`
 	// Message is a human-readable message.
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 	// Op describes the logical code operation during error. Useful for debugging.
-	Op string `json:"op"`
+	Op string `json:"op" yaml:"op"`
 	// Err is a stack of errors that occurred during processing of the request. Useful for debugging.
-	Err string `json:"err"`
+	Err string `json:"err" yaml:"err"`
 	// First line within sent body containing malformed data
-	Line *int32 `json:"line,omitempty"`
+	Line *int32 `json:"line,omitempty" yaml:"line,omitempty"`
 }
 
 // NewLineProtocolError instantiates a new LineProtocolError object

--- a/api/model_line_protocol_length_error.gen.go
+++ b/api/model_line_protocol_length_error.gen.go
@@ -16,11 +16,11 @@ import (
 
 // LineProtocolLengthError struct for LineProtocolLengthError
 type LineProtocolLengthError struct {
-	Code LineProtocolLengthErrorCode `json:"code"`
+	Code LineProtocolLengthErrorCode `json:"code" yaml:"code"`
 	// Message is a human-readable message.
-	Message string `json:"message"`
+	Message string `json:"message" yaml:"message"`
 	// Max length in bytes for a body of line-protocol.
-	MaxLength int32 `json:"maxLength"`
+	MaxLength int32 `json:"maxLength" yaml:"maxLength"`
 }
 
 // NewLineProtocolLengthError instantiates a new LineProtocolLengthError object

--- a/api/model_links.gen.go
+++ b/api/model_links.gen.go
@@ -17,11 +17,11 @@ import (
 // Links struct for Links
 type Links struct {
 	// URI of resource.
-	Next *string `json:"next,omitempty"`
+	Next *string `json:"next,omitempty" yaml:"next,omitempty"`
 	// URI of resource.
-	Self string `json:"self"`
+	Self string `json:"self" yaml:"self"`
 	// URI of resource.
-	Prev *string `json:"prev,omitempty"`
+	Prev *string `json:"prev,omitempty" yaml:"prev,omitempty"`
 }
 
 // NewLinks instantiates a new Links object

--- a/api/model_log_event.gen.go
+++ b/api/model_log_event.gen.go
@@ -18,11 +18,11 @@ import (
 // LogEvent struct for LogEvent
 type LogEvent struct {
 	// Time event occurred, RFC3339Nano.
-	Time *time.Time `json:"time,omitempty"`
+	Time *time.Time `json:"time,omitempty" yaml:"time,omitempty"`
 	// A description of the event that occurred.
-	Message *string `json:"message,omitempty"`
+	Message *string `json:"message,omitempty" yaml:"message,omitempty"`
 	// the ID of the task that logged
-	RunID *string `json:"runID,omitempty"`
+	RunID *string `json:"runID,omitempty" yaml:"runID,omitempty"`
 }
 
 // NewLogEvent instantiates a new LogEvent object

--- a/api/model_logs.gen.go
+++ b/api/model_logs.gen.go
@@ -16,7 +16,7 @@ import (
 
 // Logs struct for Logs
 type Logs struct {
-	Events *[]LogEvent `json:"events,omitempty"`
+	Events *[]LogEvent `json:"events,omitempty" yaml:"events,omitempty"`
 }
 
 // NewLogs instantiates a new Logs object

--- a/api/model_measurement_schema.gen.go
+++ b/api/model_measurement_schema.gen.go
@@ -17,12 +17,12 @@ import (
 
 // MeasurementSchema The schema definition for a single measurement
 type MeasurementSchema struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
+	Id   string `json:"id" yaml:"id"`
+	Name string `json:"name" yaml:"name"`
 	// An ordered collection of column definitions
-	Columns   []MeasurementSchemaColumn `json:"columns"`
-	CreatedAt time.Time                 `json:"createdAt"`
-	UpdatedAt time.Time                 `json:"updatedAt"`
+	Columns   []MeasurementSchemaColumn `json:"columns" yaml:"columns"`
+	CreatedAt time.Time                 `json:"createdAt" yaml:"createdAt"`
+	UpdatedAt time.Time                 `json:"updatedAt" yaml:"updatedAt"`
 }
 
 // NewMeasurementSchema instantiates a new MeasurementSchema object

--- a/api/model_measurement_schema_column.gen.go
+++ b/api/model_measurement_schema_column.gen.go
@@ -16,9 +16,9 @@ import (
 
 // MeasurementSchemaColumn Definition of a measurement column
 type MeasurementSchemaColumn struct {
-	Name     string             `json:"name"`
-	Type     ColumnSemanticType `json:"type"`
-	DataType *ColumnDataType    `json:"dataType,omitempty"`
+	Name     string             `json:"name" yaml:"name"`
+	Type     ColumnSemanticType `json:"type" yaml:"type"`
+	DataType *ColumnDataType    `json:"dataType,omitempty" yaml:"dataType,omitempty"`
 }
 
 // NewMeasurementSchemaColumn instantiates a new MeasurementSchemaColumn object

--- a/api/model_measurement_schema_create_request.gen.go
+++ b/api/model_measurement_schema_create_request.gen.go
@@ -16,9 +16,9 @@ import (
 
 // MeasurementSchemaCreateRequest Create a new measurement schema
 type MeasurementSchemaCreateRequest struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// An ordered collection of column definitions
-	Columns []MeasurementSchemaColumn `json:"columns"`
+	Columns []MeasurementSchemaColumn `json:"columns" yaml:"columns"`
 }
 
 // NewMeasurementSchemaCreateRequest instantiates a new MeasurementSchemaCreateRequest object

--- a/api/model_measurement_schema_list.gen.go
+++ b/api/model_measurement_schema_list.gen.go
@@ -16,7 +16,7 @@ import (
 
 // MeasurementSchemaList A list of measurement schemas returning summary information
 type MeasurementSchemaList struct {
-	MeasurementSchemas []MeasurementSchema `json:"measurementSchemas"`
+	MeasurementSchemas []MeasurementSchema `json:"measurementSchemas" yaml:"measurementSchemas"`
 }
 
 // NewMeasurementSchemaList instantiates a new MeasurementSchemaList object

--- a/api/model_measurement_schema_update_request.gen.go
+++ b/api/model_measurement_schema_update_request.gen.go
@@ -17,7 +17,7 @@ import (
 // MeasurementSchemaUpdateRequest Update an existing measurement schema
 type MeasurementSchemaUpdateRequest struct {
 	// An ordered collection of column definitions
-	Columns []MeasurementSchemaColumn `json:"columns"`
+	Columns []MeasurementSchemaColumn `json:"columns" yaml:"columns"`
 }
 
 // NewMeasurementSchemaUpdateRequest instantiates a new MeasurementSchemaUpdateRequest object

--- a/api/model_metadata_backup.gen.go
+++ b/api/model_metadata_backup.gen.go
@@ -17,9 +17,9 @@ import (
 
 // MetadataBackup struct for MetadataBackup
 type MetadataBackup struct {
-	Kv      *os.File                 `json:"kv"`
-	Sql     *os.File                 `json:"sql"`
-	Buckets []BucketMetadataManifest `json:"buckets"`
+	Kv      *os.File                 `json:"kv" yaml:"kv"`
+	Sql     *os.File                 `json:"sql" yaml:"sql"`
+	Buckets []BucketMetadataManifest `json:"buckets" yaml:"buckets"`
 }
 
 // NewMetadataBackup instantiates a new MetadataBackup object

--- a/api/model_onboarding_request.gen.go
+++ b/api/model_onboarding_request.gen.go
@@ -16,15 +16,15 @@ import (
 
 // OnboardingRequest struct for OnboardingRequest
 type OnboardingRequest struct {
-	Username               string  `json:"username"`
-	Password               *string `json:"password,omitempty"`
-	Org                    string  `json:"org"`
-	Bucket                 string  `json:"bucket"`
-	RetentionPeriodSeconds *int64  `json:"retentionPeriodSeconds,omitempty"`
+	Username               string  `json:"username" yaml:"username"`
+	Password               *string `json:"password,omitempty" yaml:"password,omitempty"`
+	Org                    string  `json:"org" yaml:"org"`
+	Bucket                 string  `json:"bucket" yaml:"bucket"`
+	RetentionPeriodSeconds *int64  `json:"retentionPeriodSeconds,omitempty" yaml:"retentionPeriodSeconds,omitempty"`
 	// Retention period *in nanoseconds* for the new bucket. This key's name has been misleading since OSS 2.0 GA, please transition to use `retentionPeriodSeconds`
-	RetentionPeriodHrs *int32 `json:"retentionPeriodHrs,omitempty"`
+	RetentionPeriodHrs *int32 `json:"retentionPeriodHrs,omitempty" yaml:"retentionPeriodHrs,omitempty"`
 	// Authentication token to set on the initial user. If not specified, the server will generate a token.
-	Token *string `json:"token,omitempty"`
+	Token *string `json:"token,omitempty" yaml:"token,omitempty"`
 }
 
 // NewOnboardingRequest instantiates a new OnboardingRequest object

--- a/api/model_onboarding_response.gen.go
+++ b/api/model_onboarding_response.gen.go
@@ -16,10 +16,10 @@ import (
 
 // OnboardingResponse struct for OnboardingResponse
 type OnboardingResponse struct {
-	User   *UserResponse  `json:"user,omitempty"`
-	Org    *Organization  `json:"org,omitempty"`
-	Bucket *Bucket        `json:"bucket,omitempty"`
-	Auth   *Authorization `json:"auth,omitempty"`
+	User   *UserResponse  `json:"user,omitempty" yaml:"user,omitempty"`
+	Org    *Organization  `json:"org,omitempty" yaml:"org,omitempty"`
+	Bucket *Bucket        `json:"bucket,omitempty" yaml:"bucket,omitempty"`
+	Auth   *Authorization `json:"auth,omitempty" yaml:"auth,omitempty"`
 }
 
 // NewOnboardingResponse instantiates a new OnboardingResponse object

--- a/api/model_organization.gen.go
+++ b/api/model_organization.gen.go
@@ -17,14 +17,14 @@ import (
 
 // Organization struct for Organization
 type Organization struct {
-	Links       *OrganizationLinks `json:"links,omitempty"`
-	Id          *string            `json:"id,omitempty"`
-	Name        string             `json:"name"`
-	Description *string            `json:"description,omitempty"`
-	CreatedAt   *time.Time         `json:"createdAt,omitempty"`
-	UpdatedAt   *time.Time         `json:"updatedAt,omitempty"`
+	Links       *OrganizationLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	Id          *string            `json:"id,omitempty" yaml:"id,omitempty"`
+	Name        string             `json:"name" yaml:"name"`
+	Description *string            `json:"description,omitempty" yaml:"description,omitempty"`
+	CreatedAt   *time.Time         `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt   *time.Time         `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 	// If inactive the organization is inactive.
-	Status *string `json:"status,omitempty"`
+	Status *string `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // NewOrganization instantiates a new Organization object

--- a/api/model_organization_links.gen.go
+++ b/api/model_organization_links.gen.go
@@ -17,21 +17,21 @@ import (
 // OrganizationLinks struct for OrganizationLinks
 type OrganizationLinks struct {
 	// URI of resource.
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 	// URI of resource.
-	Members *string `json:"members,omitempty"`
+	Members *string `json:"members,omitempty" yaml:"members,omitempty"`
 	// URI of resource.
-	Owners *string `json:"owners,omitempty"`
+	Owners *string `json:"owners,omitempty" yaml:"owners,omitempty"`
 	// URI of resource.
-	Labels *string `json:"labels,omitempty"`
+	Labels *string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// URI of resource.
-	Secrets *string `json:"secrets,omitempty"`
+	Secrets *string `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 	// URI of resource.
-	Buckets *string `json:"buckets,omitempty"`
+	Buckets *string `json:"buckets,omitempty" yaml:"buckets,omitempty"`
 	// URI of resource.
-	Tasks *string `json:"tasks,omitempty"`
+	Tasks *string `json:"tasks,omitempty" yaml:"tasks,omitempty"`
 	// URI of resource.
-	Dashboards *string `json:"dashboards,omitempty"`
+	Dashboards *string `json:"dashboards,omitempty" yaml:"dashboards,omitempty"`
 }
 
 // NewOrganizationLinks instantiates a new OrganizationLinks object

--- a/api/model_organizations.gen.go
+++ b/api/model_organizations.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Organizations struct for Organizations
 type Organizations struct {
-	Links *Links          `json:"links,omitempty"`
-	Orgs  *[]Organization `json:"orgs,omitempty"`
+	Links *Links          `json:"links,omitempty" yaml:"links,omitempty"`
+	Orgs  *[]Organization `json:"orgs,omitempty" yaml:"orgs,omitempty"`
 }
 
 // NewOrganizations instantiates a new Organizations object

--- a/api/model_password_reset_body.gen.go
+++ b/api/model_password_reset_body.gen.go
@@ -16,7 +16,7 @@ import (
 
 // PasswordResetBody struct for PasswordResetBody
 type PasswordResetBody struct {
-	Password string `json:"password"`
+	Password string `json:"password" yaml:"password"`
 }
 
 // NewPasswordResetBody instantiates a new PasswordResetBody object

--- a/api/model_patch_bucket_request.gen.go
+++ b/api/model_patch_bucket_request.gen.go
@@ -16,10 +16,10 @@ import (
 
 // PatchBucketRequest Updates to an existing bucket resource.
 type PatchBucketRequest struct {
-	Name        *string `json:"name,omitempty"`
-	Description *string `json:"description,omitempty"`
+	Name        *string `json:"name,omitempty" yaml:"name,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Updates to rules to expire or retain data. No rules means no updates.
-	RetentionRules *[]PatchRetentionRule `json:"retentionRules,omitempty"`
+	RetentionRules *[]PatchRetentionRule `json:"retentionRules,omitempty" yaml:"retentionRules,omitempty"`
 }
 
 // NewPatchBucketRequest instantiates a new PatchBucketRequest object

--- a/api/model_patch_organization_request.gen.go
+++ b/api/model_patch_organization_request.gen.go
@@ -17,9 +17,9 @@ import (
 // PatchOrganizationRequest struct for PatchOrganizationRequest
 type PatchOrganizationRequest struct {
 	// New name to set on the organization
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 	// New description to set on the organization
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewPatchOrganizationRequest instantiates a new PatchOrganizationRequest object

--- a/api/model_patch_retention_rule.gen.go
+++ b/api/model_patch_retention_rule.gen.go
@@ -16,11 +16,11 @@ import (
 
 // PatchRetentionRule Updates to a rule to expire or retain data.
 type PatchRetentionRule struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 	// Duration in seconds for how long data will be kept in the database. 0 means infinite.
-	EverySeconds *int64 `json:"everySeconds,omitempty"`
+	EverySeconds *int64 `json:"everySeconds,omitempty" yaml:"everySeconds,omitempty"`
 	// Shard duration measured in seconds.
-	ShardGroupDurationSeconds *int64 `json:"shardGroupDurationSeconds,omitempty"`
+	ShardGroupDurationSeconds *int64 `json:"shardGroupDurationSeconds,omitempty" yaml:"shardGroupDurationSeconds,omitempty"`
 }
 
 // NewPatchRetentionRule instantiates a new PatchRetentionRule object

--- a/api/model_permission.gen.go
+++ b/api/model_permission.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Permission struct for Permission
 type Permission struct {
-	Action   string             `json:"action"`
-	Resource PermissionResource `json:"resource"`
+	Action   string             `json:"action" yaml:"action"`
+	Resource PermissionResource `json:"resource" yaml:"resource"`
 }
 
 // NewPermission instantiates a new Permission object

--- a/api/model_permission_resource.gen.go
+++ b/api/model_permission_resource.gen.go
@@ -16,15 +16,15 @@ import (
 
 // PermissionResource struct for PermissionResource
 type PermissionResource struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 	// If ID is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type.
-	Id *string `json:"id,omitempty"`
+	Id *string `json:"id,omitempty" yaml:"id,omitempty"`
 	// Optional name of the resource if the resource has a name field.
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 	// If orgID is set that is a permission for all resources owned my that org. if it is not set it is a permission for all resources of that resource type.
-	OrgID *string `json:"orgID,omitempty"`
+	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	// Optional name of the organization of the organization with orgID.
-	Org *string `json:"org,omitempty"`
+	Org *string `json:"org,omitempty" yaml:"org,omitempty"`
 }
 
 // NewPermissionResource instantiates a new PermissionResource object

--- a/api/model_post_bucket_request.gen.go
+++ b/api/model_post_bucket_request.gen.go
@@ -16,13 +16,13 @@ import (
 
 // PostBucketRequest struct for PostBucketRequest
 type PostBucketRequest struct {
-	OrgID       string  `json:"orgID"`
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
-	Rp          *string `json:"rp,omitempty"`
+	OrgID       string  `json:"orgID" yaml:"orgID"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Rp          *string `json:"rp,omitempty" yaml:"rp,omitempty"`
 	// Rules to expire or retain data.  No rules means data never expires.
-	RetentionRules []RetentionRule `json:"retentionRules"`
-	SchemaType     *SchemaType     `json:"schemaType,omitempty"`
+	RetentionRules []RetentionRule `json:"retentionRules" yaml:"retentionRules"`
+	SchemaType     *SchemaType     `json:"schemaType,omitempty" yaml:"schemaType,omitempty"`
 }
 
 // NewPostBucketRequest instantiates a new PostBucketRequest object

--- a/api/model_post_organization_request.gen.go
+++ b/api/model_post_organization_request.gen.go
@@ -16,8 +16,8 @@ import (
 
 // PostOrganizationRequest struct for PostOrganizationRequest
 type PostOrganizationRequest struct {
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewPostOrganizationRequest instantiates a new PostOrganizationRequest object

--- a/api/model_query.gen.go
+++ b/api/model_query.gen.go
@@ -17,14 +17,14 @@ import (
 
 // Query Query influx using the Flux language
 type Query struct {
-	Extern *Extern `json:"extern,omitempty"`
+	Extern *Extern `json:"extern,omitempty" yaml:"extern,omitempty"`
 	// Query script to execute.
-	Query string `json:"query"`
+	Query string `json:"query" yaml:"query"`
 	// The type of query. Must be \"flux\".
-	Type    *string  `json:"type,omitempty"`
-	Dialect *Dialect `json:"dialect,omitempty"`
+	Type    *string  `json:"type,omitempty" yaml:"type,omitempty"`
+	Dialect *Dialect `json:"dialect,omitempty" yaml:"dialect,omitempty"`
 	// Specifies the time that should be reported as \"now\" in the query. Default is the server's now time.
-	Now *time.Time `json:"now,omitempty"`
+	Now *time.Time `json:"now,omitempty" yaml:"now,omitempty"`
 }
 
 // NewQuery instantiates a new Query object

--- a/api/model_resource_member.gen.go
+++ b/api/model_resource_member.gen.go
@@ -16,13 +16,13 @@ import (
 
 // ResourceMember struct for ResourceMember
 type ResourceMember struct {
-	Id      *string `json:"id,omitempty"`
-	OauthID *string `json:"oauthID,omitempty"`
-	Name    string  `json:"name"`
+	Id      *string `json:"id,omitempty" yaml:"id,omitempty"`
+	OauthID *string `json:"oauthID,omitempty" yaml:"oauthID,omitempty"`
+	Name    string  `json:"name" yaml:"name"`
 	// If inactive the user is inactive.
-	Status *string            `json:"status,omitempty"`
-	Links  *UserResponseLinks `json:"links,omitempty"`
-	Role   *string            `json:"role,omitempty"`
+	Status *string            `json:"status,omitempty" yaml:"status,omitempty"`
+	Links  *UserResponseLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	Role   *string            `json:"role,omitempty" yaml:"role,omitempty"`
 }
 
 // NewResourceMember instantiates a new ResourceMember object

--- a/api/model_resource_member_all_of.gen.go
+++ b/api/model_resource_member_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // ResourceMemberAllOf struct for ResourceMemberAllOf
 type ResourceMemberAllOf struct {
-	Role *string `json:"role,omitempty"`
+	Role *string `json:"role,omitempty" yaml:"role,omitempty"`
 }
 
 // NewResourceMemberAllOf instantiates a new ResourceMemberAllOf object

--- a/api/model_resource_members.gen.go
+++ b/api/model_resource_members.gen.go
@@ -16,8 +16,8 @@ import (
 
 // ResourceMembers struct for ResourceMembers
 type ResourceMembers struct {
-	Links *UsersLinks       `json:"links,omitempty"`
-	Users *[]ResourceMember `json:"users,omitempty"`
+	Links *UsersLinks       `json:"links,omitempty" yaml:"links,omitempty"`
+	Users *[]ResourceMember `json:"users,omitempty" yaml:"users,omitempty"`
 }
 
 // NewResourceMembers instantiates a new ResourceMembers object

--- a/api/model_restored_bucket_mappings.gen.go
+++ b/api/model_restored_bucket_mappings.gen.go
@@ -17,9 +17,9 @@ import (
 // RestoredBucketMappings struct for RestoredBucketMappings
 type RestoredBucketMappings struct {
 	// New ID of the restored bucket
-	Id            string               `json:"id"`
-	Name          string               `json:"name"`
-	ShardMappings []BucketShardMapping `json:"shardMappings"`
+	Id            string               `json:"id" yaml:"id"`
+	Name          string               `json:"name" yaml:"name"`
+	ShardMappings []BucketShardMapping `json:"shardMappings" yaml:"shardMappings"`
 }
 
 // NewRestoredBucketMappings instantiates a new RestoredBucketMappings object

--- a/api/model_retention_policy_manifest.gen.go
+++ b/api/model_retention_policy_manifest.gen.go
@@ -16,12 +16,12 @@ import (
 
 // RetentionPolicyManifest struct for RetentionPolicyManifest
 type RetentionPolicyManifest struct {
-	Name               string                 `json:"name"`
-	ReplicaN           int32                  `json:"replicaN"`
-	Duration           int64                  `json:"duration"`
-	ShardGroupDuration int64                  `json:"shardGroupDuration"`
-	ShardGroups        []ShardGroupManifest   `json:"shardGroups"`
-	Subscriptions      []SubscriptionManifest `json:"subscriptions"`
+	Name               string                 `json:"name" yaml:"name"`
+	ReplicaN           int32                  `json:"replicaN" yaml:"replicaN"`
+	Duration           int64                  `json:"duration" yaml:"duration"`
+	ShardGroupDuration int64                  `json:"shardGroupDuration" yaml:"shardGroupDuration"`
+	ShardGroups        []ShardGroupManifest   `json:"shardGroups" yaml:"shardGroups"`
+	Subscriptions      []SubscriptionManifest `json:"subscriptions" yaml:"subscriptions"`
 }
 
 // NewRetentionPolicyManifest instantiates a new RetentionPolicyManifest object

--- a/api/model_retention_rule.gen.go
+++ b/api/model_retention_rule.gen.go
@@ -16,11 +16,11 @@ import (
 
 // RetentionRule struct for RetentionRule
 type RetentionRule struct {
-	Type string `json:"type"`
+	Type string `json:"type" yaml:"type"`
 	// Duration in seconds for how long data will be kept in the database. 0 means infinite.
-	EverySeconds int64 `json:"everySeconds"`
+	EverySeconds int64 `json:"everySeconds" yaml:"everySeconds"`
 	// Shard duration measured in seconds.
-	ShardGroupDurationSeconds *int64 `json:"shardGroupDurationSeconds,omitempty"`
+	ShardGroupDurationSeconds *int64 `json:"shardGroupDurationSeconds,omitempty" yaml:"shardGroupDurationSeconds,omitempty"`
 }
 
 // NewRetentionRule instantiates a new RetentionRule object

--- a/api/model_run.gen.go
+++ b/api/model_run.gen.go
@@ -17,20 +17,20 @@ import (
 
 // Run struct for Run
 type Run struct {
-	Id     *string `json:"id,omitempty"`
-	TaskID *string `json:"taskID,omitempty"`
-	Status *string `json:"status,omitempty"`
+	Id     *string `json:"id,omitempty" yaml:"id,omitempty"`
+	TaskID *string `json:"taskID,omitempty" yaml:"taskID,omitempty"`
+	Status *string `json:"status,omitempty" yaml:"status,omitempty"`
 	// Time used for run's \"now\" option, RFC3339.
-	ScheduledFor *time.Time `json:"scheduledFor,omitempty"`
+	ScheduledFor *time.Time `json:"scheduledFor,omitempty" yaml:"scheduledFor,omitempty"`
 	// An array of logs associated with the run.
-	Log *[]LogEvent `json:"log,omitempty"`
+	Log *[]LogEvent `json:"log,omitempty" yaml:"log,omitempty"`
 	// Time run started executing, RFC3339Nano.
-	StartedAt *time.Time `json:"startedAt,omitempty"`
+	StartedAt *time.Time `json:"startedAt,omitempty" yaml:"startedAt,omitempty"`
 	// Time run finished executing, RFC3339Nano.
-	FinishedAt *time.Time `json:"finishedAt,omitempty"`
+	FinishedAt *time.Time `json:"finishedAt,omitempty" yaml:"finishedAt,omitempty"`
 	// Time run was manually requested, RFC3339Nano.
-	RequestedAt *time.Time `json:"requestedAt,omitempty"`
-	Links       *RunLinks  `json:"links,omitempty"`
+	RequestedAt *time.Time `json:"requestedAt,omitempty" yaml:"requestedAt,omitempty"`
+	Links       *RunLinks  `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewRun instantiates a new Run object

--- a/api/model_run_links.gen.go
+++ b/api/model_run_links.gen.go
@@ -16,9 +16,9 @@ import (
 
 // RunLinks struct for RunLinks
 type RunLinks struct {
-	Self  *string `json:"self,omitempty"`
-	Task  *string `json:"task,omitempty"`
-	Retry *string `json:"retry,omitempty"`
+	Self  *string `json:"self,omitempty" yaml:"self,omitempty"`
+	Task  *string `json:"task,omitempty" yaml:"task,omitempty"`
+	Retry *string `json:"retry,omitempty" yaml:"retry,omitempty"`
 }
 
 // NewRunLinks instantiates a new RunLinks object

--- a/api/model_run_manually.gen.go
+++ b/api/model_run_manually.gen.go
@@ -18,7 +18,7 @@ import (
 // RunManually struct for RunManually
 type RunManually struct {
 	// Time used for run's \"now\" option, RFC3339.  Default is the server's now time.
-	ScheduledFor NullableTime `json:"scheduledFor,omitempty"`
+	ScheduledFor NullableTime `json:"scheduledFor,omitempty" yaml:"scheduledFor,omitempty"`
 }
 
 // NewRunManually instantiates a new RunManually object

--- a/api/model_runs.gen.go
+++ b/api/model_runs.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Runs struct for Runs
 type Runs struct {
-	Links *Links `json:"links,omitempty"`
-	Runs  *[]Run `json:"runs,omitempty"`
+	Links *Links `json:"links,omitempty" yaml:"links,omitempty"`
+	Runs  *[]Run `json:"runs,omitempty" yaml:"runs,omitempty"`
 }
 
 // NewRuns instantiates a new Runs object

--- a/api/model_secret_keys.gen.go
+++ b/api/model_secret_keys.gen.go
@@ -16,7 +16,7 @@ import (
 
 // SecretKeys struct for SecretKeys
 type SecretKeys struct {
-	Secrets *[]string `json:"secrets,omitempty"`
+	Secrets *[]string `json:"secrets,omitempty" yaml:"secrets,omitempty"`
 }
 
 // NewSecretKeys instantiates a new SecretKeys object

--- a/api/model_secret_keys_response.gen.go
+++ b/api/model_secret_keys_response.gen.go
@@ -16,8 +16,8 @@ import (
 
 // SecretKeysResponse struct for SecretKeysResponse
 type SecretKeysResponse struct {
-	Secrets *[]string                     `json:"secrets,omitempty"`
-	Links   *SecretKeysResponseAllOfLinks `json:"links,omitempty"`
+	Secrets *[]string                     `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Links   *SecretKeysResponseAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewSecretKeysResponse instantiates a new SecretKeysResponse object

--- a/api/model_secret_keys_response_all_of.gen.go
+++ b/api/model_secret_keys_response_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // SecretKeysResponseAllOf struct for SecretKeysResponseAllOf
 type SecretKeysResponseAllOf struct {
-	Links *SecretKeysResponseAllOfLinks `json:"links,omitempty"`
+	Links *SecretKeysResponseAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewSecretKeysResponseAllOf instantiates a new SecretKeysResponseAllOf object

--- a/api/model_secret_keys_response_all_of_links.gen.go
+++ b/api/model_secret_keys_response_all_of_links.gen.go
@@ -16,8 +16,8 @@ import (
 
 // SecretKeysResponseAllOfLinks struct for SecretKeysResponseAllOfLinks
 type SecretKeysResponseAllOfLinks struct {
-	Self *string `json:"self,omitempty"`
-	Org  *string `json:"org,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
+	Org  *string `json:"org,omitempty" yaml:"org,omitempty"`
 }
 
 // NewSecretKeysResponseAllOfLinks instantiates a new SecretKeysResponseAllOfLinks object

--- a/api/model_shard_group_manifest.gen.go
+++ b/api/model_shard_group_manifest.gen.go
@@ -17,12 +17,12 @@ import (
 
 // ShardGroupManifest struct for ShardGroupManifest
 type ShardGroupManifest struct {
-	Id          int64           `json:"id"`
-	StartTime   time.Time       `json:"startTime"`
-	EndTime     time.Time       `json:"endTime"`
-	DeletedAt   *time.Time      `json:"deletedAt,omitempty"`
-	TruncatedAt *time.Time      `json:"truncatedAt,omitempty"`
-	Shards      []ShardManifest `json:"shards"`
+	Id          int64           `json:"id" yaml:"id"`
+	StartTime   time.Time       `json:"startTime" yaml:"startTime"`
+	EndTime     time.Time       `json:"endTime" yaml:"endTime"`
+	DeletedAt   *time.Time      `json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
+	TruncatedAt *time.Time      `json:"truncatedAt,omitempty" yaml:"truncatedAt,omitempty"`
+	Shards      []ShardManifest `json:"shards" yaml:"shards"`
 }
 
 // NewShardGroupManifest instantiates a new ShardGroupManifest object

--- a/api/model_shard_manifest.gen.go
+++ b/api/model_shard_manifest.gen.go
@@ -16,8 +16,8 @@ import (
 
 // ShardManifest struct for ShardManifest
 type ShardManifest struct {
-	Id          int64        `json:"id"`
-	ShardOwners []ShardOwner `json:"shardOwners"`
+	Id          int64        `json:"id" yaml:"id"`
+	ShardOwners []ShardOwner `json:"shardOwners" yaml:"shardOwners"`
 }
 
 // NewShardManifest instantiates a new ShardManifest object

--- a/api/model_shard_owner.gen.go
+++ b/api/model_shard_owner.gen.go
@@ -17,7 +17,7 @@ import (
 // ShardOwner struct for ShardOwner
 type ShardOwner struct {
 	// ID of the node that owns a shard.
-	NodeID int64 `json:"nodeID"`
+	NodeID int64 `json:"nodeID" yaml:"nodeID"`
 }
 
 // NewShardOwner instantiates a new ShardOwner object

--- a/api/model_subscription_manifest.gen.go
+++ b/api/model_subscription_manifest.gen.go
@@ -16,9 +16,9 @@ import (
 
 // SubscriptionManifest struct for SubscriptionManifest
 type SubscriptionManifest struct {
-	Name         string   `json:"name"`
-	Mode         string   `json:"mode"`
-	Destinations []string `json:"destinations"`
+	Name         string   `json:"name" yaml:"name"`
+	Mode         string   `json:"mode" yaml:"mode"`
+	Destinations []string `json:"destinations" yaml:"destinations"`
 }
 
 // NewSubscriptionManifest instantiates a new SubscriptionManifest object

--- a/api/model_task.gen.go
+++ b/api/model_task.gen.go
@@ -17,36 +17,36 @@ import (
 
 // Task struct for Task
 type Task struct {
-	Id string `json:"id"`
+	Id string `json:"id" yaml:"id"`
 	// The type of task, this can be used for filtering tasks on list actions.
-	Type *string `json:"type,omitempty"`
+	Type *string `json:"type,omitempty" yaml:"type,omitempty"`
 	// The ID of the organization that owns this Task.
-	OrgID string `json:"orgID"`
+	OrgID string `json:"orgID" yaml:"orgID"`
 	// The name of the organization that owns this Task.
-	Org *string `json:"org,omitempty"`
+	Org *string `json:"org,omitempty" yaml:"org,omitempty"`
 	// The name of the task.
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 	// An optional description of the task.
-	Description *string         `json:"description,omitempty"`
-	Status      *TaskStatusType `json:"status,omitempty"`
-	Labels      *[]Label        `json:"labels,omitempty"`
+	Description *string         `json:"description,omitempty" yaml:"description,omitempty"`
+	Status      *TaskStatusType `json:"status,omitempty" yaml:"status,omitempty"`
+	Labels      *[]Label        `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// The ID of the authorization used when this task communicates with the query engine.
-	AuthorizationID *string `json:"authorizationID,omitempty"`
+	AuthorizationID *string `json:"authorizationID,omitempty" yaml:"authorizationID,omitempty"`
 	// The Flux script to run for this task.
-	Flux string `json:"flux"`
+	Flux string `json:"flux" yaml:"flux"`
 	// A simple task repetition schedule; parsed from Flux.
-	Every *string `json:"every,omitempty"`
+	Every *string `json:"every,omitempty" yaml:"every,omitempty"`
 	// A task repetition schedule in the form '* * * * * *'; parsed from Flux.
-	Cron *string `json:"cron,omitempty"`
+	Cron *string `json:"cron,omitempty" yaml:"cron,omitempty"`
 	// Duration to delay after the schedule, before executing the task; parsed from flux, if set to zero it will remove this option and use 0 as the default.
-	Offset *string `json:"offset,omitempty"`
+	Offset *string `json:"offset,omitempty" yaml:"offset,omitempty"`
 	// Timestamp of latest scheduled, completed run, RFC3339.
-	LatestCompleted *time.Time `json:"latestCompleted,omitempty"`
-	LastRunStatus   *string    `json:"lastRunStatus,omitempty"`
-	LastRunError    *string    `json:"lastRunError,omitempty"`
-	CreatedAt       *time.Time `json:"createdAt,omitempty"`
-	UpdatedAt       *time.Time `json:"updatedAt,omitempty"`
-	Links           *TaskLinks `json:"links,omitempty"`
+	LatestCompleted *time.Time `json:"latestCompleted,omitempty" yaml:"latestCompleted,omitempty"`
+	LastRunStatus   *string    `json:"lastRunStatus,omitempty" yaml:"lastRunStatus,omitempty"`
+	LastRunError    *string    `json:"lastRunError,omitempty" yaml:"lastRunError,omitempty"`
+	CreatedAt       *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt       *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+	Links           *TaskLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewTask instantiates a new Task object

--- a/api/model_task_create_request.gen.go
+++ b/api/model_task_create_request.gen.go
@@ -17,14 +17,14 @@ import (
 // TaskCreateRequest struct for TaskCreateRequest
 type TaskCreateRequest struct {
 	// The ID of the organization that owns this Task.
-	OrgID *string `json:"orgID,omitempty"`
+	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	// The name of the organization that owns this Task.
-	Org    *string         `json:"org,omitempty"`
-	Status *TaskStatusType `json:"status,omitempty"`
+	Org    *string         `json:"org,omitempty" yaml:"org,omitempty"`
+	Status *TaskStatusType `json:"status,omitempty" yaml:"status,omitempty"`
 	// The Flux script to run for this task.
-	Flux string `json:"flux"`
+	Flux string `json:"flux" yaml:"flux"`
 	// An optional description of the task.
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTaskCreateRequest instantiates a new TaskCreateRequest object

--- a/api/model_task_links.gen.go
+++ b/api/model_task_links.gen.go
@@ -17,17 +17,17 @@ import (
 // TaskLinks struct for TaskLinks
 type TaskLinks struct {
 	// URI of resource.
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 	// URI of resource.
-	Owners *string `json:"owners,omitempty"`
+	Owners *string `json:"owners,omitempty" yaml:"owners,omitempty"`
 	// URI of resource.
-	Members *string `json:"members,omitempty"`
+	Members *string `json:"members,omitempty" yaml:"members,omitempty"`
 	// URI of resource.
-	Runs *string `json:"runs,omitempty"`
+	Runs *string `json:"runs,omitempty" yaml:"runs,omitempty"`
 	// URI of resource.
-	Logs *string `json:"logs,omitempty"`
+	Logs *string `json:"logs,omitempty" yaml:"logs,omitempty"`
 	// URI of resource.
-	Labels *string `json:"labels,omitempty"`
+	Labels *string `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // NewTaskLinks instantiates a new TaskLinks object

--- a/api/model_task_update_request.gen.go
+++ b/api/model_task_update_request.gen.go
@@ -16,19 +16,19 @@ import (
 
 // TaskUpdateRequest struct for TaskUpdateRequest
 type TaskUpdateRequest struct {
-	Status *TaskStatusType `json:"status,omitempty"`
+	Status *TaskStatusType `json:"status,omitempty" yaml:"status,omitempty"`
 	// The Flux script to run for this task.
-	Flux *string `json:"flux,omitempty"`
+	Flux *string `json:"flux,omitempty" yaml:"flux,omitempty"`
 	// Override the 'name' option in the flux script.
-	Name *string `json:"name,omitempty"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 	// Override the 'every' option in the flux script.
-	Every *string `json:"every,omitempty"`
+	Every *string `json:"every,omitempty" yaml:"every,omitempty"`
 	// Override the 'cron' option in the flux script.
-	Cron *string `json:"cron,omitempty"`
+	Cron *string `json:"cron,omitempty" yaml:"cron,omitempty"`
 	// Override the 'offset' option in the flux script.
-	Offset *string `json:"offset,omitempty"`
+	Offset *string `json:"offset,omitempty" yaml:"offset,omitempty"`
 	// An optional description of the task.
-	Description *string `json:"description,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTaskUpdateRequest instantiates a new TaskUpdateRequest object

--- a/api/model_tasks.gen.go
+++ b/api/model_tasks.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Tasks struct for Tasks
 type Tasks struct {
-	Links *Links  `json:"links,omitempty"`
-	Tasks *[]Task `json:"tasks,omitempty"`
+	Links *Links  `json:"links,omitempty" yaml:"links,omitempty"`
+	Tasks *[]Task `json:"tasks,omitempty" yaml:"tasks,omitempty"`
 }
 
 // NewTasks instantiates a new Tasks object

--- a/api/model_telegraf.gen.go
+++ b/api/model_telegraf.gen.go
@@ -16,14 +16,14 @@ import (
 
 // Telegraf struct for Telegraf
 type Telegraf struct {
-	Name        *string                  `json:"name,omitempty"`
-	Description *string                  `json:"description,omitempty"`
-	Metadata    *TelegrafRequestMetadata `json:"metadata,omitempty"`
-	Config      *string                  `json:"config,omitempty"`
-	OrgID       *string                  `json:"orgID,omitempty"`
-	Id          *string                  `json:"id,omitempty"`
-	Links       *TelegrafAllOfLinks      `json:"links,omitempty"`
-	Labels      *[]Label                 `json:"labels,omitempty"`
+	Name        *string                  `json:"name,omitempty" yaml:"name,omitempty"`
+	Description *string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	Metadata    *TelegrafRequestMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Config      *string                  `json:"config,omitempty" yaml:"config,omitempty"`
+	OrgID       *string                  `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Id          *string                  `json:"id,omitempty" yaml:"id,omitempty"`
+	Links       *TelegrafAllOfLinks      `json:"links,omitempty" yaml:"links,omitempty"`
+	Labels      *[]Label                 `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // NewTelegraf instantiates a new Telegraf object

--- a/api/model_telegraf_all_of.gen.go
+++ b/api/model_telegraf_all_of.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TelegrafAllOf struct for TelegrafAllOf
 type TelegrafAllOf struct {
-	Id     *string             `json:"id,omitempty"`
-	Links  *TelegrafAllOfLinks `json:"links,omitempty"`
-	Labels *[]Label            `json:"labels,omitempty"`
+	Id     *string             `json:"id,omitempty" yaml:"id,omitempty"`
+	Links  *TelegrafAllOfLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	Labels *[]Label            `json:"labels,omitempty" yaml:"labels,omitempty"`
 }
 
 // NewTelegrafAllOf instantiates a new TelegrafAllOf object

--- a/api/model_telegraf_all_of_links.gen.go
+++ b/api/model_telegraf_all_of_links.gen.go
@@ -17,13 +17,13 @@ import (
 // TelegrafAllOfLinks struct for TelegrafAllOfLinks
 type TelegrafAllOfLinks struct {
 	// URI of resource.
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 	// URI of resource.
-	Labels *string `json:"labels,omitempty"`
+	Labels *string `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// URI of resource.
-	Members *string `json:"members,omitempty"`
+	Members *string `json:"members,omitempty" yaml:"members,omitempty"`
 	// URI of resource.
-	Owners *string `json:"owners,omitempty"`
+	Owners *string `json:"owners,omitempty" yaml:"owners,omitempty"`
 }
 
 // NewTelegrafAllOfLinks instantiates a new TelegrafAllOfLinks object

--- a/api/model_telegraf_request.gen.go
+++ b/api/model_telegraf_request.gen.go
@@ -16,11 +16,11 @@ import (
 
 // TelegrafRequest struct for TelegrafRequest
 type TelegrafRequest struct {
-	Name        *string                  `json:"name,omitempty"`
-	Description *string                  `json:"description,omitempty"`
-	Metadata    *TelegrafRequestMetadata `json:"metadata,omitempty"`
-	Config      *string                  `json:"config,omitempty"`
-	OrgID       *string                  `json:"orgID,omitempty"`
+	Name        *string                  `json:"name,omitempty" yaml:"name,omitempty"`
+	Description *string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	Metadata    *TelegrafRequestMetadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Config      *string                  `json:"config,omitempty" yaml:"config,omitempty"`
+	OrgID       *string                  `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 }
 
 // NewTelegrafRequest instantiates a new TelegrafRequest object

--- a/api/model_telegraf_request_metadata.gen.go
+++ b/api/model_telegraf_request_metadata.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TelegrafRequestMetadata struct for TelegrafRequestMetadata
 type TelegrafRequestMetadata struct {
-	Buckets *[]string `json:"buckets,omitempty"`
+	Buckets *[]string `json:"buckets,omitempty" yaml:"buckets,omitempty"`
 }
 
 // NewTelegrafRequestMetadata instantiates a new TelegrafRequestMetadata object

--- a/api/model_telegrafs.gen.go
+++ b/api/model_telegrafs.gen.go
@@ -16,7 +16,7 @@ import (
 
 // Telegrafs struct for Telegrafs
 type Telegrafs struct {
-	Configurations *[]Telegraf `json:"configurations,omitempty"`
+	Configurations *[]Telegraf `json:"configurations,omitempty" yaml:"configurations,omitempty"`
 }
 
 // NewTelegrafs instantiates a new Telegrafs object

--- a/api/model_template_apply.gen.go
+++ b/api/model_template_apply.gen.go
@@ -16,15 +16,15 @@ import (
 
 // TemplateApply struct for TemplateApply
 type TemplateApply struct {
-	DryRun    bool                               `json:"dryRun"`
-	OrgID     string                             `json:"orgID"`
-	StackID   *string                            `json:"stackID,omitempty"`
-	Template  *TemplateApplyTemplate             `json:"template,omitempty"`
-	Templates []TemplateApplyTemplate            `json:"templates"`
-	EnvRefs   *map[string]map[string]interface{} `json:"envRefs,omitempty"`
-	Secrets   *map[string]string                 `json:"secrets,omitempty"`
-	Remotes   []TemplateApplyRemoteRef           `json:"remotes"`
-	Actions   []TemplateApplyAction              `json:"actions"`
+	DryRun    bool                               `json:"dryRun" yaml:"dryRun"`
+	OrgID     string                             `json:"orgID" yaml:"orgID"`
+	StackID   *string                            `json:"stackID,omitempty" yaml:"stackID,omitempty"`
+	Template  *TemplateApplyTemplate             `json:"template,omitempty" yaml:"template,omitempty"`
+	Templates []TemplateApplyTemplate            `json:"templates" yaml:"templates"`
+	EnvRefs   *map[string]map[string]interface{} `json:"envRefs,omitempty" yaml:"envRefs,omitempty"`
+	Secrets   *map[string]string                 `json:"secrets,omitempty" yaml:"secrets,omitempty"`
+	Remotes   []TemplateApplyRemoteRef           `json:"remotes" yaml:"remotes"`
+	Actions   []TemplateApplyAction              `json:"actions" yaml:"actions"`
 }
 
 // NewTemplateApply instantiates a new TemplateApply object

--- a/api/model_template_apply_action.gen.go
+++ b/api/model_template_apply_action.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateApplyAction struct for TemplateApplyAction
 type TemplateApplyAction struct {
-	Action     TemplateApplyActionKind       `json:"action"`
-	Properties TemplateApplyActionProperties `json:"properties"`
+	Action     TemplateApplyActionKind       `json:"action" yaml:"action"`
+	Properties TemplateApplyActionProperties `json:"properties" yaml:"properties"`
 }
 
 // NewTemplateApplyAction instantiates a new TemplateApplyAction object

--- a/api/model_template_apply_action_properties.gen.go
+++ b/api/model_template_apply_action_properties.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateApplyActionProperties struct for TemplateApplyActionProperties
 type TemplateApplyActionProperties struct {
-	Kind                 string  `json:"kind"`
-	ResourceTemplateName *string `json:"resourceTemplateName,omitempty"`
+	Kind                 string  `json:"kind" yaml:"kind"`
+	ResourceTemplateName *string `json:"resourceTemplateName,omitempty" yaml:"resourceTemplateName,omitempty"`
 }
 
 // NewTemplateApplyActionProperties instantiates a new TemplateApplyActionProperties object

--- a/api/model_template_apply_remote_ref.gen.go
+++ b/api/model_template_apply_remote_ref.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateApplyRemoteRef struct for TemplateApplyRemoteRef
 type TemplateApplyRemoteRef struct {
-	Url         string  `json:"url"`
-	ContentType *string `json:"contentType,omitempty"`
+	Url         string  `json:"url" yaml:"url"`
+	ContentType *string `json:"contentType,omitempty" yaml:"contentType,omitempty"`
 }
 
 // NewTemplateApplyRemoteRef instantiates a new TemplateApplyRemoteRef object

--- a/api/model_template_apply_template.gen.go
+++ b/api/model_template_apply_template.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateApplyTemplate struct for TemplateApplyTemplate
 type TemplateApplyTemplate struct {
-	Sources  []string        `json:"sources"`
-	Contents []TemplateEntry `json:"contents"`
+	Sources  []string        `json:"sources" yaml:"sources"`
+	Contents []TemplateEntry `json:"contents" yaml:"contents"`
 }
 
 // NewTemplateApplyTemplate instantiates a new TemplateApplyTemplate object

--- a/api/model_template_entry.gen.go
+++ b/api/model_template_entry.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateEntry struct for TemplateEntry
 type TemplateEntry struct {
-	ApiVersion string                 `json:"apiVersion"`
-	Kind       string                 `json:"kind"`
-	Meta       TemplateEntryMeta      `json:"meta"`
-	Spec       map[string]interface{} `json:"spec"`
+	ApiVersion string                 `json:"apiVersion" yaml:"apiVersion"`
+	Kind       string                 `json:"kind" yaml:"kind"`
+	Meta       TemplateEntryMeta      `json:"meta" yaml:"meta"`
+	Spec       map[string]interface{} `json:"spec" yaml:"spec"`
 }
 
 // NewTemplateEntry instantiates a new TemplateEntry object

--- a/api/model_template_entry_meta.gen.go
+++ b/api/model_template_entry_meta.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateEntryMeta struct for TemplateEntryMeta
 type TemplateEntryMeta struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // NewTemplateEntryMeta instantiates a new TemplateEntryMeta object

--- a/api/model_template_env_reference.gen.go
+++ b/api/model_template_env_reference.gen.go
@@ -17,13 +17,13 @@ import (
 // TemplateEnvReference struct for TemplateEnvReference
 type TemplateEnvReference struct {
 	// Field the environment reference corresponds too
-	ResourceField string `json:"resourceField"`
+	ResourceField string `json:"resourceField" yaml:"resourceField"`
 	// Key identified as environment reference and is the key identified in the template
-	EnvRefKey string `json:"envRefKey"`
+	EnvRefKey string `json:"envRefKey" yaml:"envRefKey"`
 	// Value provided to fulfill reference
-	Value interface{} `json:"value,omitempty"`
+	Value interface{} `json:"value,omitempty" yaml:"value,omitempty"`
 	// Default value that will be provided for the reference when no value is provided
-	DefaultValue interface{} `json:"defaultValue,omitempty"`
+	DefaultValue interface{} `json:"defaultValue,omitempty" yaml:"defaultValue,omitempty"`
 }
 
 // NewTemplateEnvReference instantiates a new TemplateEnvReference object

--- a/api/model_template_export.gen.go
+++ b/api/model_template_export.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateExport struct for TemplateExport
 type TemplateExport struct {
-	StackID   *string                   `json:"stackID,omitempty"`
-	OrgIDs    *[]TemplateExportOrgIDs   `json:"orgIDs,omitempty"`
-	Resources []TemplateExportResources `json:"resources"`
+	StackID   *string                   `json:"stackID,omitempty" yaml:"stackID,omitempty"`
+	OrgIDs    *[]TemplateExportOrgIDs   `json:"orgIDs,omitempty" yaml:"orgIDs,omitempty"`
+	Resources []TemplateExportResources `json:"resources" yaml:"resources"`
 }
 
 // NewTemplateExport instantiates a new TemplateExport object

--- a/api/model_template_export_org_ids.gen.go
+++ b/api/model_template_export_org_ids.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateExportOrgIDs struct for TemplateExportOrgIDs
 type TemplateExportOrgIDs struct {
-	OrgID           *string                        `json:"orgID,omitempty"`
-	ResourceFilters *TemplateExportResourceFilters `json:"resourceFilters,omitempty"`
+	OrgID           *string                        `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	ResourceFilters *TemplateExportResourceFilters `json:"resourceFilters,omitempty" yaml:"resourceFilters,omitempty"`
 }
 
 // NewTemplateExportOrgIDs instantiates a new TemplateExportOrgIDs object

--- a/api/model_template_export_resource_filters.gen.go
+++ b/api/model_template_export_resource_filters.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateExportResourceFilters struct for TemplateExportResourceFilters
 type TemplateExportResourceFilters struct {
-	ByLabel        *[]string `json:"byLabel,omitempty"`
-	ByResourceKind *[]string `json:"byResourceKind,omitempty"`
+	ByLabel        *[]string `json:"byLabel,omitempty" yaml:"byLabel,omitempty"`
+	ByResourceKind *[]string `json:"byResourceKind,omitempty" yaml:"byResourceKind,omitempty"`
 }
 
 // NewTemplateExportResourceFilters instantiates a new TemplateExportResourceFilters object

--- a/api/model_template_export_resources.gen.go
+++ b/api/model_template_export_resources.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateExportResources struct for TemplateExportResources
 type TemplateExportResources struct {
-	Id   *string `json:"id,omitempty"`
-	Kind string  `json:"kind"`
-	Name *string `json:"name,omitempty"`
+	Id   *string `json:"id,omitempty" yaml:"id,omitempty"`
+	Kind string  `json:"kind" yaml:"kind"`
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 }
 
 // NewTemplateExportResources instantiates a new TemplateExportResources object

--- a/api/model_template_summary.gen.go
+++ b/api/model_template_summary.gen.go
@@ -16,11 +16,11 @@ import (
 
 // TemplateSummary struct for TemplateSummary
 type TemplateSummary struct {
-	Sources []string                 `json:"sources"`
-	StackID string                   `json:"stackID"`
-	Summary TemplateSummaryResources `json:"summary"`
-	Diff    TemplateSummaryDiff      `json:"diff"`
-	Errors  []TemplateSummaryError   `json:"errors"`
+	Sources []string                 `json:"sources" yaml:"sources"`
+	StackID string                   `json:"stackID" yaml:"stackID"`
+	Summary TemplateSummaryResources `json:"summary" yaml:"summary"`
+	Diff    TemplateSummaryDiff      `json:"diff" yaml:"diff"`
+	Errors  []TemplateSummaryError   `json:"errors" yaml:"errors"`
 }
 
 // NewTemplateSummary instantiates a new TemplateSummary object

--- a/api/model_template_summary_bucket.gen.go
+++ b/api/model_template_summary_bucket.gen.go
@@ -16,15 +16,15 @@ import (
 
 // TemplateSummaryBucket struct for TemplateSummaryBucket
 type TemplateSummaryBucket struct {
-	Kind              string                 `json:"kind"`
-	TemplateMetaName  *string                `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
-	Id                string                 `json:"id"`
-	Name              string                 `json:"name"`
-	Description       *string                `json:"description,omitempty"`
-	RetentionPeriod   int32                  `json:"retentionPeriod"`
-	SchemaType        *string                `json:"schemaType,omitempty"`
+	Kind              string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
+	Id                string                 `json:"id" yaml:"id"`
+	Name              string                 `json:"name" yaml:"name"`
+	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
+	RetentionPeriod   int32                  `json:"retentionPeriod" yaml:"retentionPeriod"`
+	SchemaType        *string                `json:"schemaType,omitempty" yaml:"schemaType,omitempty"`
 }
 
 // NewTemplateSummaryBucket instantiates a new TemplateSummaryBucket object

--- a/api/model_template_summary_bucket_all_of.gen.go
+++ b/api/model_template_summary_bucket_all_of.gen.go
@@ -16,11 +16,11 @@ import (
 
 // TemplateSummaryBucketAllOf struct for TemplateSummaryBucketAllOf
 type TemplateSummaryBucketAllOf struct {
-	Id              string  `json:"id"`
-	Name            string  `json:"name"`
-	Description     *string `json:"description,omitempty"`
-	RetentionPeriod int32   `json:"retentionPeriod"`
-	SchemaType      *string `json:"schemaType,omitempty"`
+	Id              string  `json:"id" yaml:"id"`
+	Name            string  `json:"name" yaml:"name"`
+	Description     *string `json:"description,omitempty" yaml:"description,omitempty"`
+	RetentionPeriod int32   `json:"retentionPeriod" yaml:"retentionPeriod"`
+	SchemaType      *string `json:"schemaType,omitempty" yaml:"schemaType,omitempty"`
 }
 
 // NewTemplateSummaryBucketAllOf instantiates a new TemplateSummaryBucketAllOf object

--- a/api/model_template_summary_check.gen.go
+++ b/api/model_template_summary_check.gen.go
@@ -16,13 +16,13 @@ import (
 
 // TemplateSummaryCheck struct for TemplateSummaryCheck
 type TemplateSummaryCheck struct {
-	Kind              string                 `json:"kind"`
-	TemplateMetaName  *string                `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
-	Id                string                 `json:"id"`
-	Name              string                 `json:"name"`
-	Description       *string                `json:"description,omitempty"`
+	Kind              string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
+	Id                string                 `json:"id" yaml:"id"`
+	Name              string                 `json:"name" yaml:"name"`
+	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryCheck instantiates a new TemplateSummaryCheck object

--- a/api/model_template_summary_check_all_of.gen.go
+++ b/api/model_template_summary_check_all_of.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateSummaryCheckAllOf struct for TemplateSummaryCheckAllOf
 type TemplateSummaryCheckAllOf struct {
-	Id          string  `json:"id"`
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
+	Id          string  `json:"id" yaml:"id"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryCheckAllOf instantiates a new TemplateSummaryCheckAllOf object

--- a/api/model_template_summary_common.gen.go
+++ b/api/model_template_summary_common.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateSummaryCommon struct for TemplateSummaryCommon
 type TemplateSummaryCommon struct {
-	Kind              string                 `json:"kind"`
-	TemplateMetaName  *string                `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
+	Kind              string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
 }
 
 // NewTemplateSummaryCommon instantiates a new TemplateSummaryCommon object

--- a/api/model_template_summary_common_all_of.gen.go
+++ b/api/model_template_summary_common_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryCommonAllOf struct for TemplateSummaryCommonAllOf
 type TemplateSummaryCommonAllOf struct {
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
 }
 
 // NewTemplateSummaryCommonAllOf instantiates a new TemplateSummaryCommonAllOf object

--- a/api/model_template_summary_core.gen.go
+++ b/api/model_template_summary_core.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateSummaryCore struct for TemplateSummaryCore
 type TemplateSummaryCore struct {
-	Kind             string                 `json:"kind"`
-	TemplateMetaName *string                `json:"templateMetaName,omitempty"`
-	EnvReferences    []TemplateEnvReference `json:"envReferences"`
+	Kind             string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences    []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
 }
 
 // NewTemplateSummaryCore instantiates a new TemplateSummaryCore object

--- a/api/model_template_summary_dashboard.gen.go
+++ b/api/model_template_summary_dashboard.gen.go
@@ -16,13 +16,13 @@ import (
 
 // TemplateSummaryDashboard struct for TemplateSummaryDashboard
 type TemplateSummaryDashboard struct {
-	Kind              string                 `json:"kind"`
-	TemplateMetaName  *string                `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
-	Id                string                 `json:"id"`
-	Name              string                 `json:"name"`
-	Description       *string                `json:"description,omitempty"`
+	Kind              string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
+	Id                string                 `json:"id" yaml:"id"`
+	Name              string                 `json:"name" yaml:"name"`
+	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryDashboard instantiates a new TemplateSummaryDashboard object

--- a/api/model_template_summary_diff.gen.go
+++ b/api/model_template_summary_diff.gen.go
@@ -16,16 +16,16 @@ import (
 
 // TemplateSummaryDiff struct for TemplateSummaryDiff
 type TemplateSummaryDiff struct {
-	Buckets               []TemplateSummaryDiffBucket               `json:"buckets"`
-	Checks                []TemplateSummaryDiffCheck                `json:"checks"`
-	Dashboards            []TemplateSummaryDiffDashboard            `json:"dashboards"`
-	Labels                []TemplateSummaryDiffLabel                `json:"labels"`
-	LabelMappings         []TemplateSummaryLabelMapping             `json:"labelMappings"`
-	NotificationEndpoints []TemplateSummaryDiffNotificationEndpoint `json:"notificationEndpoints"`
-	NotificationRules     []TemplateSummaryDiffNotificationRule     `json:"notificationRules"`
-	Tasks                 []TemplateSummaryDiffTask                 `json:"tasks"`
-	TelegrafConfigs       []TemplateSummaryDiffTelegraf             `json:"telegrafConfigs"`
-	Variables             []TemplateSummaryDiffVariable             `json:"variables"`
+	Buckets               []TemplateSummaryDiffBucket               `json:"buckets" yaml:"buckets"`
+	Checks                []TemplateSummaryDiffCheck                `json:"checks" yaml:"checks"`
+	Dashboards            []TemplateSummaryDiffDashboard            `json:"dashboards" yaml:"dashboards"`
+	Labels                []TemplateSummaryDiffLabel                `json:"labels" yaml:"labels"`
+	LabelMappings         []TemplateSummaryLabelMapping             `json:"labelMappings" yaml:"labelMappings"`
+	NotificationEndpoints []TemplateSummaryDiffNotificationEndpoint `json:"notificationEndpoints" yaml:"notificationEndpoints"`
+	NotificationRules     []TemplateSummaryDiffNotificationRule     `json:"notificationRules" yaml:"notificationRules"`
+	Tasks                 []TemplateSummaryDiffTask                 `json:"tasks" yaml:"tasks"`
+	TelegrafConfigs       []TemplateSummaryDiffTelegraf             `json:"telegrafConfigs" yaml:"telegrafConfigs"`
+	Variables             []TemplateSummaryDiffVariable             `json:"variables" yaml:"variables"`
 }
 
 // NewTemplateSummaryDiff instantiates a new TemplateSummaryDiff object

--- a/api/model_template_summary_diff_bucket.gen.go
+++ b/api/model_template_summary_diff_bucket.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffBucket struct for TemplateSummaryDiffBucket
 type TemplateSummaryDiffBucket struct {
-	Kind             string                           `json:"kind"`
-	StateStatus      string                           `json:"stateStatus"`
-	Id               string                           `json:"id"`
-	TemplateMetaName string                           `json:"templateMetaName"`
-	New              *TemplateSummaryDiffBucketFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffBucketFields `json:"old,omitempty"`
+	Kind             string                           `json:"kind" yaml:"kind"`
+	StateStatus      string                           `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                           `json:"id" yaml:"id"`
+	TemplateMetaName string                           `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffBucketFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffBucketFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffBucket instantiates a new TemplateSummaryDiffBucket object

--- a/api/model_template_summary_diff_bucket_fields.gen.go
+++ b/api/model_template_summary_diff_bucket_fields.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateSummaryDiffBucketFields struct for TemplateSummaryDiffBucketFields
 type TemplateSummaryDiffBucketFields struct {
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	// Rules to expire or retain data.  No rules means data never expires.
-	RetentionRules []RetentionRule `json:"retentionRules"`
+	RetentionRules []RetentionRule `json:"retentionRules" yaml:"retentionRules"`
 }
 
 // NewTemplateSummaryDiffBucketFields instantiates a new TemplateSummaryDiffBucketFields object

--- a/api/model_template_summary_diff_check.gen.go
+++ b/api/model_template_summary_diff_check.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffCheck struct for TemplateSummaryDiffCheck
 type TemplateSummaryDiffCheck struct {
-	Kind             string                          `json:"kind"`
-	StateStatus      string                          `json:"stateStatus"`
-	Id               string                          `json:"id"`
-	TemplateMetaName string                          `json:"templateMetaName"`
-	New              *TemplateSummaryDiffCheckFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffCheckFields `json:"old,omitempty"`
+	Kind             string                          `json:"kind" yaml:"kind"`
+	StateStatus      string                          `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                          `json:"id" yaml:"id"`
+	TemplateMetaName string                          `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffCheckFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffCheckFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffCheck instantiates a new TemplateSummaryDiffCheck object

--- a/api/model_template_summary_diff_check_fields.gen.go
+++ b/api/model_template_summary_diff_check_fields.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateSummaryDiffCheckFields struct for TemplateSummaryDiffCheckFields
 type TemplateSummaryDiffCheckFields struct {
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryDiffCheckFields instantiates a new TemplateSummaryDiffCheckFields object

--- a/api/model_template_summary_diff_dashboard.gen.go
+++ b/api/model_template_summary_diff_dashboard.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffDashboard struct for TemplateSummaryDiffDashboard
 type TemplateSummaryDiffDashboard struct {
-	StateStatus      string                              `json:"stateStatus"`
-	Id               string                              `json:"id"`
-	Kind             string                              `json:"kind"`
-	TemplateMetaName string                              `json:"templateMetaName"`
-	New              *TemplateSummaryDiffDashboardFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffDashboardFields `json:"old,omitempty"`
+	StateStatus      string                              `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                              `json:"id" yaml:"id"`
+	Kind             string                              `json:"kind" yaml:"kind"`
+	TemplateMetaName string                              `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffDashboardFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffDashboardFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffDashboard instantiates a new TemplateSummaryDiffDashboard object

--- a/api/model_template_summary_diff_dashboard_fields.gen.go
+++ b/api/model_template_summary_diff_dashboard_fields.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateSummaryDiffDashboardFields struct for TemplateSummaryDiffDashboardFields
 type TemplateSummaryDiffDashboardFields struct {
-	Name        string                   `json:"name"`
-	Description *string                  `json:"description,omitempty"`
-	Charts      []map[string]interface{} `json:"charts"`
+	Name        string                   `json:"name" yaml:"name"`
+	Description *string                  `json:"description,omitempty" yaml:"description,omitempty"`
+	Charts      []map[string]interface{} `json:"charts" yaml:"charts"`
 }
 
 // NewTemplateSummaryDiffDashboardFields instantiates a new TemplateSummaryDiffDashboardFields object

--- a/api/model_template_summary_diff_label.gen.go
+++ b/api/model_template_summary_diff_label.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffLabel struct for TemplateSummaryDiffLabel
 type TemplateSummaryDiffLabel struct {
-	StateStatus      string                          `json:"stateStatus"`
-	Kind             string                          `json:"kind"`
-	Id               string                          `json:"id"`
-	TemplateMetaName string                          `json:"templateMetaName"`
-	New              *TemplateSummaryDiffLabelFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffLabelFields `json:"old,omitempty"`
+	StateStatus      string                          `json:"stateStatus" yaml:"stateStatus"`
+	Kind             string                          `json:"kind" yaml:"kind"`
+	Id               string                          `json:"id" yaml:"id"`
+	TemplateMetaName string                          `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffLabelFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffLabelFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffLabel instantiates a new TemplateSummaryDiffLabel object

--- a/api/model_template_summary_diff_label_fields.gen.go
+++ b/api/model_template_summary_diff_label_fields.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateSummaryDiffLabelFields struct for TemplateSummaryDiffLabelFields
 type TemplateSummaryDiffLabelFields struct {
-	Name        string  `json:"name"`
-	Color       string  `json:"color"`
-	Description *string `json:"description,omitempty"`
+	Name        string  `json:"name" yaml:"name"`
+	Color       string  `json:"color" yaml:"color"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryDiffLabelFields instantiates a new TemplateSummaryDiffLabelFields object

--- a/api/model_template_summary_diff_notification_endpoint.gen.go
+++ b/api/model_template_summary_diff_notification_endpoint.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffNotificationEndpoint struct for TemplateSummaryDiffNotificationEndpoint
 type TemplateSummaryDiffNotificationEndpoint struct {
-	Kind             string                                         `json:"kind"`
-	StateStatus      string                                         `json:"stateStatus"`
-	Id               string                                         `json:"id"`
-	TemplateMetaName string                                         `json:"templateMetaName"`
-	New              *TemplateSummaryDiffNotificationEndpointFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffNotificationEndpointFields `json:"old,omitempty"`
+	Kind             string                                         `json:"kind" yaml:"kind"`
+	StateStatus      string                                         `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                                         `json:"id" yaml:"id"`
+	TemplateMetaName string                                         `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffNotificationEndpointFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffNotificationEndpointFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffNotificationEndpoint instantiates a new TemplateSummaryDiffNotificationEndpoint object

--- a/api/model_template_summary_diff_notification_endpoint_fields.gen.go
+++ b/api/model_template_summary_diff_notification_endpoint_fields.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryDiffNotificationEndpointFields struct for TemplateSummaryDiffNotificationEndpointFields
 type TemplateSummaryDiffNotificationEndpointFields struct {
-	Name string `json:"name"`
+	Name string `json:"name" yaml:"name"`
 }
 
 // NewTemplateSummaryDiffNotificationEndpointFields instantiates a new TemplateSummaryDiffNotificationEndpointFields object

--- a/api/model_template_summary_diff_notification_rule.gen.go
+++ b/api/model_template_summary_diff_notification_rule.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffNotificationRule struct for TemplateSummaryDiffNotificationRule
 type TemplateSummaryDiffNotificationRule struct {
-	Kind             string                                     `json:"kind"`
-	StateStatus      string                                     `json:"stateStatus"`
-	Id               string                                     `json:"id"`
-	TemplateMetaName string                                     `json:"templateMetaName"`
-	New              *TemplateSummaryDiffNotificationRuleFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffNotificationRuleFields `json:"old,omitempty"`
+	Kind             string                                     `json:"kind" yaml:"kind"`
+	StateStatus      string                                     `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                                     `json:"id" yaml:"id"`
+	TemplateMetaName string                                     `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffNotificationRuleFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffNotificationRuleFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffNotificationRule instantiates a new TemplateSummaryDiffNotificationRule object

--- a/api/model_template_summary_diff_notification_rule_fields.gen.go
+++ b/api/model_template_summary_diff_notification_rule_fields.gen.go
@@ -16,14 +16,14 @@ import (
 
 // TemplateSummaryDiffNotificationRuleFields struct for TemplateSummaryDiffNotificationRuleFields
 type TemplateSummaryDiffNotificationRuleFields struct {
-	Name            string  `json:"name"`
-	Description     *string `json:"description,omitempty"`
-	EndpointName    string  `json:"endpointName"`
-	EndpointID      string  `json:"endpointID"`
-	EndpointType    string  `json:"endpointType"`
-	Every           string  `json:"every"`
-	Offset          string  `json:"offset"`
-	MessageTemplate *string `json:"messageTemplate,omitempty"`
+	Name            string  `json:"name" yaml:"name"`
+	Description     *string `json:"description,omitempty" yaml:"description,omitempty"`
+	EndpointName    string  `json:"endpointName" yaml:"endpointName"`
+	EndpointID      string  `json:"endpointID" yaml:"endpointID"`
+	EndpointType    string  `json:"endpointType" yaml:"endpointType"`
+	Every           string  `json:"every" yaml:"every"`
+	Offset          string  `json:"offset" yaml:"offset"`
+	MessageTemplate *string `json:"messageTemplate,omitempty" yaml:"messageTemplate,omitempty"`
 }
 
 // NewTemplateSummaryDiffNotificationRuleFields instantiates a new TemplateSummaryDiffNotificationRuleFields object

--- a/api/model_template_summary_diff_task.gen.go
+++ b/api/model_template_summary_diff_task.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffTask struct for TemplateSummaryDiffTask
 type TemplateSummaryDiffTask struct {
-	Kind             string                         `json:"kind"`
-	StateStatus      string                         `json:"stateStatus"`
-	Id               string                         `json:"id"`
-	TemplateMetaName string                         `json:"templateMetaName"`
-	New              *TemplateSummaryDiffTaskFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffTaskFields `json:"old,omitempty"`
+	Kind             string                         `json:"kind" yaml:"kind"`
+	StateStatus      string                         `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                         `json:"id" yaml:"id"`
+	TemplateMetaName string                         `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffTaskFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffTaskFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffTask instantiates a new TemplateSummaryDiffTask object

--- a/api/model_template_summary_diff_task_fields.gen.go
+++ b/api/model_template_summary_diff_task_fields.gen.go
@@ -16,13 +16,13 @@ import (
 
 // TemplateSummaryDiffTaskFields struct for TemplateSummaryDiffTaskFields
 type TemplateSummaryDiffTaskFields struct {
-	Name        string  `json:"name"`
-	Cron        *string `json:"cron,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Every       *string `json:"every,omitempty"`
-	Offset      *string `json:"offset,omitempty"`
-	Query       *string `json:"query,omitempty"`
-	Status      string  `json:"status"`
+	Name        string  `json:"name" yaml:"name"`
+	Cron        *string `json:"cron,omitempty" yaml:"cron,omitempty"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Every       *string `json:"every,omitempty" yaml:"every,omitempty"`
+	Offset      *string `json:"offset,omitempty" yaml:"offset,omitempty"`
+	Query       *string `json:"query,omitempty" yaml:"query,omitempty"`
+	Status      string  `json:"status" yaml:"status"`
 }
 
 // NewTemplateSummaryDiffTaskFields instantiates a new TemplateSummaryDiffTaskFields object

--- a/api/model_template_summary_diff_telegraf.gen.go
+++ b/api/model_template_summary_diff_telegraf.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffTelegraf struct for TemplateSummaryDiffTelegraf
 type TemplateSummaryDiffTelegraf struct {
-	Kind             string                         `json:"kind"`
-	StateStatus      string                         `json:"stateStatus"`
-	Id               string                         `json:"id"`
-	TemplateMetaName string                         `json:"templateMetaName"`
-	New              *TemplateSummaryTelegrafConfig `json:"new,omitempty"`
-	Old              *TemplateSummaryTelegrafConfig `json:"old,omitempty"`
+	Kind             string                         `json:"kind" yaml:"kind"`
+	StateStatus      string                         `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                         `json:"id" yaml:"id"`
+	TemplateMetaName string                         `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryTelegrafConfig `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryTelegrafConfig `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffTelegraf instantiates a new TemplateSummaryDiffTelegraf object

--- a/api/model_template_summary_diff_variable.gen.go
+++ b/api/model_template_summary_diff_variable.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryDiffVariable struct for TemplateSummaryDiffVariable
 type TemplateSummaryDiffVariable struct {
-	Kind             string                             `json:"kind"`
-	StateStatus      string                             `json:"stateStatus"`
-	Id               string                             `json:"id"`
-	TemplateMetaName string                             `json:"templateMetaName"`
-	New              *TemplateSummaryDiffVariableFields `json:"new,omitempty"`
-	Old              *TemplateSummaryDiffVariableFields `json:"old,omitempty"`
+	Kind             string                             `json:"kind" yaml:"kind"`
+	StateStatus      string                             `json:"stateStatus" yaml:"stateStatus"`
+	Id               string                             `json:"id" yaml:"id"`
+	TemplateMetaName string                             `json:"templateMetaName" yaml:"templateMetaName"`
+	New              *TemplateSummaryDiffVariableFields `json:"new,omitempty" yaml:"new,omitempty"`
+	Old              *TemplateSummaryDiffVariableFields `json:"old,omitempty" yaml:"old,omitempty"`
 }
 
 // NewTemplateSummaryDiffVariable instantiates a new TemplateSummaryDiffVariable object

--- a/api/model_template_summary_diff_variable_fields.gen.go
+++ b/api/model_template_summary_diff_variable_fields.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateSummaryDiffVariableFields struct for TemplateSummaryDiffVariableFields
 type TemplateSummaryDiffVariableFields struct {
-	Name        string                      `json:"name"`
-	Description *string                     `json:"description,omitempty"`
-	Args        TemplateSummaryVariableArgs `json:"args"`
+	Name        string                      `json:"name" yaml:"name"`
+	Description *string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Args        TemplateSummaryVariableArgs `json:"args" yaml:"args"`
 }
 
 // NewTemplateSummaryDiffVariableFields instantiates a new TemplateSummaryDiffVariableFields object

--- a/api/model_template_summary_error.gen.go
+++ b/api/model_template_summary_error.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateSummaryError struct for TemplateSummaryError
 type TemplateSummaryError struct {
-	Kind    string   `json:"kind"`
-	Reason  string   `json:"reason"`
-	Fields  []string `json:"fields"`
-	Indexes []int32  `json:"indexes"`
+	Kind    string   `json:"kind" yaml:"kind"`
+	Reason  string   `json:"reason" yaml:"reason"`
+	Fields  []string `json:"fields" yaml:"fields"`
+	Indexes []int32  `json:"indexes" yaml:"indexes"`
 }
 
 // NewTemplateSummaryError instantiates a new TemplateSummaryError object

--- a/api/model_template_summary_label.gen.go
+++ b/api/model_template_summary_label.gen.go
@@ -16,13 +16,13 @@ import (
 
 // TemplateSummaryLabel struct for TemplateSummaryLabel
 type TemplateSummaryLabel struct {
-	Kind             string                              `json:"kind"`
-	TemplateMetaName *string                             `json:"templateMetaName,omitempty"`
-	EnvReferences    []TemplateEnvReference              `json:"envReferences"`
-	Id               string                              `json:"id"`
-	OrgID            *string                             `json:"orgID,omitempty"`
-	Name             string                              `json:"name"`
-	Properties       TemplateSummaryLabelAllOfProperties `json:"properties"`
+	Kind             string                              `json:"kind" yaml:"kind"`
+	TemplateMetaName *string                             `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences    []TemplateEnvReference              `json:"envReferences" yaml:"envReferences"`
+	Id               string                              `json:"id" yaml:"id"`
+	OrgID            *string                             `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Name             string                              `json:"name" yaml:"name"`
+	Properties       TemplateSummaryLabelAllOfProperties `json:"properties" yaml:"properties"`
 }
 
 // NewTemplateSummaryLabel instantiates a new TemplateSummaryLabel object

--- a/api/model_template_summary_label_all_of.gen.go
+++ b/api/model_template_summary_label_all_of.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateSummaryLabelAllOf struct for TemplateSummaryLabelAllOf
 type TemplateSummaryLabelAllOf struct {
-	Id         string                              `json:"id"`
-	OrgID      *string                             `json:"orgID,omitempty"`
-	Name       string                              `json:"name"`
-	Properties TemplateSummaryLabelAllOfProperties `json:"properties"`
+	Id         string                              `json:"id" yaml:"id"`
+	OrgID      *string                             `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Name       string                              `json:"name" yaml:"name"`
+	Properties TemplateSummaryLabelAllOfProperties `json:"properties" yaml:"properties"`
 }
 
 // NewTemplateSummaryLabelAllOf instantiates a new TemplateSummaryLabelAllOf object

--- a/api/model_template_summary_label_all_of_properties.gen.go
+++ b/api/model_template_summary_label_all_of_properties.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateSummaryLabelAllOfProperties struct for TemplateSummaryLabelAllOfProperties
 type TemplateSummaryLabelAllOfProperties struct {
-	Color       string  `json:"color"`
-	Description *string `json:"description,omitempty"`
+	Color       string  `json:"color" yaml:"color"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryLabelAllOfProperties instantiates a new TemplateSummaryLabelAllOfProperties object

--- a/api/model_template_summary_label_mapping.gen.go
+++ b/api/model_template_summary_label_mapping.gen.go
@@ -16,14 +16,14 @@ import (
 
 // TemplateSummaryLabelMapping struct for TemplateSummaryLabelMapping
 type TemplateSummaryLabelMapping struct {
-	Status                   string `json:"status"`
-	ResourceTemplateMetaName string `json:"resourceTemplateMetaName"`
-	ResourceName             string `json:"resourceName"`
-	ResourceID               string `json:"resourceID"`
-	ResourceType             string `json:"resourceType"`
-	LabelTemplateMetaName    string `json:"labelTemplateMetaName"`
-	LabelName                string `json:"labelName"`
-	LabelID                  string `json:"labelID"`
+	Status                   string `json:"status" yaml:"status"`
+	ResourceTemplateMetaName string `json:"resourceTemplateMetaName" yaml:"resourceTemplateMetaName"`
+	ResourceName             string `json:"resourceName" yaml:"resourceName"`
+	ResourceID               string `json:"resourceID" yaml:"resourceID"`
+	ResourceType             string `json:"resourceType" yaml:"resourceType"`
+	LabelTemplateMetaName    string `json:"labelTemplateMetaName" yaml:"labelTemplateMetaName"`
+	LabelName                string `json:"labelName" yaml:"labelName"`
+	LabelID                  string `json:"labelID" yaml:"labelID"`
 }
 
 // NewTemplateSummaryLabelMapping instantiates a new TemplateSummaryLabelMapping object

--- a/api/model_template_summary_notification_endpoint.gen.go
+++ b/api/model_template_summary_notification_endpoint.gen.go
@@ -16,14 +16,14 @@ import (
 
 // TemplateSummaryNotificationEndpoint struct for TemplateSummaryNotificationEndpoint
 type TemplateSummaryNotificationEndpoint struct {
-	Kind              string                 `json:"kind"`
-	TemplateMetaName  *string                `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
-	Id                string                 `json:"id"`
-	Name              string                 `json:"name"`
-	Description       *string                `json:"description,omitempty"`
-	Status            string                 `json:"status"`
+	Kind              string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
+	Id                string                 `json:"id" yaml:"id"`
+	Name              string                 `json:"name" yaml:"name"`
+	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Status            string                 `json:"status" yaml:"status"`
 }
 
 // NewTemplateSummaryNotificationEndpoint instantiates a new TemplateSummaryNotificationEndpoint object

--- a/api/model_template_summary_notification_endpoint_all_of.gen.go
+++ b/api/model_template_summary_notification_endpoint_all_of.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateSummaryNotificationEndpointAllOf struct for TemplateSummaryNotificationEndpointAllOf
 type TemplateSummaryNotificationEndpointAllOf struct {
-	Id          string  `json:"id"`
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
-	Status      string  `json:"status"`
+	Id          string  `json:"id" yaml:"id"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Status      string  `json:"status" yaml:"status"`
 }
 
 // NewTemplateSummaryNotificationEndpointAllOf instantiates a new TemplateSummaryNotificationEndpointAllOf object

--- a/api/model_template_summary_notification_rule.gen.go
+++ b/api/model_template_summary_notification_rule.gen.go
@@ -16,17 +16,17 @@ import (
 
 // TemplateSummaryNotificationRule struct for TemplateSummaryNotificationRule
 type TemplateSummaryNotificationRule struct {
-	Kind                     string                 `json:"kind"`
-	TemplateMetaName         *string                `json:"templateMetaName,omitempty"`
-	EnvReferences            []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations        []TemplateSummaryLabel `json:"labelAssociations"`
-	Name                     string                 `json:"name"`
-	Description              *string                `json:"description,omitempty"`
-	EndpointTemplateMetaName string                 `json:"endpointTemplateMetaName"`
-	EndpointID               string                 `json:"endpointID"`
-	EndpointType             string                 `json:"endpointType"`
-	Every                    string                 `json:"every"`
-	Offset                   string                 `json:"offset"`
+	Kind                     string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName         *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences            []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations        []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
+	Name                     string                 `json:"name" yaml:"name"`
+	Description              *string                `json:"description,omitempty" yaml:"description,omitempty"`
+	EndpointTemplateMetaName string                 `json:"endpointTemplateMetaName" yaml:"endpointTemplateMetaName"`
+	EndpointID               string                 `json:"endpointID" yaml:"endpointID"`
+	EndpointType             string                 `json:"endpointType" yaml:"endpointType"`
+	Every                    string                 `json:"every" yaml:"every"`
+	Offset                   string                 `json:"offset" yaml:"offset"`
 }
 
 // NewTemplateSummaryNotificationRule instantiates a new TemplateSummaryNotificationRule object

--- a/api/model_template_summary_notification_rule_all_of.gen.go
+++ b/api/model_template_summary_notification_rule_all_of.gen.go
@@ -16,13 +16,13 @@ import (
 
 // TemplateSummaryNotificationRuleAllOf struct for TemplateSummaryNotificationRuleAllOf
 type TemplateSummaryNotificationRuleAllOf struct {
-	Name                     string  `json:"name"`
-	Description              *string `json:"description,omitempty"`
-	EndpointTemplateMetaName string  `json:"endpointTemplateMetaName"`
-	EndpointID               string  `json:"endpointID"`
-	EndpointType             string  `json:"endpointType"`
-	Every                    string  `json:"every"`
-	Offset                   string  `json:"offset"`
+	Name                     string  `json:"name" yaml:"name"`
+	Description              *string `json:"description,omitempty" yaml:"description,omitempty"`
+	EndpointTemplateMetaName string  `json:"endpointTemplateMetaName" yaml:"endpointTemplateMetaName"`
+	EndpointID               string  `json:"endpointID" yaml:"endpointID"`
+	EndpointType             string  `json:"endpointType" yaml:"endpointType"`
+	Every                    string  `json:"every" yaml:"every"`
+	Offset                   string  `json:"offset" yaml:"offset"`
 }
 
 // NewTemplateSummaryNotificationRuleAllOf instantiates a new TemplateSummaryNotificationRuleAllOf object

--- a/api/model_template_summary_resources.gen.go
+++ b/api/model_template_summary_resources.gen.go
@@ -16,18 +16,18 @@ import (
 
 // TemplateSummaryResources struct for TemplateSummaryResources
 type TemplateSummaryResources struct {
-	Buckets               []TemplateSummaryBucket               `json:"buckets"`
-	Checks                []TemplateSummaryCheck                `json:"checks"`
-	Dashboards            []TemplateSummaryDashboard            `json:"dashboards"`
-	Labels                []TemplateSummaryLabel                `json:"labels"`
-	LabelMappings         []TemplateSummaryLabelMapping         `json:"labelMappings"`
-	MissingEnvRefs        []string                              `json:"missingEnvRefs"`
-	MissingSecrets        []string                              `json:"missingSecrets"`
-	NotificationEndpoints []TemplateSummaryNotificationEndpoint `json:"notificationEndpoints"`
-	NotificationRules     []TemplateSummaryNotificationRule     `json:"notificationRules"`
-	Tasks                 []TemplateSummaryTask                 `json:"tasks"`
-	TelegrafConfigs       []TemplateSummaryTelegraf             `json:"telegrafConfigs"`
-	Variables             []TemplateSummaryVariable             `json:"variables"`
+	Buckets               []TemplateSummaryBucket               `json:"buckets" yaml:"buckets"`
+	Checks                []TemplateSummaryCheck                `json:"checks" yaml:"checks"`
+	Dashboards            []TemplateSummaryDashboard            `json:"dashboards" yaml:"dashboards"`
+	Labels                []TemplateSummaryLabel                `json:"labels" yaml:"labels"`
+	LabelMappings         []TemplateSummaryLabelMapping         `json:"labelMappings" yaml:"labelMappings"`
+	MissingEnvRefs        []string                              `json:"missingEnvRefs" yaml:"missingEnvRefs"`
+	MissingSecrets        []string                              `json:"missingSecrets" yaml:"missingSecrets"`
+	NotificationEndpoints []TemplateSummaryNotificationEndpoint `json:"notificationEndpoints" yaml:"notificationEndpoints"`
+	NotificationRules     []TemplateSummaryNotificationRule     `json:"notificationRules" yaml:"notificationRules"`
+	Tasks                 []TemplateSummaryTask                 `json:"tasks" yaml:"tasks"`
+	TelegrafConfigs       []TemplateSummaryTelegraf             `json:"telegrafConfigs" yaml:"telegrafConfigs"`
+	Variables             []TemplateSummaryVariable             `json:"variables" yaml:"variables"`
 }
 
 // NewTemplateSummaryResources instantiates a new TemplateSummaryResources object

--- a/api/model_template_summary_task.gen.go
+++ b/api/model_template_summary_task.gen.go
@@ -16,16 +16,16 @@ import (
 
 // TemplateSummaryTask struct for TemplateSummaryTask
 type TemplateSummaryTask struct {
-	Kind              string                 `json:"kind"`
-	TemplateMetaName  *string                `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations"`
-	Id                string                 `json:"id"`
-	Name              string                 `json:"name"`
-	Description       *string                `json:"description,omitempty"`
-	Cron              *string                `json:"cron,omitempty"`
-	Every             *string                `json:"every,omitempty"`
-	Offset            *string                `json:"offset,omitempty"`
+	Kind              string                 `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
+	Id                string                 `json:"id" yaml:"id"`
+	Name              string                 `json:"name" yaml:"name"`
+	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
+	Cron              *string                `json:"cron,omitempty" yaml:"cron,omitempty"`
+	Every             *string                `json:"every,omitempty" yaml:"every,omitempty"`
+	Offset            *string                `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
 // NewTemplateSummaryTask instantiates a new TemplateSummaryTask object

--- a/api/model_template_summary_task_all_of.gen.go
+++ b/api/model_template_summary_task_all_of.gen.go
@@ -16,12 +16,12 @@ import (
 
 // TemplateSummaryTaskAllOf struct for TemplateSummaryTaskAllOf
 type TemplateSummaryTaskAllOf struct {
-	Id          string  `json:"id"`
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
-	Cron        *string `json:"cron,omitempty"`
-	Every       *string `json:"every,omitempty"`
-	Offset      *string `json:"offset,omitempty"`
+	Id          string  `json:"id" yaml:"id"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	Cron        *string `json:"cron,omitempty" yaml:"cron,omitempty"`
+	Every       *string `json:"every,omitempty" yaml:"every,omitempty"`
+	Offset      *string `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
 // NewTemplateSummaryTaskAllOf instantiates a new TemplateSummaryTaskAllOf object

--- a/api/model_template_summary_telegraf.gen.go
+++ b/api/model_template_summary_telegraf.gen.go
@@ -16,11 +16,11 @@ import (
 
 // TemplateSummaryTelegraf struct for TemplateSummaryTelegraf
 type TemplateSummaryTelegraf struct {
-	Kind              string                        `json:"kind"`
-	TemplateMetaName  *string                       `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference        `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel        `json:"labelAssociations"`
-	TelegrafConfig    TemplateSummaryTelegrafConfig `json:"telegrafConfig"`
+	Kind              string                        `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                       `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference        `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel        `json:"labelAssociations" yaml:"labelAssociations"`
+	TelegrafConfig    TemplateSummaryTelegrafConfig `json:"telegrafConfig" yaml:"telegrafConfig"`
 }
 
 // NewTemplateSummaryTelegraf instantiates a new TemplateSummaryTelegraf object

--- a/api/model_template_summary_telegraf_all_of.gen.go
+++ b/api/model_template_summary_telegraf_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryTelegrafAllOf struct for TemplateSummaryTelegrafAllOf
 type TemplateSummaryTelegrafAllOf struct {
-	TelegrafConfig TemplateSummaryTelegrafConfig `json:"telegrafConfig"`
+	TelegrafConfig TemplateSummaryTelegrafConfig `json:"telegrafConfig" yaml:"telegrafConfig"`
 }
 
 // NewTemplateSummaryTelegrafAllOf instantiates a new TemplateSummaryTelegrafAllOf object

--- a/api/model_template_summary_telegraf_config.gen.go
+++ b/api/model_template_summary_telegraf_config.gen.go
@@ -16,9 +16,9 @@ import (
 
 // TemplateSummaryTelegrafConfig struct for TemplateSummaryTelegrafConfig
 type TemplateSummaryTelegrafConfig struct {
-	Id          string  `json:"id"`
-	Name        string  `json:"name"`
-	Description *string `json:"description,omitempty"`
+	Id          string  `json:"id" yaml:"id"`
+	Name        string  `json:"name" yaml:"name"`
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
 
 // NewTemplateSummaryTelegrafConfig instantiates a new TemplateSummaryTelegrafConfig object

--- a/api/model_template_summary_variable.gen.go
+++ b/api/model_template_summary_variable.gen.go
@@ -16,14 +16,14 @@ import (
 
 // TemplateSummaryVariable struct for TemplateSummaryVariable
 type TemplateSummaryVariable struct {
-	Kind              string                      `json:"kind"`
-	TemplateMetaName  *string                     `json:"templateMetaName,omitempty"`
-	EnvReferences     []TemplateEnvReference      `json:"envReferences"`
-	LabelAssociations []TemplateSummaryLabel      `json:"labelAssociations"`
-	Id                string                      `json:"id"`
-	Name              string                      `json:"name"`
-	Description       *string                     `json:"description,omitempty"`
-	Arguments         TemplateSummaryVariableArgs `json:"arguments"`
+	Kind              string                      `json:"kind" yaml:"kind"`
+	TemplateMetaName  *string                     `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
+	EnvReferences     []TemplateEnvReference      `json:"envReferences" yaml:"envReferences"`
+	LabelAssociations []TemplateSummaryLabel      `json:"labelAssociations" yaml:"labelAssociations"`
+	Id                string                      `json:"id" yaml:"id"`
+	Name              string                      `json:"name" yaml:"name"`
+	Description       *string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Arguments         TemplateSummaryVariableArgs `json:"arguments" yaml:"arguments"`
 }
 
 // NewTemplateSummaryVariable instantiates a new TemplateSummaryVariable object

--- a/api/model_template_summary_variable_all_of.gen.go
+++ b/api/model_template_summary_variable_all_of.gen.go
@@ -16,10 +16,10 @@ import (
 
 // TemplateSummaryVariableAllOf struct for TemplateSummaryVariableAllOf
 type TemplateSummaryVariableAllOf struct {
-	Id          string                      `json:"id"`
-	Name        string                      `json:"name"`
-	Description *string                     `json:"description,omitempty"`
-	Arguments   TemplateSummaryVariableArgs `json:"arguments"`
+	Id          string                      `json:"id" yaml:"id"`
+	Name        string                      `json:"name" yaml:"name"`
+	Description *string                     `json:"description,omitempty" yaml:"description,omitempty"`
+	Arguments   TemplateSummaryVariableArgs `json:"arguments" yaml:"arguments"`
 }
 
 // NewTemplateSummaryVariableAllOf instantiates a new TemplateSummaryVariableAllOf object

--- a/api/model_template_summary_variable_args.gen.go
+++ b/api/model_template_summary_variable_args.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryVariableArgs struct for TemplateSummaryVariableArgs
 type TemplateSummaryVariableArgs struct {
-	Type                 string `json:"type"`
+	Type                 string `json:"type" yaml:"type"`
 	AdditionalProperties map[string]interface{}
 }
 

--- a/api/model_user.gen.go
+++ b/api/model_user.gen.go
@@ -16,11 +16,11 @@ import (
 
 // User struct for User
 type User struct {
-	Id      *string `json:"id,omitempty"`
-	OauthID *string `json:"oauthID,omitempty"`
-	Name    string  `json:"name"`
+	Id      *string `json:"id,omitempty" yaml:"id,omitempty"`
+	OauthID *string `json:"oauthID,omitempty" yaml:"oauthID,omitempty"`
+	Name    string  `json:"name" yaml:"name"`
 	// If inactive the user is inactive.
-	Status *string `json:"status,omitempty"`
+	Status *string `json:"status,omitempty" yaml:"status,omitempty"`
 }
 
 // NewUser instantiates a new User object

--- a/api/model_user_response.gen.go
+++ b/api/model_user_response.gen.go
@@ -16,12 +16,12 @@ import (
 
 // UserResponse struct for UserResponse
 type UserResponse struct {
-	Id      *string `json:"id,omitempty"`
-	OauthID *string `json:"oauthID,omitempty"`
-	Name    string  `json:"name"`
+	Id      *string `json:"id,omitempty" yaml:"id,omitempty"`
+	OauthID *string `json:"oauthID,omitempty" yaml:"oauthID,omitempty"`
+	Name    string  `json:"name" yaml:"name"`
 	// If inactive the user is inactive.
-	Status *string            `json:"status,omitempty"`
-	Links  *UserResponseLinks `json:"links,omitempty"`
+	Status *string            `json:"status,omitempty" yaml:"status,omitempty"`
+	Links  *UserResponseLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewUserResponse instantiates a new UserResponse object

--- a/api/model_user_response_links.gen.go
+++ b/api/model_user_response_links.gen.go
@@ -16,7 +16,7 @@ import (
 
 // UserResponseLinks struct for UserResponseLinks
 type UserResponseLinks struct {
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 }
 
 // NewUserResponseLinks instantiates a new UserResponseLinks object

--- a/api/model_users.gen.go
+++ b/api/model_users.gen.go
@@ -16,8 +16,8 @@ import (
 
 // Users struct for Users
 type Users struct {
-	Links *UsersLinks     `json:"links,omitempty"`
-	Users *[]UserResponse `json:"users,omitempty"`
+	Links *UsersLinks     `json:"links,omitempty" yaml:"links,omitempty"`
+	Users *[]UserResponse `json:"users,omitempty" yaml:"users,omitempty"`
 }
 
 // NewUsers instantiates a new Users object

--- a/api/model_users_links.gen.go
+++ b/api/model_users_links.gen.go
@@ -16,7 +16,7 @@ import (
 
 // UsersLinks struct for UsersLinks
 type UsersLinks struct {
-	Self *string `json:"self,omitempty"`
+	Self *string `json:"self,omitempty" yaml:"self,omitempty"`
 }
 
 // NewUsersLinks instantiates a new UsersLinks object

--- a/api/templates/README.md
+++ b/api/templates/README.md
@@ -34,3 +34,6 @@ multiple locations.
 
 `model_oneof.mustache`
 * Fixed error strings to be idiomatic according to staticcheck (lowercase, no punctuation)
+
+`model_simple.mustache`
+* Added `yaml:` tags to all model fields to support unmarshalling camelCase

--- a/api/templates/model_simple.mustache
+++ b/api/templates/model_simple.mustache
@@ -1,0 +1,391 @@
+// {{classname}}{{#description}} {{{description}}}{{/description}}{{^description}} struct for {{{classname}}}{{/description}}
+type {{classname}} struct {
+{{#parent}}
+    {{^isMap}}
+        {{^isArray}}
+            {{{parent}}}
+        {{/isArray}}
+    {{/isMap}}
+    {{#isArray}}
+        Items {{{parent}}}
+    {{/isArray}}
+{{/parent}}
+{{#vars}}
+    {{^-first}}
+    {{/-first}}
+    {{#description}}
+        // {{{description}}}
+    {{/description}}
+    {{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}" yaml:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+{{/vars}}
+{{#isAdditionalPropertiesTrue}}
+    AdditionalProperties map[string]interface{}
+{{/isAdditionalPropertiesTrue}}
+}
+
+{{#isAdditionalPropertiesTrue}}
+    type _{{{classname}}} {{{classname}}}
+
+{{/isAdditionalPropertiesTrue}}
+// New{{classname}} instantiates a new {{classname}} object
+// This constructor will assign default values to properties that have it defined,
+// and makes sure properties required by API are set, but the set of arguments
+// will change when the set of required properties is changed
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+this := {{classname}}{}
+{{#allVars}}
+    {{#required}}
+        this.{{name}} = {{nameInCamelCase}}
+    {{/required}}
+    {{^required}}
+        {{#defaultValue}}
+            {{^vendorExtensions.x-golang-is-container}}
+                {{#isNullable}}
+                    var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+                    this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+                {{/isNullable}}
+                {{^isNullable}}
+                    var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+                    this.{{name}} = &{{nameInCamelCase}}
+                {{/isNullable}}
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/defaultValue}}
+    {{/required}}
+{{/allVars}}
+return &this
+}
+
+// New{{classname}}WithDefaults instantiates a new {{classname}} object
+// This constructor will only assign default values to properties that have it defined,
+// but it doesn't guarantee that properties required by API are set
+func New{{classname}}WithDefaults() *{{classname}} {
+this := {{classname}}{}
+{{#vars}}
+    {{#defaultValue}}
+        {{^vendorExtensions.x-golang-is-container}}
+            {{#isNullable}}
+            {{!we use datatypeWithEnum here, since it will represent the non-nullable name of the datatype, e.g. int64 for NullableInt64}}
+                var {{nameInCamelCase}} {{{datatypeWithEnum}}} = {{{.}}}
+                this.{{name}} = *New{{{dataType}}}(&{{nameInCamelCase}})
+            {{/isNullable}}
+            {{^isNullable}}
+                var {{nameInCamelCase}} {{{dataType}}} = {{{.}}}
+                this.{{name}} = {{^required}}&{{/required}}{{nameInCamelCase}}
+            {{/isNullable}}
+        {{/vendorExtensions.x-golang-is-container}}
+    {{/defaultValue}}
+{{/vars}}
+return &this
+}
+
+{{#vars}}
+    {{#required}}
+        // Get{{name}} returns the {{name}} field value
+        {{#isNullable}}
+            // If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
+        {{/isNullable}}
+        func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+        if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+        var ret {{vendorExtensions.x-go-base-type}}
+        return ret
+        }
+
+        {{#isNullable}}
+            {{#vendorExtensions.x-golang-is-container}}
+                return o.{{name}}
+            {{/vendorExtensions.x-golang-is-container}}
+            {{^vendorExtensions.x-golang-is-container}}
+                return *o.{{name}}.Get()
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+        {{^isNullable}}
+            return o.{{name}}
+        {{/isNullable}}
+        }
+
+        // Get{{name}}Ok returns a tuple with the {{name}} field value
+        // and a boolean to check if the value has been set.
+        {{#isNullable}}
+            // NOTE: If the value is an explicit nil, `nil, true` will be returned
+        {{/isNullable}}
+        func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
+        if o == nil {{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+        return nil, false
+        }
+        {{#isNullable}}
+            {{#vendorExtensions.x-golang-is-container}}
+                return &o.{{name}}, true
+            {{/vendorExtensions.x-golang-is-container}}
+            {{^vendorExtensions.x-golang-is-container}}
+                return o.{{name}}.Get(), o.{{name}}.IsSet()
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+        {{^isNullable}}
+            return &o.{{name}}, true
+        {{/isNullable}}
+        }
+
+        // Set{{name}} sets field value
+        func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+        {{#isNullable}}
+            {{#vendorExtensions.x-golang-is-container}}
+                o.{{name}} = v
+            {{/vendorExtensions.x-golang-is-container}}
+            {{^vendorExtensions.x-golang-is-container}}
+                o.{{name}}.Set(&v)
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+        {{^isNullable}}
+            o.{{name}} = v
+        {{/isNullable}}
+        }
+
+    {{/required}}
+    {{^required}}
+        // Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
+        func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+        if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}}|| o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+        var ret {{vendorExtensions.x-go-base-type}}
+        return ret
+        }
+        {{#isNullable}}
+            {{#vendorExtensions.x-golang-is-container}}
+                return o.{{name}}
+            {{/vendorExtensions.x-golang-is-container}}
+            {{^vendorExtensions.x-golang-is-container}}
+                return *o.{{name}}.Get()
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+        {{^isNullable}}
+            return *o.{{name}}
+        {{/isNullable}}
+        }
+
+        // Get{{name}}Ok returns a tuple with the {{name}} field value if set, nil otherwise
+        // and a boolean to check if the value has been set.
+        {{#isNullable}}
+            // NOTE: If the value is an explicit nil, `nil, true` will be returned
+        {{/isNullable}}
+        func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
+        if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+        return nil, false
+        }
+        {{#isNullable}}
+            {{#vendorExtensions.x-golang-is-container}}
+                return &o.{{name}}, true
+            {{/vendorExtensions.x-golang-is-container}}
+            {{^vendorExtensions.x-golang-is-container}}
+                return o.{{name}}.Get(), o.{{name}}.IsSet()
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+        {{^isNullable}}
+            return o.{{name}}, true
+        {{/isNullable}}
+        }
+
+        // Has{{name}} returns a boolean if a field has been set.
+        func (o *{{classname}}) Has{{name}}() bool {
+        if o != nil && {{^isNullable}}o.{{name}} != nil{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}o.{{name}} != nil{{/vendorExtensions.x-golang-is-container}}{{^vendorExtensions.x-golang-is-container}}o.{{name}}.IsSet(){{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
+        return true
+        }
+
+        return false
+        }
+
+        // Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
+        func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+        {{#isNullable}}
+            {{#vendorExtensions.x-golang-is-container}}
+                o.{{name}} = v
+            {{/vendorExtensions.x-golang-is-container}}
+            {{^vendorExtensions.x-golang-is-container}}
+                o.{{name}}.Set(&v)
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+        {{^isNullable}}
+            o.{{name}} = &v
+        {{/isNullable}}
+        }
+        {{#isNullable}}
+            {{^vendorExtensions.x-golang-is-container}}
+                // Set{{name}}Nil sets the value for {{name}} to be an explicit nil
+                func (o *{{classname}}) Set{{name}}Nil() {
+                o.{{name}}.Set(nil)
+                }
+
+                // Unset{{name}} ensures that no value is present for {{name}}, not even an explicit nil
+                func (o *{{classname}}) Unset{{name}}() {
+                o.{{name}}.Unset()
+                }
+            {{/vendorExtensions.x-golang-is-container}}
+        {{/isNullable}}
+
+    {{/required}}
+{{/vars}}
+func (o {{classname}}) MarshalJSON() ([]byte, error) {
+toSerialize := {{#isArray}}make([]interface{}, len(o.Items)){{/isArray}}{{^isArray}}map[string]interface{}{}{{/isArray}}
+{{#parent}}
+    {{^isMap}}
+        {{^isArray}}
+            serialized{{parent}}, err{{parent}} := json.Marshal(o.{{parent}})
+            if err{{parent}} != nil {
+            return []byte{}, err{{parent}}
+            }
+            err{{parent}} = json.Unmarshal([]byte(serialized{{parent}}), &toSerialize)
+            if err{{parent}} != nil {
+            return []byte{}, err{{parent}}
+            }
+        {{/isArray}}
+    {{/isMap}}
+    {{#isArray}}
+        for i, item := range o.Items {
+        toSerialize[i] = item
+        }
+    {{/isArray}}
+{{/parent}}
+{{#vars}}
+{{! if argument is nullable, only serialize it if it is set}}
+    {{#isNullable}}
+        {{#vendorExtensions.x-golang-is-container}}
+        {{! support for container fields is not ideal at this point because of lack of Nullable* types}}
+            if o.{{name}} != nil {
+            toSerialize["{{baseName}}"] = o.{{name}}
+            }
+        {{/vendorExtensions.x-golang-is-container}}
+        {{^vendorExtensions.x-golang-is-container}}
+            if {{#required}}true{{/required}}{{^required}}o.{{name}}.IsSet(){{/required}} {
+            toSerialize["{{baseName}}"] = o.{{name}}.Get()
+            }
+        {{/vendorExtensions.x-golang-is-container}}
+    {{/isNullable}}
+    {{! if argument is not nullable, don't set it if it is nil}}
+    {{^isNullable}}
+        if {{#required}}true{{/required}}{{^required}}o.{{name}} != nil{{/required}} {
+        toSerialize["{{baseName}}"] = o.{{name}}
+        }
+    {{/isNullable}}
+{{/vars}}
+{{#isAdditionalPropertiesTrue}}
+
+    for key, value := range o.AdditionalProperties {
+    toSerialize[key] = value
+    }
+
+{{/isAdditionalPropertiesTrue}}
+return json.Marshal(toSerialize)
+}
+
+{{#isAdditionalPropertiesTrue}}
+    func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+    {{#parent}}
+        {{^isMap}}
+            type {{classname}}WithoutEmbeddedStruct struct {
+            {{#vars}}
+                {{^-first}}
+                {{/-first}}
+                {{#description}}
+                    // {{{description}}}
+                {{/description}}
+                {{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}" yaml:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+            {{/vars}}
+            }
+
+            var{{{classname}}}WithoutEmbeddedStruct := {{{classname}}}WithoutEmbeddedStruct{}
+
+            err = json.Unmarshal(bytes, &var{{{classname}}}WithoutEmbeddedStruct)
+            if err == nil {
+            var{{{classname}}} := _{{{classname}}}{}
+            {{#vars}}
+                var{{{classname}}}.{{{name}}} = var{{{classname}}}WithoutEmbeddedStruct.{{{name}}}
+            {{/vars}}
+            *o = {{{classname}}}(var{{{classname}}})
+            } else {
+            return err
+            }
+
+            var{{{classname}}} := _{{{classname}}}{}
+
+            err = json.Unmarshal(bytes, &var{{{classname}}})
+            if err == nil {
+            o.{{{parent}}} = var{{{classname}}}.{{{parent}}}
+            } else {
+            return err
+            }
+
+            additionalProperties := make(map[string]interface{})
+
+            if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+            {{#vars}}
+                delete(additionalProperties, "{{{baseName}}}")
+            {{/vars}}
+
+            // remove fields from embedded structs
+            reflect{{{parent}}} := reflect.ValueOf(o.{{{parent}}})
+            for i := 0; i < reflect{{{parent}}}.Type().NumField(); i++ {
+            t := reflect{{{parent}}}.Type().Field(i)
+
+            if jsonTag := t.Tag.Get("json"); jsonTag != "" {
+            fieldName := ""
+            if commaIdx := strings.Index(jsonTag, ","); commaIdx > 0 {
+            fieldName = jsonTag[:commaIdx]
+            } else {
+            fieldName = jsonTag
+            }
+            if fieldName != "AdditionalProperties" {
+            delete(additionalProperties, fieldName)
+            }
+            }
+            }
+
+            o.AdditionalProperties = additionalProperties
+            }
+
+            return err
+        {{/isMap}}
+        {{#isMap}}
+            var{{{classname}}} := _{{{classname}}}{}
+
+            if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+            *o = {{{classname}}}(var{{{classname}}})
+            }
+
+            additionalProperties := make(map[string]interface{})
+
+            if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+            {{#vars}}
+                delete(additionalProperties, "{{{baseName}}}")
+            {{/vars}}
+            o.AdditionalProperties = additionalProperties
+            }
+
+            return err
+        {{/isMap}}
+    {{/parent}}
+    {{^parent}}
+        var{{{classname}}} := _{{{classname}}}{}
+
+        if err = json.Unmarshal(bytes, &var{{{classname}}}); err == nil {
+        *o = {{{classname}}}(var{{{classname}}})
+        }
+
+        additionalProperties := make(map[string]interface{})
+
+        if err = json.Unmarshal(bytes, &additionalProperties); err == nil {
+        {{#vars}}
+            delete(additionalProperties, "{{{baseName}}}")
+        {{/vars}}
+        o.AdditionalProperties = additionalProperties
+        }
+
+        return err
+    {{/parent}}
+    }
+
+{{/isAdditionalPropertiesTrue}}
+{{#isArray}}
+    func (o *{{{classname}}}) UnmarshalJSON(bytes []byte) (err error) {
+    return json.Unmarshal(bytes, &o.Items)
+    }
+
+{{/isArray}}
+{{>nullable_model}}

--- a/clients/apply/source_test.go
+++ b/clients/apply/source_test.go
@@ -313,7 +313,7 @@ func TestTemplateSource_Read(t *testing.T) {
 	t.Parallel()
 
 	yamlTemplate := `---
-apiversion: influxdata.com/v2alpha1
+apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 meta: null
 spec:
@@ -321,7 +321,7 @@ spec:
     retentionRules:
       - type: expire
 ---
-apiversion: influxdata.com/v2alpha1
+apiVersion: influxdata.com/v2alpha1
 kind: Bucket
 meta: null
 spec:


### PR DESCRIPTION
Was driving myself crazy trying to figure out why `apiVersion` was getting dropped from YAML templates while working on #4...