### PR TITLE
feat: port influx export stack subcommand

### DIFF
--- a/clients/errors.go
+++ b/clients/errors.go
@@ -6,4 +6,5 @@ var (
 	ErrPasswordIsTooShort = errors.New("password is too short")
 	ErrMustSpecifyOrg     = errors.New("must specify org ID or org name")
 	ErrMustSpecifyBucket  = errors.New("must specify bucket ID or bucket name")
+	ErrMustSpecifyStack   = errors.New("must specify stack ID")
 )

--- a/clients/errors.go
+++ b/clients/errors.go
@@ -6,5 +6,4 @@ var (
 	ErrPasswordIsTooShort = errors.New("password is too short")
 	ErrMustSpecifyOrg     = errors.New("must specify org ID or org name")
 	ErrMustSpecifyBucket  = errors.New("must specify bucket ID or bucket name")
-	ErrMustSpecifyStack   = errors.New("must specify stack ID")
 )

--- a/clients/export/export.go
+++ b/clients/export/export.go
@@ -110,3 +110,9 @@ func (c Client) ExportAll(ctx context.Context, params *AllParams) error {
 	}
 	return nil
 }
+//
+//func (c Client) ExportStack(ctx context.Context, params *AllParams) error {
+//	if ctx.NArg() != 1 {
+//		return clients.ErrMustSpecifyStack
+//	}
+//}

--- a/clients/export/export.go
+++ b/clients/export/export.go
@@ -118,15 +118,14 @@ type StackParams struct {
 
 func (c Client) ExportStack(ctx context.Context, params *StackParams) error {
 	if params.StackId == "" {
-		return clients.ErrMustSpecifyStack
+		return fmt.Errorf("no stack id provided")
 	}
 
-	stackId := params.StackId
-
-	exportReq := api.TemplateExport{StackID: &stackId}
+	exportReq := api.TemplateExport{StackID: &params.StackId}
 	tmpl, err := c.ExportTemplate(ctx).TemplateExport(exportReq).Execute()
+
 	if err != nil {
-		return fmt.Errorf("failed to export template: %w", err)
+		return fmt.Errorf("failed to export stack %q: %w", params.StackId, err)
 	}
 	if err := params.OutParams.writeTemplate(tmpl); err != nil {
 		return fmt.Errorf("failed to write exported template: %w", err)

--- a/clients/export/export.go
+++ b/clients/export/export.go
@@ -110,9 +110,27 @@ func (c Client) ExportAll(ctx context.Context, params *AllParams) error {
 	}
 	return nil
 }
-//
-//func (c Client) ExportStack(ctx context.Context, params *AllParams) error {
-//	if ctx.NArg() != 1 {
-//		return clients.ErrMustSpecifyStack
-//	}
-//}
+
+type StackParams struct {
+	OutParams
+	StackId 	string
+}
+
+func (c Client) ExportStack(ctx context.Context, params *StackParams) error {
+	if params.StackId == "" {
+		return clients.ErrMustSpecifyStack
+	}
+
+	stackId := params.StackId
+
+	exportReq := api.TemplateExport{StackID: &stackId}
+	tmpl, err := c.ExportTemplate(ctx).TemplateExport(exportReq).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to export template: %w", err)
+	}
+	if err := params.OutParams.writeTemplate(tmpl); err != nil {
+		return fmt.Errorf("failed to write exported template: %w", err)
+	}
+
+	return nil
+}

--- a/clients/export/export.go
+++ b/clients/export/export.go
@@ -113,7 +113,7 @@ func (c Client) ExportAll(ctx context.Context, params *AllParams) error {
 
 type StackParams struct {
 	OutParams
-	StackId 	string
+	StackId string
 }
 
 func (c Client) ExportStack(ctx context.Context, params *StackParams) error {

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -362,6 +362,11 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 }
 
 func  newExportStackCmd() *cli.Command {
+	var params struct {
+		out     string
+		stackId string
+	}
+
 	return &cli.Command{
 		Name:  "stack",
 		Usage: "Export all resources associated with a stack as a template",
@@ -379,72 +384,39 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/stack/
 `,
 		Flags: append(
 			commonFlagsNoPrint(),
-			//&cli.StringFlag{
-			//	Name:        "stack-id",
-			//	Usage:       "The ID of the stack",
-			//	EnvVars:     []string{"INFLUX_STACK_ID"},
-			//	Destination: &params.stackId,
-			//},
-			//&cli.StringFlag{
-			//	Name:        "org-id",
-			//	Usage:       "The ID of the organization",
-			//	EnvVars:     []string{"INFLUX_ORG_ID"},
-			//	Destination: &params.orgId,
-			//},
-			//&cli.StringFlag{
-			//	Name:        "org",
-			//	Usage:       "The name of the organization",
-			//	Aliases:     []string{"o"},
-			//	EnvVars:     []string{"INFLUX_ORG"},
-			//	Destination: &params.orgName,
-			//},
-			//&cli.StringFlag{
-			//	Name:        "file",
-			//	Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
-			//	Aliases:     []string{"f"},
-			//	Destination: &params.out,
-			//},
+			&cli.StringFlag{
+				Name:        "file",
+				Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
+				Aliases:     []string{"f"},
+				Destination: &params.out,
+			},
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
-			fmt.Println("HELLO THIS IS SHELLS STACK SUBCOMMAND");
-			return nil
-			//parsedParams := export.AllParams{
-			//	OrgId:   params.orgId,
-			//	OrgName: params.orgName,
-			//}
-			//
-			//for _, filter := range params.filters.Value() {
-			//	components := strings.Split(filter, "=")
-			//	if len(components) != 2 {
-			//		return fmt.Errorf("invalid filter %q, must have format `type=example`", filter)
-			//	}
-			//	switch key, val := components[0], components[1]; key {
-			//	case "labelName":
-			//		parsedParams.LabelFilters = append(parsedParams.LabelFilters, val)
-			//	case "kind", "resourceKind":
-			//		parsedParams.KindFilters = append(parsedParams.KindFilters, val)
-			//	default:
-			//		return fmt.Errorf("invalid filter provided %q; filter must be 1 in [labelName, resourceKind]", filter)
-			//	}
-			//}
-			//
-			//outParams, closer, err := parseOutParams(params.out)
-			//if closer != nil {
-			//	defer closer()
-			//}
-			//if err != nil {
-			//	return err
-			//}
-			//parsedParams.OutParams = outParams
-			//
-			//apiClient := getAPI(ctx)
-			//client := export.Client{
-			//	CLI:              getCLI(ctx),
-			//	TemplatesApi:     apiClient.TemplatesApi,
-			//	OrganizationsApi: apiClient.OrganizationsApi,
-			//}
-			//return client.ExportStack(ctx.Context, &parsedParams)
+			if ctx.NArg() != 1 {
+				return fmt.Errorf("incorrect number of arguments, expected one for <stack-id>")
+			}
+
+			parsedParams := export.StackParams{
+				StackId: ctx.Args().Get(0),
+			}
+
+			outParams, closer, err := parseOutParams(params.out)
+			if closer != nil {
+				defer closer()
+			}
+			if err != nil {
+				return err
+			}
+			parsedParams.OutParams = outParams
+
+			apiClient := getAPI(ctx)
+			client := export.Client{
+				CLI:              getCLI(ctx),
+				TemplatesApi:     apiClient.TemplatesApi,
+				OrganizationsApi: apiClient.OrganizationsApi,
+			}
+			return client.ExportStack(ctx.Context, &parsedParams)
 		},
 	}
 }

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -66,6 +66,7 @@ For information about exporting InfluxDB templates, see
 https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/`,
 		Subcommands: []*cli.Command{
 			newExportAllCmd(),
+			newExportStackCmd(),
 		},
 		Flags: append(
 			commonFlagsNoPrint(),
@@ -356,6 +357,94 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 				OrganizationsApi: apiClient.OrganizationsApi,
 			}
 			return client.ExportAll(ctx.Context, &parsedParams)
+		},
+	}
+}
+
+func  newExportStackCmd() *cli.Command {
+	return &cli.Command{
+		Name:  "stack",
+		Usage: "Export all resources associated with a stack as a template",
+		Description: `The influx export stack command exports all resources 
+	associated with a stack as a template. All metadata.name fields remain the same.
+
+Example:
+	# Export a stack as a template
+	influx export stack $STACK_ID
+
+For information about exporting InfluxDB templates, see
+https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/
+and
+https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/stack/
+`,
+		Flags: append(
+			commonFlagsNoPrint(),
+			//&cli.StringFlag{
+			//	Name:        "stack-id",
+			//	Usage:       "The ID of the stack",
+			//	EnvVars:     []string{"INFLUX_STACK_ID"},
+			//	Destination: &params.stackId,
+			//},
+			//&cli.StringFlag{
+			//	Name:        "org-id",
+			//	Usage:       "The ID of the organization",
+			//	EnvVars:     []string{"INFLUX_ORG_ID"},
+			//	Destination: &params.orgId,
+			//},
+			//&cli.StringFlag{
+			//	Name:        "org",
+			//	Usage:       "The name of the organization",
+			//	Aliases:     []string{"o"},
+			//	EnvVars:     []string{"INFLUX_ORG"},
+			//	Destination: &params.orgName,
+			//},
+			//&cli.StringFlag{
+			//	Name:        "file",
+			//	Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
+			//	Aliases:     []string{"f"},
+			//	Destination: &params.out,
+			//},
+		),
+		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
+		Action: func(ctx *cli.Context) error {
+			fmt.Println("HELLO THIS IS SHELLS STACK SUBCOMMAND");
+			return nil
+			//parsedParams := export.AllParams{
+			//	OrgId:   params.orgId,
+			//	OrgName: params.orgName,
+			//}
+			//
+			//for _, filter := range params.filters.Value() {
+			//	components := strings.Split(filter, "=")
+			//	if len(components) != 2 {
+			//		return fmt.Errorf("invalid filter %q, must have format `type=example`", filter)
+			//	}
+			//	switch key, val := components[0], components[1]; key {
+			//	case "labelName":
+			//		parsedParams.LabelFilters = append(parsedParams.LabelFilters, val)
+			//	case "kind", "resourceKind":
+			//		parsedParams.KindFilters = append(parsedParams.KindFilters, val)
+			//	default:
+			//		return fmt.Errorf("invalid filter provided %q; filter must be 1 in [labelName, resourceKind]", filter)
+			//	}
+			//}
+			//
+			//outParams, closer, err := parseOutParams(params.out)
+			//if closer != nil {
+			//	defer closer()
+			//}
+			//if err != nil {
+			//	return err
+			//}
+			//parsedParams.OutParams = outParams
+			//
+			//apiClient := getAPI(ctx)
+			//client := export.Client{
+			//	CLI:              getCLI(ctx),
+			//	TemplatesApi:     apiClient.TemplatesApi,
+			//	OrganizationsApi: apiClient.OrganizationsApi,
+			//}
+			//return client.ExportStack(ctx.Context, &parsedParams)
 		},
 	}
 }

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -364,14 +364,13 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 func  newExportStackCmd() *cli.Command {
 	var params struct {
 		out     string
-		stackId string
 	}
 
 	return &cli.Command{
 		Name:  "stack",
 		Usage: "Export all resources associated with a stack as a template",
 		Description: `The influx export stack command exports all resources 
-	associated with a stack as a template. All metadata.name fields remain the same.
+associated with a stack as a template. All metadata.name fields remain the same.
 
 Example:
 	# Export a stack as a template

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -361,9 +361,9 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 	}
 }
 
-func  newExportStackCmd() *cli.Command {
+func newExportStackCmd() *cli.Command {
 	var params struct {
-		out     string
+		out string
 	}
 
 	return &cli.Command{


### PR DESCRIPTION
Closes #12 

Ports over the `export stack` subcommand from the influxdb repo, with modified logic to work with openapi/codegen. Usage of this command is `export stack [flags] <stack_id>`. Note that it will not currently work with the usage `export stack <stack_id> [flags]`. 