### PR TITLE
fix: Accept bucket ID or bucket name arguments

### DIFF
--- a/clients/bucket_schema/client.go
+++ b/clients/bucket_schema/client.go
@@ -49,10 +49,13 @@ func (c Client) resolveOrgBucketIds(ctx context.Context, params clients.OrgBucke
 	}
 
 	req := c.GetBuckets(ctx)
+	var nameID string
 	if params.BucketID.Valid() {
 		req = req.Id(params.BucketID.String())
+		nameID = params.BucketID.String()
 	} else {
 		req = req.Name(params.BucketName)
+		nameID = params.BucketName
 	}
 	if params.OrgID.Valid() {
 		req = req.OrgID(params.OrgID.String())
@@ -64,11 +67,11 @@ func (c Client) resolveOrgBucketIds(ctx context.Context, params clients.OrgBucke
 
 	resp, err := req.Execute()
 	if err != nil {
-		return nil, fmt.Errorf("failed to find bucket %q: %w", params.BucketName, err)
+		return nil, fmt.Errorf("failed to find bucket %q: %w", nameID, err)
 	}
 	buckets := resp.GetBuckets()
 	if len(buckets) == 0 {
-		return nil, fmt.Errorf("bucket %q not found", params.BucketName)
+		return nil, fmt.Errorf("bucket %q not found", nameID)
 	}
 
 	return &orgBucketID{OrgID: buckets[0].GetOrgID(), BucketID: buckets[0].GetId()}, nil

--- a/clients/bucket_schema/client.go
+++ b/clients/bucket_schema/client.go
@@ -40,11 +40,7 @@ func (c Client) resolveMeasurement(ctx context.Context, ids orgBucketID, name st
 }
 
 func (c Client) resolveOrgBucketIds(ctx context.Context, params clients.OrgBucketParams) (*orgBucketID, error) {
-	if params.OrgID.Valid() && params.BucketID.Valid() {
-		return &orgBucketID{OrgID: params.OrgID.String(), BucketID: params.BucketID.String()}, nil
-	}
-
-	if params.BucketName == "" {
+	if params.BucketName == "" && !params.BucketID.Valid() {
 		return nil, errors.New("bucket missing: specify bucket ID or bucket name")
 	}
 
@@ -52,7 +48,12 @@ func (c Client) resolveOrgBucketIds(ctx context.Context, params clients.OrgBucke
 		return nil, errors.New("org missing: specify org ID or org name")
 	}
 
-	req := c.GetBuckets(ctx).Name(params.BucketName)
+	req := c.GetBuckets(ctx)
+	if params.BucketName != "" {
+		req = req.Name(params.BucketName)
+	} else {
+		req = req.Id(params.BucketID.String())
+	}
 	if params.OrgID.Valid() {
 		req = req.OrgID(params.OrgID.String())
 	} else if params.OrgName != "" {

--- a/clients/bucket_schema/client.go
+++ b/clients/bucket_schema/client.go
@@ -49,10 +49,10 @@ func (c Client) resolveOrgBucketIds(ctx context.Context, params clients.OrgBucke
 	}
 
 	req := c.GetBuckets(ctx)
-	if params.BucketName != "" {
-		req = req.Name(params.BucketName)
-	} else {
+	if params.BucketID.Valid() {
 		req = req.Id(params.BucketID.String())
+	} else {
+		req = req.Name(params.BucketName)
 	}
 	if params.OrgID.Valid() {
 		req = req.OrgID(params.OrgID.String())

--- a/clients/bucket_schema/list_test.go
+++ b/clients/bucket_schema/list_test.go
@@ -175,6 +175,14 @@ func TestClient_List(t *testing.T) {
 			expErr: `bucket "my-bucket" not found`,
 		},
 		{
+			name: "bucket not found by id",
+			opts: opts(
+				withArgs(args{OrgName: "my-org", BucketID: influxid.MustIDFromString("baadf00d7777deed")}),
+				expGetBuckets(),
+			),
+			expErr: `bucket "baadf00d7777deed" not found`,
+		},
+		{
 			name: "list succeeds with org name and bucket name",
 			opts: opts(
 				withArgs(args{OrgName: "my-org", BucketName: "my-bucket", Name: "cpu"}),

--- a/clients/bucket_schema/list_test.go
+++ b/clients/bucket_schema/list_test.go
@@ -3,6 +3,7 @@ package bucket_schema_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients/bucket_schema"
 	"github.com/influxdata/influx-cli/v2/internal/mock"
 	"github.com/influxdata/influx-cli/v2/internal/testutils"
+	"github.com/influxdata/influx-cli/v2/pkg/influxid"
 	"github.com/stretchr/testify/assert"
 	tmock "github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -24,9 +26,9 @@ func TestClient_List(t *testing.T) {
 	t.Parallel()
 
 	var (
-		orgID         = "dead"
-		bucketID      = "f00d"
-		measurementID = "1010"
+		orgID         = influxid.MustIDFromString("deadf00dbaadf00d")
+		bucketID      = influxid.MustIDFromString("f00ddeadf00dbaad")
+		measurementID = influxid.MustIDFromString("1010f00ddeedfeed")
 		createdAt     = time.Date(2004, 4, 9, 2, 15, 0, 0, time.UTC)
 		updatedAt     = time.Date(2009, 9, 1, 2, 15, 0, 0, time.UTC)
 	)
@@ -44,7 +46,9 @@ func TestClient_List(t *testing.T) {
 
 	type args struct {
 		OrgName        string
+		OrgID          influxid.ID
 		BucketName     string
+		BucketID       influxid.ID
 		Name           string
 		ExtendedOutput bool
 	}
@@ -54,8 +58,8 @@ func TestClient_List(t *testing.T) {
 			t.Helper()
 			a.params = bucket_schema.ListParams{
 				OrgBucketParams: clients.OrgBucketParams{
-					OrgParams:    clients.OrgParams{OrgName: args.OrgName},
-					BucketParams: clients.BucketParams{BucketName: args.BucketName},
+					OrgParams:    clients.OrgParams{OrgName: args.OrgName, OrgID: args.OrgID},
+					BucketParams: clients.BucketParams{BucketName: args.BucketName, BucketID: args.BucketID},
 				},
 				Name:           args.Name,
 				ExtendedOutput: args.ExtendedOutput,
@@ -70,8 +74,8 @@ func TestClient_List(t *testing.T) {
 			var buckets []api.Bucket
 			if len(n) == 1 {
 				bucket := api.NewBucket(n[0], nil)
-				bucket.SetOrgID(orgID)
-				bucket.SetId(bucketID)
+				bucket.SetOrgID(orgID.String())
+				bucket.SetId(bucketID.String())
 				bucket.SetName(n[0])
 				buckets = []api.Bucket{*bucket}
 			}
@@ -84,8 +88,11 @@ func TestClient_List(t *testing.T) {
 
 			a.buckets.EXPECT().
 				GetBucketsExecute(tmock.MatchedBy(func(in api.ApiGetBucketsRequest) bool {
-					return (in.GetOrg() != nil && *in.GetOrg() == a.params.OrgName) &&
-						(in.GetName() != nil && *in.GetName() == a.params.BucketName)
+					matchOrg := (in.GetOrg() != nil && *in.GetOrg() == a.params.OrgName) ||
+						(in.GetOrgID() != nil && a.params.OrgID.Valid() && *in.GetOrgID() == a.params.OrgID.String())
+					matchBucket := (in.GetName() != nil && *in.GetName() == a.params.BucketName) ||
+						(in.GetId() != nil && a.params.BucketID.Valid() && *in.GetId() == a.params.BucketID.String())
+					return matchOrg && matchBucket
 				})).
 				Return(api.Buckets{Buckets: &buckets}, nil)
 		}
@@ -109,22 +116,22 @@ func TestClient_List(t *testing.T) {
 		return func(t *testing.T, a *setupArgs) {
 			t.Helper()
 
-			req := api.ApiGetMeasurementSchemasRequest{ApiService: a.schemas}.BucketID(bucketID)
+			req := api.ApiGetMeasurementSchemasRequest{ApiService: a.schemas}.BucketID(bucketID.String())
 
 			a.schemas.EXPECT().
-				GetMeasurementSchemas(gomock.Any(), bucketID).
+				GetMeasurementSchemas(gomock.Any(), bucketID.String()).
 				Return(req)
 
 			a.schemas.EXPECT().
 				GetMeasurementSchemasExecute(tmock.MatchedBy(func(in api.ApiGetMeasurementSchemasRequest) bool {
-					return (in.GetOrgID() != nil && *in.GetOrgID() == orgID) &&
-						in.GetBucketID() == bucketID &&
+					return (in.GetOrgID() != nil && *in.GetOrgID() == orgID.String()) &&
+						in.GetBucketID() == bucketID.String() &&
 						(in.GetName() != nil && *in.GetName() == a.params.Name)
 				})).
 				Return(api.MeasurementSchemaList{
 					MeasurementSchemas: []api.MeasurementSchema{
 						{
-							Id:        measurementID,
+							Id:        measurementID.String(),
 							Name:      a.params.Name,
 							Columns:   a.cols,
 							CreatedAt: createdAt,
@@ -153,7 +160,7 @@ func TestClient_List(t *testing.T) {
 			expErr: "org missing: specify org ID or org name",
 		},
 		{
-			name: "bucket arg missing",
+			name: "bucket args missing",
 			opts: opts(
 				withArgs(args{OrgName: "my-org"}),
 			),
@@ -168,7 +175,7 @@ func TestClient_List(t *testing.T) {
 			expErr: `bucket "my-bucket" not found`,
 		},
 		{
-			name: "list succeeds",
+			name: "list succeeds with org name and bucket name",
 			opts: opts(
 				withArgs(args{OrgName: "my-org", BucketName: "my-bucket", Name: "cpu"}),
 				withCols("columns.csv"),
@@ -177,7 +184,46 @@ func TestClient_List(t *testing.T) {
 			),
 			expLines: lines(
 				`^ID\s+Measurement Name\s+Bucket ID$`,
-				`^1010\s+cpu\s+f00d$`,
+				fmt.Sprintf(`^%s\s+cpu\s+%s`, measurementID, bucketID),
+			),
+		},
+		{
+			name: "list succeeds with org id and bucket name",
+			opts: opts(
+				withArgs(args{OrgID: orgID, BucketName: "my-bucket", Name: "cpu"}),
+				withCols("columns.csv"),
+				expGetBuckets("my-bucket"),
+				expGetMeasurementSchemas(),
+			),
+			expLines: lines(
+				`^ID\s+Measurement Name\s+Bucket ID$`,
+				fmt.Sprintf(`^%s\s+cpu\s+%s`, measurementID, bucketID),
+			),
+		},
+		{
+			name: "list succeeds with org name and bucket id",
+			opts: opts(
+				withArgs(args{OrgName: "my-org", BucketID: bucketID, Name: "cpu"}),
+				withCols("columns.csv"),
+				expGetBuckets("my-bucket"),
+				expGetMeasurementSchemas(),
+			),
+			expLines: lines(
+				`^ID\s+Measurement Name\s+Bucket ID$`,
+				fmt.Sprintf(`^%s\s+cpu\s+%s`, measurementID, bucketID),
+			),
+		},
+		{
+			name: "list succeeds with org id and bucket id",
+			opts: opts(
+				withArgs(args{OrgID: orgID, BucketID: bucketID, Name: "cpu"}),
+				withCols("columns.csv"),
+				expGetBuckets("my-bucket"),
+				expGetMeasurementSchemas(),
+			),
+			expLines: lines(
+				`^ID\s+Measurement Name\s+Bucket ID$`,
+				fmt.Sprintf(`^%s\s+cpu\s+%s`, measurementID, bucketID),
 			),
 		},
 		{
@@ -190,9 +236,9 @@ func TestClient_List(t *testing.T) {
 			),
 			expLines: lines(
 				`^ID\s+Measurement Name\s+Column Name\s+Column Type\s+Column Data Type\s+Bucket ID$`,
-				`^1010\s+cpu\s+time\s+timestamp\s+f00d$`,
-				`^1010\s+cpu\s+host\s+tag\s+f00d$`,
-				`^1010\s+cpu\s+usage_user\s+field\s+float\s+f00d$`,
+				fmt.Sprintf(`^%s\s+cpu\s+time\s+timestamp\s+%s`, measurementID, bucketID),
+				fmt.Sprintf(`^%s\s+cpu\s+host\s+tag\s+%s`, measurementID, bucketID),
+				fmt.Sprintf(`^%s\s+cpu\s+usage_user\s+field\s+float\s+%s`, measurementID, bucketID),
 			),
 		},
 	}


### PR DESCRIPTION
This PR ensures that either the `--bucket-id` or `-i` CLI options are permitted for the `bucket-schema` commands. It adds complete test coverage for all the `bucket-schema` commands to ensure the CLI options are permitted in all combinations.

Fixes #149 