### PR TITLE
fix: downgrade urfave/cli to v1 to enable more flexible parsing

### DIFF
--- a/clients/helpers.go
+++ b/clients/helpers.go
@@ -5,20 +5,17 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
-
-	"github.com/urfave/cli"
 )
 
 // ReadQuery reads a Flux query into memory from a --file argument, args, or stdin
-func ReadQuery(ctx *cli.Context) (string, error) {
-	nargs := ctx.NArg()
-	file := ctx.String("file")
+func ReadQuery(filepath string, args []string) (string, error) {
+	nargs := len(args)
 
 	if nargs > 1 {
-		return "", fmt.Errorf("at most 1 query string can be specified over the CLI, got %d", ctx.NArg())
+		return "", fmt.Errorf("at most 1 query string can be specified as an argument, got %d", nargs)
 	}
-	if nargs == 1 && file != "" {
-		return "", fmt.Errorf("query can be specified via --file or over the CLI, not both")
+	if nargs == 1 && filepath != "" {
+		return "", fmt.Errorf("query can be specified as a CLI arg or passed in a file via flag, not both")
 	}
 
 	readFile := func(path string) (string, error) {
@@ -37,14 +34,14 @@ func ReadQuery(ctx *cli.Context) (string, error) {
 		return string(queryBytes), err
 	}
 
-	if file != "" {
-		return readFile(file)
+	if filepath != "" {
+		return readFile(filepath)
 	}
 	if nargs == 0 {
 		return readStdin()
 	}
 
-	arg := ctx.Args().Get(0)
+	arg := args[0]
 	// Backwards compatibility.
 	if strings.HasPrefix(arg, "@") {
 		return readFile(arg[1:])

--- a/clients/helpers.go
+++ b/clients/helpers.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 // ReadQuery reads a Flux query into memory from a --file argument, args, or stdin

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -6,15 +6,15 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients/backup"
 	br "github.com/influxdata/influx-cli/v2/internal/backup_restore"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newBackupCmd() *cli.Command {
+func newBackupCmd() cli.Command {
 	var params backup.Params
 	// Default to gzipping local files.
 	params.Compression = br.GzipCompression
 
-	return &cli.Command{
+	return cli.Command{
 		Name:  "backup",
 		Usage: "Backup database",
 		Description: `Backs up InfluxDB to a directory
@@ -30,14 +30,13 @@ Examples:
 			&cli.StringFlag{
 				Name:        "org-id",
 				Usage:       "The ID of the organization",
-				EnvVars:     []string{"INFLUX_ORG_ID"},
+				EnvVar:      "INFLUX_ORG_ID",
 				Destination: &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.Org,
 			},
 			&cli.StringFlag{
@@ -46,9 +45,8 @@ Examples:
 				Destination: &params.BucketID,
 			},
 			&cli.StringFlag{
-				Name:        "bucket",
+				Name:        "bucket, b",
 				Usage:       "The name of the bucket to backup",
-				Aliases:     []string{"b"},
 				Destination: &params.Bucket,
 			},
 			&cli.GenericFlag{
@@ -67,7 +65,7 @@ Examples:
 				CLI:       getCLI(ctx),
 				BackupApi: getAPI(ctx).BackupApi.OnlyOSS(),
 			}
-			return client.Backup(ctx.Context, &params)
+			return client.Backup(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -4,14 +4,14 @@ import (
 	"github.com/influxdata/influx-cli/v2/api"
 	"github.com/influxdata/influx-cli/v2/clients/bucket"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newBucketCmd() *cli.Command {
-	return &cli.Command{
+func newBucketCmd() cli.Command {
+	return cli.Command{
 		Name:  "bucket",
 		Usage: "Bucket management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newBucketCreateCmd(),
 			newBucketDeleteCmd(),
 			newBucketListCmd(),
@@ -20,11 +20,11 @@ func newBucketCmd() *cli.Command {
 	}
 }
 
-func newBucketCreateCmd() *cli.Command {
+func newBucketCreateCmd() cli.Command {
 	params := bucket.BucketsCreateParams{
 		SchemaType: api.SCHEMATYPE_IMPLICIT,
 	}
-	return &cli.Command{
+	return cli.Command{
 		Name:  "create",
 		Usage: "Create bucket",
 		Before: middleware.WithBeforeFns(
@@ -34,50 +34,43 @@ func newBucketCreateCmd() *cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "New bucket name",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_BUCKET_NAME"},
+				EnvVar:      "INFLUX_BUCKET_NAME",
 				Destination: &params.Name,
 				Required:    true,
 			},
 			&cli.StringFlag{
-				Name:        "description",
+				Name:        "description, d",
 				Usage:       "Description of the bucket that will be created",
-				Aliases:     []string{"d"},
 				Destination: &params.Description,
 			},
 			&cli.StringFlag{
-				Name:        "retention",
+				Name:        "retention, r",
 				Usage:       "Duration bucket will retain data, or 0 for infinite",
-				Aliases:     []string{"r"},
-				DefaultText: "infinite",
 				Destination: &params.Retention,
 			},
 			&cli.StringFlag{
 				Name:        "shard-group-duration",
 				Usage:       "Shard group duration used internally by the storage engine",
-				DefaultText: "calculated from retention",
 				Destination: &params.ShardGroupDuration,
 			},
 			&cli.StringFlag{
 				Name:        "org-id",
 				Usage:       "The ID of the organization",
-				EnvVars:     []string{"INFLUX_ORG_ID"},
+				EnvVar:      "INFLUX_ORG_ID",
 				Destination: &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 			&cli.GenericFlag{
-				Name:        "schema-type",
-				Usage:       "The schema type (implicit, explicit)",
-				DefaultText: "implicit",
-				Value:       &params.SchemaType,
+				Name:  "schema-type",
+				Usage: "The schema type (implicit, explicit)",
+				Value: &params.SchemaType,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -87,42 +80,39 @@ func newBucketCreateCmd() *cli.Command {
 				BucketsApi:       api.BucketsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newBucketDeleteCmd() *cli.Command {
+func newBucketDeleteCmd() cli.Command {
 	var params bucket.BucketsDeleteParams
-	return &cli.Command{
+	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete bucket",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "id",
+				Name:        "id, i",
 				Usage:       "The bucket ID, required if name isn't provided",
-				Aliases:     []string{"i"},
 				Destination: &params.ID,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The bucket name, org or org-id will be required by choosing this",
-				Aliases:     []string{"n"},
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
 				Name:        "org-id",
 				Usage:       "The ID of the organization",
-				EnvVars:     []string{"INFLUX_ORG_ID"},
+				EnvVar:      "INFLUX_ORG_ID",
 				Destination: &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 		),
@@ -133,14 +123,14 @@ func newBucketDeleteCmd() *cli.Command {
 				BucketsApi:       api.BucketsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Delete(ctx.Context, &params)
+			return client.Delete(getContext(ctx), &params)
 		},
 	}
 }
 
-func newBucketListCmd() *cli.Command {
+func newBucketListCmd() cli.Command {
 	var params bucket.BucketsListParams
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List buckets",
 		Aliases: []string{"find", "ls"},
@@ -148,28 +138,25 @@ func newBucketListCmd() *cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "id",
+				Name:        "id, i",
 				Usage:       "The bucket ID, required if name isn't provided",
-				Aliases:     []string{"i"},
 				Destination: &params.ID,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The bucket name, org or org-id will be required by choosing this",
-				Aliases:     []string{"n"},
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
 				Name:        "org-id",
 				Usage:       "The ID of the organization",
-				EnvVars:     []string{"INFLUX_ORG_ID"},
+				EnvVar:      "INFLUX_ORG_ID",
 				Destination: &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 		),
@@ -180,14 +167,14 @@ func newBucketListCmd() *cli.Command {
 				BucketsApi:       api.BucketsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newBucketUpdateCmd() *cli.Command {
+func newBucketUpdateCmd() cli.Command {
 	var params bucket.BucketsUpdateParams
-	return &cli.Command{
+	return cli.Command{
 		Name:    "update",
 		Usage:   "Update bucket",
 		Aliases: []string{"find", "ls"},
@@ -195,29 +182,25 @@ func newBucketUpdateCmd() *cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "New name to set on the bucket",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_BUCKET_NAME"},
+				EnvVar:      "INFLUX_BUCKET_NAME",
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
-				Name:        "id",
+				Name:        "id, i",
 				Usage:       "The bucket ID",
-				Aliases:     []string{"i"},
 				Required:    true,
 				Destination: &params.ID,
 			},
 			&cli.StringFlag{
-				Name:        "description",
+				Name:        "description, d",
 				Usage:       "New description to set on the bucket",
-				Aliases:     []string{"d"},
 				Destination: &params.Description,
 			},
 			&cli.StringFlag{
-				Name:        "retention",
+				Name:        "retention, r",
 				Usage:       "New retention duration to set on the bucket, or 0 for infinite",
-				Aliases:     []string{"r"},
 				Destination: &params.Retention,
 			},
 			&cli.StringFlag{
@@ -233,7 +216,7 @@ func newBucketUpdateCmd() *cli.Command {
 				BucketsApi:       api.BucketsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/bucket_schema.go
+++ b/cmd/influx/bucket_schema.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"os"
+
 	"github.com/influxdata/influx-cli/v2/clients"
 	"github.com/influxdata/influx-cli/v2/clients/bucket_schema"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/influxdata/influx-cli/v2/pkg/influxid"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 func withBucketSchemaClient() cli.BeforeFunc {
@@ -31,11 +33,11 @@ func getBucketSchemaClient(ctx *cli.Context) bucket_schema.Client {
 	return i
 }
 
-func newBucketSchemaCmd() *cli.Command {
-	return &cli.Command{
+func newBucketSchemaCmd() cli.Command {
+	return cli.Command{
 		Name:  "bucket-schema",
 		Usage: "Bucket schema management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newBucketSchemaCreateCmd(),
 			newBucketSchemaUpdateCmd(),
 			newBucketSchemaListCmd(),
@@ -43,7 +45,7 @@ func newBucketSchemaCmd() *cli.Command {
 	}
 }
 
-func newBucketSchemaCreateCmd() *cli.Command {
+func newBucketSchemaCreateCmd() cli.Command {
 	var params struct {
 		clients.OrgBucketParams
 		Name           string
@@ -51,7 +53,7 @@ func newBucketSchemaCreateCmd() *cli.Command {
 		ColumnsFormat  bucket_schema.ColumnsFormat
 		ExtendedOutput bool
 	}
-	return &cli.Command{
+	return cli.Command{
 		Name:   "create",
 		Usage:  "Create a measurement schema for a bucket",
 		Before: withBucketSchemaClient(),
@@ -70,25 +72,23 @@ func newBucketSchemaCreateCmd() *cli.Command {
 					Destination: &params.ColumnsFile,
 				},
 				&cli.GenericFlag{
-					Name:        "columns-format",
-					Usage:       "The format of the columns file. \"auto\" will attempt to guess the format.",
-					DefaultText: "auto",
-					Value:       &params.ColumnsFormat,
+					Name:  "columns-format",
+					Usage: "The format of the columns file. \"auto\" will attempt to guess the format.",
+					Value: &params.ColumnsFormat,
 				},
 				&cli.BoolFlag{
-					Name:        "extended-output",
+					Name:        "extended-output, x",
 					Usage:       "Print column information for each measurement",
-					Aliases:     []string{"x"},
 					Destination: &params.ExtendedOutput,
 				},
 			)...,
 		),
 		Action: func(ctx *cli.Context) error {
 			return getBucketSchemaClient(ctx).
-				Create(ctx.Context, bucket_schema.CreateParams{
+				Create(getContext(ctx), bucket_schema.CreateParams{
 					OrgBucketParams: params.OrgBucketParams,
 					Name:            params.Name,
-					Stdin:           ctx.App.Reader,
+					Stdin:           os.Stdin,
 					ColumnsFile:     params.ColumnsFile,
 					ColumnsFormat:   params.ColumnsFormat,
 					ExtendedOutput:  params.ExtendedOutput,
@@ -97,7 +97,7 @@ func newBucketSchemaCreateCmd() *cli.Command {
 	}
 }
 
-func newBucketSchemaUpdateCmd() *cli.Command {
+func newBucketSchemaUpdateCmd() cli.Command {
 	var params struct {
 		clients.OrgBucketParams
 		ID             influxid.ID
@@ -106,7 +106,7 @@ func newBucketSchemaUpdateCmd() *cli.Command {
 		ColumnsFormat  bucket_schema.ColumnsFormat
 		ExtendedOutput bool
 	}
-	return &cli.Command{
+	return cli.Command{
 		Name:   "update",
 		Usage:  "Update a measurement schema for a bucket",
 		Before: withBucketSchemaClient(),
@@ -130,26 +130,24 @@ func newBucketSchemaUpdateCmd() *cli.Command {
 					Destination: &params.ColumnsFile,
 				},
 				&cli.GenericFlag{
-					Name:        "columns-format",
-					Usage:       "The format of the columns file. \"auto\" will attempt to guess the format.",
-					DefaultText: "auto",
-					Value:       &params.ColumnsFormat,
+					Name:  "columns-format",
+					Usage: "The format of the columns file. \"auto\" will attempt to guess the format.",
+					Value: &params.ColumnsFormat,
 				},
 				&cli.BoolFlag{
-					Name:        "extended-output",
+					Name:        "extended-output, x",
 					Usage:       "Print column information for each measurement",
-					Aliases:     []string{"x"},
 					Destination: &params.ExtendedOutput,
 				},
 			)...,
 		),
 		Action: func(ctx *cli.Context) error {
 			return getBucketSchemaClient(ctx).
-				Update(ctx.Context, bucket_schema.UpdateParams{
+				Update(getContext(ctx), bucket_schema.UpdateParams{
 					OrgBucketParams: params.OrgBucketParams,
 					ID:              params.ID.String(),
 					Name:            params.Name,
-					Stdin:           ctx.App.Reader,
+					Stdin:           os.Stdin,
 					ColumnsFile:     params.ColumnsFile,
 					ColumnsFormat:   params.ColumnsFormat,
 					ExtendedOutput:  params.ExtendedOutput,
@@ -158,9 +156,9 @@ func newBucketSchemaUpdateCmd() *cli.Command {
 	}
 }
 
-func newBucketSchemaListCmd() *cli.Command {
+func newBucketSchemaListCmd() cli.Command {
 	var params bucket_schema.ListParams
-	return &cli.Command{
+	return cli.Command{
 		Name:   "list",
 		Usage:  "List schemas for a bucket",
 		Before: withBucketSchemaClient(),
@@ -174,15 +172,14 @@ func newBucketSchemaListCmd() *cli.Command {
 					Destination: &params.Name,
 				},
 				&cli.BoolFlag{
-					Name:        "extended-output",
+					Name:        "extended-output, x",
 					Usage:       "Print column information for each measurement",
-					Aliases:     []string{"x"},
 					Destination: &params.ExtendedOutput,
 				},
 			)...,
 		),
 		Action: func(ctx *cli.Context) error {
-			return getBucketSchemaClient(ctx).List(ctx.Context, params)
+			return getBucketSchemaClient(ctx).List(getContext(ctx), params)
 		},
 	}
 }

--- a/cmd/influx/completion.go
+++ b/cmd/influx/completion.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 var (
@@ -67,14 +67,14 @@ param($commandName, $wordToComplete, $cursorPosition)
 `
 )
 
-func newCompletionCmd() *cli.Command {
-	return &cli.Command{
+func newCompletionCmd() cli.Command {
+	return cli.Command{
 		Name:      "completion",
 		Usage:     "Generates completion scripts",
 		ArgsUsage: "[bash|zsh|powershell]",
 		Action: func(ctx *cli.Context) error {
 			prog := path.Base(os.Args[0])
-			completeFlag := cli.BashCompletionFlag.Names()[0]
+			completeFlag := cli.BashCompletionFlag.GetName()
 
 			if ctx.NArg() != 1 {
 				return fmt.Errorf("usage: %s completion [bash|zsh|powershell]", prog)

--- a/cmd/influx/config.go
+++ b/cmd/influx/config.go
@@ -7,13 +7,13 @@ import (
 
 	cmd "github.com/influxdata/influx-cli/v2/clients/config"
 	"github.com/influxdata/influx-cli/v2/config"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 var configPathAndPrintFlags = append([]cli.Flag{configPathFlag()}, printFlags()...)
 
-func newConfigCmd() *cli.Command {
-	return &cli.Command{
+func newConfigCmd() cli.Command {
+	return cli.Command{
 		Name:      "config",
 		Usage:     "Config management commands",
 		ArgsUsage: "[config name]",
@@ -54,7 +54,7 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/
 			}
 			return client.PrintActive()
 		},
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newConfigCreateCmd(),
 			newConfigDeleteCmd(),
 			newConfigUpdateCmd(),
@@ -63,9 +63,9 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/
 	}
 }
 
-func newConfigCreateCmd() *cli.Command {
+func newConfigCreateCmd() cli.Command {
 	var cfg config.Config
-	return &cli.Command{
+	return cli.Command{
 		Name:  "create",
 		Usage: "Create config",
 		Description: `
@@ -88,36 +88,31 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/create/
 		Flags: append(
 			configPathAndPrintFlags,
 			&cli.StringFlag{
-				Name:        "config-name",
+				Name:        "config-name, n",
 				Usage:       "Name for the new config",
-				Aliases:     []string{"n"},
 				Required:    true,
 				Destination: &cfg.Name,
 			},
 			&cli.StringFlag{
-				Name:        "host-url",
+				Name:        "host-url, u",
 				Usage:       "Base URL of the InfluxDB server the new config should target",
-				Aliases:     []string{"u"},
 				Required:    true,
 				Destination: &cfg.Host,
 			},
 			&cli.StringFlag{
-				Name:        "token",
+				Name:        "token, t",
 				Usage:       "Auth token to use when communicating with the InfluxDB server",
-				Aliases:     []string{"t"},
 				Required:    true,
 				Destination: &cfg.Token,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "Default organization name to use in the new config",
-				Aliases:     []string{"o"},
 				Destination: &cfg.Org,
 			},
 			&cli.BoolFlag{
-				Name:        "active",
+				Name:        "active, a",
 				Usage:       "Set the new config as active",
-				Aliases:     []string{"a"},
 				Destination: &cfg.Active,
 			},
 		),
@@ -128,8 +123,8 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/create/
 	}
 }
 
-func newConfigDeleteCmd() *cli.Command {
-	return &cli.Command{
+func newConfigDeleteCmd() cli.Command {
+	return cli.Command{
 		Name:      "rm",
 		Aliases:   []string{"delete", "remove"},
 		Usage:     "Delete config",
@@ -154,14 +149,14 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/rm/
 		Flags:  append([]cli.Flag{configPathFlag()}, printFlags()...),
 		Action: func(ctx *cli.Context) error {
 			client := cmd.Client{CLI: getCLI(ctx)}
-			return client.Delete(ctx.Args().Slice())
+			return client.Delete(ctx.Args())
 		},
 	}
 }
 
-func newConfigUpdateCmd() *cli.Command {
+func newConfigUpdateCmd() cli.Command {
 	var cfg config.Config
-	return &cli.Command{
+	return cli.Command{
 		Name:    "set",
 		Aliases: []string{"update"},
 		Usage:   "Update config",
@@ -185,34 +180,29 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/set/
 		Flags: append(
 			configPathAndPrintFlags,
 			&cli.StringFlag{
-				Name:        "config-name",
+				Name:        "config-name, n",
 				Usage:       "Name of the config to update",
-				Aliases:     []string{"n"},
 				Required:    true,
 				Destination: &cfg.Name,
 			},
 			&cli.StringFlag{
-				Name:        "host-url",
+				Name:        "host-url, u",
 				Usage:       "New URL to set on the config",
-				Aliases:     []string{"u"},
 				Destination: &cfg.Host,
 			},
 			&cli.StringFlag{
-				Name:        "token",
+				Name:        "token, t",
 				Usage:       "New auth token to set on the config",
-				Aliases:     []string{"t"},
 				Destination: &cfg.Token,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "New default organization to set on the config",
-				Aliases:     []string{"o"},
 				Destination: &cfg.Org,
 			},
 			&cli.BoolFlag{
-				Name:        "active",
+				Name:        "active, a",
 				Usage:       "Set the config as active",
-				Aliases:     []string{"a"},
 				Destination: &cfg.Active,
 			},
 		),
@@ -223,8 +213,8 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/config/set/
 	}
 }
 
-func newConfigListCmd() *cli.Command {
-	return &cli.Command{
+func newConfigListCmd() cli.Command {
+	return cli.Command{
 		Name:    "ls",
 		Aliases: []string{"list"},
 		Usage:   "List configs",

--- a/cmd/influx/dashboards.go
+++ b/cmd/influx/dashboards.go
@@ -3,18 +3,17 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/dashboards"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newDashboardsCommand() *cli.Command {
+func newDashboardsCommand() cli.Command {
 	var params dashboards.Params
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, &cli.StringSliceFlag{
-		Name:    "id",
-		Usage:   "Dashboard ID to retrieve",
-		Aliases: []string{"i"},
+		Name:  "id, i",
+		Usage: "Dashboard ID to retrieve",
 	})
-	return &cli.Command{
+	return cli.Command{
 		Name:  "dashboards",
 		Usage: "List Dashboard(s).",
 		Description: `List Dashboard(s).
@@ -40,7 +39,7 @@ Examples:
 				CLI:           getCLI(ctx),
 				DashboardsApi: api.DashboardsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -3,40 +3,39 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/delete"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newDeleteCmd() *cli.Command {
+func newDeleteCmd() cli.Command {
 	var params delete.Params
-	return &cli.Command{
+	return cli.Command{
 		Name:        "delete",
 		Usage:       "Delete points from InfluxDB",
 		Description: "Delete points from InfluxDB, by specify start, end time and a sql like predicate string",
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.GenericFlag{
-				Name:    "org-id",
-				Usage:   "The ID of the organization that owns the bucket",
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &params.OrgID,
+				Name:   "org-id",
+				Usage:  "The ID of the organization that owns the bucket",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization that owns the bucket",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 			&cli.GenericFlag{
-				Name:    "bucket-id",
-				Usage:   "The ID of the bucket to delete from",
-				EnvVars: []string{"INFLUX_BUCKET_ID"},
-				Value:   &params.BucketID,
+				Name:   "bucket-id",
+				Usage:  "The ID of the bucket to delete from",
+				EnvVar: "INFLUX_BUCKET_ID",
+				Value:  &params.BucketID,
 			},
 			&cli.StringFlag{
 				Name:        "bucket",
 				Usage:       "The name of the bucket to delete from",
-				EnvVars:     []string{"INFLUX_BUCKET_NAME"},
+				EnvVar:      "INFLUX_BUCKET_NAME",
 				Destination: &params.BucketName,
 			},
 			// NOTE: cli has a Timestamp flag we could use to parse the strings immediately on input,
@@ -54,16 +53,15 @@ func newDeleteCmd() *cli.Command {
 				Destination: &params.Stop,
 			},
 			&cli.StringFlag{
-				Name:        "predicate",
+				Name:        "predicate, p",
 				Usage:       "sql like predicate string (ex: 'tag1=\"v1\" and (tag2=123)')",
-				Aliases:     []string{"p"},
 				Destination: &params.Predicate,
 			},
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
 			client := delete.Client{CLI: getCLI(ctx), DeleteApi: getAPI(ctx).DeleteApi}
-			return client.Delete(ctx.Context, &params)
+			return client.Delete(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -10,10 +10,10 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients/export"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/mattn/go-isatty"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newExportCmd() *cli.Command {
+func newExportCmd() cli.Command {
 	var params struct {
 		out            string
 		stackId        string
@@ -37,7 +37,7 @@ func newExportCmd() *cli.Command {
 		variableIds    string
 		variableNames  string
 	}
-	return &cli.Command{
+	return cli.Command{
 		Name:  "export",
 		Usage: "Export existing resources as a template",
 		Description: `The export command provides a mechanism to export existing resources to a
@@ -64,16 +64,15 @@ resource flag and then provide the IDs.
 
 For information about exporting InfluxDB templates, see
 https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/`,
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newExportAllCmd(),
 			newExportStackCmd(),
 		},
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.StringFlag{
-				Name:        "file",
+				Name:        "file, f",
 				Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
-				Aliases:     []string{"f"},
 				Destination: &params.out,
 			},
 			&cli.StringFlag{
@@ -216,7 +215,7 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/`,
 			parsedParams.OutParams = outParams
 
 			if params.resourceType != "" {
-				ids := ctx.Args().Slice()
+				ids := ctx.Args()
 
 				// Read any IDs from stdin.
 				// !IsTerminal detects when some other process is piping into this command.
@@ -245,19 +244,19 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/`,
 				CLI:          getCLI(ctx),
 				TemplatesApi: getAPI(ctx).TemplatesApi,
 			}
-			return client.Export(ctx.Context, &parsedParams)
+			return client.Export(getContext(ctx), &parsedParams)
 		},
 	}
 }
 
-func newExportAllCmd() *cli.Command {
+func newExportAllCmd() cli.Command {
 	var params struct {
 		out     string
 		orgId   string
 		orgName string
 		filters cli.StringSlice
 	}
-	return &cli.Command{
+	return cli.Command{
 		Name:  "all",
 		Usage: "Export all existing resources for an organization as a template",
 		Description: `The export all command will export all resources for an organization. The
@@ -297,26 +296,24 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 			&cli.StringFlag{
 				Name:        "org-id",
 				Usage:       "The ID of the organization",
-				EnvVars:     []string{"INFLUX_ORG_ID"},
+				EnvVar:      "INFLUX_ORG_ID",
 				Destination: &params.orgId,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.orgName,
 			},
 			&cli.StringFlag{
-				Name:        "file",
+				Name:        "file, f",
 				Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
-				Aliases:     []string{"f"},
 				Destination: &params.out,
 			},
 			&cli.StringSliceFlag{
-				Name:        "filter",
-				Usage:       "Filter exported resources by labelName or resourceKind (format: labelName=example)",
-				Destination: &params.filters,
+				Name:  "filter",
+				Usage: "Filter exported resources by labelName or resourceKind (format: labelName=example)",
+				Value: &params.filters,
 			},
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
@@ -356,7 +353,7 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 				TemplatesApi:     apiClient.TemplatesApi,
 				OrganizationsApi: apiClient.OrganizationsApi,
 			}
-			return client.ExportAll(ctx.Context, &parsedParams)
+			return client.ExportAll(getContext(ctx), &parsedParams)
 		},
 	}
 }

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -358,12 +358,12 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 	}
 }
 
-func newExportStackCmd() *cli.Command {
+func newExportStackCmd() cli.Command {
 	var params struct {
 		out string
 	}
 
-	return &cli.Command{
+	return cli.Command{
 		Name:  "stack",
 		Usage: "Export all resources associated with a stack as a template",
 		Description: `The influx export stack command exports all resources 
@@ -381,9 +381,8 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/stack/
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.StringFlag{
-				Name:        "file",
+				Name:        "file, f",
 				Usage:       "Output file for created template; defaults to std out if no file provided; the extension of provided file (.yml/.json) will dictate encoding",
-				Aliases:     []string{"f"},
 				Destination: &params.out,
 			},
 		),
@@ -412,7 +411,7 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/stack/
 				TemplatesApi:     apiClient.TemplatesApi,
 				OrganizationsApi: apiClient.OrganizationsApi,
 			}
-			return client.ExportStack(ctx.Context, &parsedParams)
+			return client.ExportStack(getContext(ctx), &parsedParams)
 		},
 	}
 }

--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -252,15 +252,15 @@ func commonFlags() []cli.Flag {
 func getOrgFlags(params *clients.OrgParams) []cli.Flag {
 	return []cli.Flag{
 		&cli.GenericFlag{
-			Name:    "org-id",
-			Usage:   "The ID of the organization",
+			Name:   "org-id",
+			Usage:  "The ID of the organization",
 			EnvVar: "INFLUX_ORG_ID",
-			Value:   &params.OrgID,
+			Value:  &params.OrgID,
 		},
 		&cli.StringFlag{
 			Name:        "org, o",
 			Usage:       "The name of the organization",
-			EnvVar:     "INFLUX_ORG",
+			EnvVar:      "INFLUX_ORG",
 			Destination: &params.OrgName,
 		},
 	}
@@ -271,9 +271,9 @@ func getOrgFlags(params *clients.OrgParams) []cli.Flag {
 func getBucketFlags(params *clients.BucketParams) []cli.Flag {
 	return []cli.Flag{
 		&cli.GenericFlag{
-			Name:    "bucket-id, i",
-			Usage:   "The bucket ID, required if name isn't provided",
-			Value:   &params.BucketID,
+			Name:  "bucket-id, i",
+			Usage: "The bucket ID, required if name isn't provided",
+			Value: &params.BucketID,
 		},
 		&cli.StringFlag{
 			Name:        "bucket, n",

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
 
-	"github.com/influxdata/influx-cli/v2/pkg/signals"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 // Fields set via ldflags at build time.
@@ -30,7 +28,7 @@ var app = cli.App{
 	Usage:                "Influx Client",
 	UsageText:            "influx [command]",
 	EnableBashCompletion: true,
-	Commands: []*cli.Command{
+	Commands: []cli.Command{
 		newVersionCmd(),
 		newPingCmd(),
 		newSetupCmd(),
@@ -52,11 +50,11 @@ var app = cli.App{
 		newSecretCommand(),
 		newV1SubCommand(),
 	},
+	Before: withContext(),
 }
 
 func main() {
-	ctx := signals.WithStandardSignals(context.Background())
-	if err := app.RunContext(ctx, os.Args); err != nil {
+	if err := app.Run(os.Args); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/cmd/influx/org.go
+++ b/cmd/influx/org.go
@@ -4,15 +4,15 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients/org"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/influxdata/influx-cli/v2/pkg/influxid"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newOrgCmd() *cli.Command {
-	return &cli.Command{
+func newOrgCmd() cli.Command {
+	return cli.Command{
 		Name:    "org",
 		Aliases: []string{"organization"},
 		Usage:   "Organization management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newOrgCreateCmd(),
 			newOrgDeleteCmd(),
 			newOrgListCmd(),
@@ -22,25 +22,23 @@ func newOrgCmd() *cli.Command {
 	}
 }
 
-func newOrgCreateCmd() *cli.Command {
+func newOrgCreateCmd() cli.Command {
 	var params org.CreateParams
-	return &cli.Command{
+	return cli.Command{
 		Name:   "create",
 		Usage:  "Create organization",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "Name to set on the new organization",
-				Aliases:     []string{"n"},
 				Required:    true,
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
-				Name:        "description",
+				Name:        "description, d",
 				Usage:       "Description to set on the new organization",
-				Aliases:     []string{"d"},
 				Destination: &params.Description,
 			},
 		),
@@ -49,25 +47,24 @@ func newOrgCreateCmd() *cli.Command {
 				CLI:              getCLI(ctx),
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newOrgDeleteCmd() *cli.Command {
+func newOrgDeleteCmd() cli.Command {
 	var id influxid.ID
-	return &cli.Command{
+	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete organization",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags: append(
 			commonFlags(),
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The organization ID",
-				Aliases: []string{"i"},
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &id,
+				Name:   "id, i",
+				Usage:  "The organization ID",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &id,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -75,14 +72,14 @@ func newOrgDeleteCmd() *cli.Command {
 				CLI:              getCLI(ctx),
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 			}
-			return client.Delete(ctx.Context, id)
+			return client.Delete(getContext(ctx), id)
 		},
 	}
 }
 
-func newOrgListCmd() *cli.Command {
+func newOrgListCmd() cli.Command {
 	var params org.ListParams
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Aliases: []string{"find", "ls"},
 		Usage:   "List organizations",
@@ -90,18 +87,16 @@ func newOrgListCmd() *cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The organization name",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.Name,
 			},
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The organization ID",
-				Aliases: []string{"i"},
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &params.ID,
+				Name:   "id, i",
+				Usage:  "The organization ID",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &params.ID,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -109,39 +104,36 @@ func newOrgListCmd() *cli.Command {
 				CLI:              getCLI(ctx),
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newOrgUpdateCmd() *cli.Command {
+func newOrgUpdateCmd() cli.Command {
 	var params org.UpdateParams
-	return &cli.Command{
+	return cli.Command{
 		Name:   "update",
 		Usage:  "Update organization",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags: append(
 			commonFlags(),
 			&cli.GenericFlag{
-				Name:     "id",
+				Name:     "id, i",
 				Usage:    "The organization ID",
-				Aliases:  []string{"i"},
-				EnvVars:  []string{"INFLUX_ORG_ID"},
+				EnvVar:   "INFLUX_ORG_ID",
 				Required: true,
 				Value:    &params.ID,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "New name to set on the organization",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
-				Name:        "description",
+				Name:        "description, d",
 				Usage:       "New description to set on the organization",
-				Aliases:     []string{"d"},
-				EnvVars:     []string{"INFLUX_ORG_DESCRIPTION"},
+				EnvVar:      "INFLUX_ORG_DESCRIPTION",
 				Destination: &params.Description,
 			},
 		),
@@ -150,7 +142,7 @@ func newOrgUpdateCmd() *cli.Command {
 				CLI:              getCLI(ctx),
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 			}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/org_members.go
+++ b/cmd/influx/org_members.go
@@ -3,14 +3,14 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/org"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newOrgMembersCmd() *cli.Command {
-	return &cli.Command{
+func newOrgMembersCmd() cli.Command {
+	return cli.Command{
 		Name:  "members",
 		Usage: "Organization membership commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newOrgMembersAddCmd(),
 			newOrgMembersListCmd(),
 			newOrgMembersRemoveCmd(),
@@ -18,34 +18,31 @@ func newOrgMembersCmd() *cli.Command {
 	}
 }
 
-func newOrgMembersAddCmd() *cli.Command {
+func newOrgMembersAddCmd() cli.Command {
 	var params org.AddMemberParams
-	return &cli.Command{
+	return cli.Command{
 		Name:   "add",
 		Usage:  "Add organization member",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.GenericFlag{
-				Name:     "member",
+				Name:     "member, m",
 				Usage:    "The member ID",
-				Aliases:  []string{"m"},
 				Required: true,
 				Value:    &params.MemberId,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The organization name",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The organization ID",
-				Aliases: []string{"i"},
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &params.OrgID,
+				Name:   "id, i",
+				Usage:  "The organization ID",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &params.OrgID,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -53,14 +50,14 @@ func newOrgMembersAddCmd() *cli.Command {
 				CLI:              getCLI(ctx),
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 			}
-			return client.AddMember(ctx.Context, &params)
+			return client.AddMember(getContext(ctx), &params)
 		},
 	}
 }
 
-func newOrgMembersListCmd() *cli.Command {
+func newOrgMembersListCmd() cli.Command {
 	var params org.ListMemberParams
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Aliases: []string{"find", "ls"},
 		Usage:   "List organization members",
@@ -68,18 +65,16 @@ func newOrgMembersListCmd() *cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The organization name",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The organization ID",
-				Aliases: []string{"i"},
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &params.OrgID,
+				Name:   "id, i",
+				Usage:  "The organization ID",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &params.OrgID,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -88,39 +83,36 @@ func newOrgMembersListCmd() *cli.Command {
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 				UsersApi:         getAPI(ctx).UsersApi,
 			}
-			return client.ListMembers(ctx.Context, &params)
+			return client.ListMembers(getContext(ctx), &params)
 		},
 	}
 }
 
-func newOrgMembersRemoveCmd() *cli.Command {
+func newOrgMembersRemoveCmd() cli.Command {
 	var params org.RemoveMemberParams
-	return &cli.Command{
+	return cli.Command{
 		Name:   "remove",
 		Usage:  "Remove organization member",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.GenericFlag{
-				Name:     "member",
+				Name:     "member, m",
 				Usage:    "The member ID",
-				Aliases:  []string{"m"},
 				Required: true,
 				Value:    &params.MemberId,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The organization name",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The organization ID",
-				Aliases: []string{"i"},
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &params.OrgID,
+				Name:   "id, i",
+				Usage:  "The organization ID",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &params.OrgID,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -128,7 +120,7 @@ func newOrgMembersRemoveCmd() *cli.Command {
 				CLI:              getCLI(ctx),
 				OrganizationsApi: getAPI(ctx).OrganizationsApi,
 			}
-			return client.RemoveMember(ctx.Context, &params)
+			return client.RemoveMember(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/ping.go
+++ b/cmd/influx/ping.go
@@ -3,11 +3,11 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/ping"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newPingCmd() *cli.Command {
-	return &cli.Command{
+func newPingCmd() cli.Command {
+	return cli.Command{
 		Name:   "ping",
 		Usage:  "Check the InfluxDB /health endpoint",
 		Before: middleware.WithBeforeFns(withCli(), withApi(false)),
@@ -17,7 +17,7 @@ func newPingCmd() *cli.Command {
 				CLI:       getCLI(ctx),
 				HealthApi: getAPINoToken(ctx).HealthApi.OnlyOSS(),
 			}
-			return client.Ping(ctx.Context)
+			return client.Ping(getContext(ctx))
 		},
 	}
 }

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -7,12 +7,12 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients"
 	"github.com/influxdata/influx-cli/v2/clients/query"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newQueryCmd() *cli.Command {
+func newQueryCmd() cli.Command {
 	var orgParams clients.OrgParams
-	return &cli.Command{
+	return cli.Command{
 		Name:        "query",
 		Usage:       "Execute a Flux query",
 		Description: "Execute a Flux query provided via the first argument, a file, or stdin",
@@ -21,32 +21,28 @@ func newQueryCmd() *cli.Command {
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.GenericFlag{
-				Name:    "org-id",
-				Usage:   "The ID of the organization",
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &orgParams.OrgID,
+				Name:   "org-id",
+				Usage:  "The ID of the organization",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &orgParams.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &orgParams.OrgName,
 			},
 			&cli.StringFlag{
-				Name:    "file",
-				Usage:   "Path to Flux query file",
-				Aliases: []string{"f"},
+				Name:  "file, f",
+				Usage: "Path to Flux query file",
 			},
 			&cli.BoolFlag{
-				Name:    "raw",
-				Usage:   "Display raw query results",
-				Aliases: []string{"r"},
+				Name:  "raw, r",
+				Usage: "Display raw query results",
 			},
 			&cli.StringSliceFlag{
-				Name:    "profilers",
-				Usage:   "Names of Flux profilers to enable",
-				Aliases: []string{"p"},
+				Name:  "profilers, p",
+				Usage: "Names of Flux profilers to enable",
 			},
 		),
 		Action: func(ctx *cli.Context) error {
@@ -85,7 +81,7 @@ func newQueryCmd() *cli.Command {
 				QueryApi:      getAPI(ctx).QueryApi,
 				ResultPrinter: printer,
 			}
-			return client.Query(ctx.Context, &params)
+			return client.Query(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -33,8 +33,9 @@ func newQueryCmd() cli.Command {
 				Destination: &orgParams.OrgName,
 			},
 			&cli.StringFlag{
-				Name:  "file, f",
-				Usage: "Path to Flux query file",
+				Name:      "file, f",
+				Usage:     "Path to Flux query file",
+				TakesFile: true,
 			},
 			&cli.BoolFlag{
 				Name:  "raw, r",
@@ -46,7 +47,7 @@ func newQueryCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
-			queryString, err := clients.ReadQuery(ctx)
+			queryString, err := clients.ReadQuery(ctx.String("file"), ctx.Args())
 			if err != nil {
 				return err
 			}

--- a/cmd/influx/restore.go
+++ b/cmd/influx/restore.go
@@ -5,13 +5,13 @@ import (
 
 	"github.com/influxdata/influx-cli/v2/clients/restore"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newRestoreCmd() *cli.Command {
+func newRestoreCmd() cli.Command {
 	var params restore.Params
 
-	return &cli.Command{
+	return cli.Command{
 		Name:  "restore",
 		Usage: "Restores a backup directory to InfluxDB",
 		Description: `Restore influxdb.
@@ -32,14 +32,13 @@ Examples:
 			&cli.StringFlag{
 				Name:        "org-id",
 				Usage:       "The original ID of the organization to restore",
-				EnvVars:     []string{"INFLUX_ORG_ID"},
+				EnvVar:      "INFLUX_ORG_ID",
 				Destination: &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The original name of the organization to restore",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.Org,
 			},
 			&cli.StringFlag{
@@ -48,9 +47,8 @@ Examples:
 				Destination: &params.BucketID,
 			},
 			&cli.StringFlag{
-				Name:        "bucket",
+				Name:        "bucket, b",
 				Usage:       "The original name of the bucket to restore",
-				Aliases:     []string{"b"},
 				Destination: &params.Bucket,
 			},
 			&cli.StringFlag{
@@ -92,7 +90,7 @@ Examples:
 				RestoreApi:       api.RestoreApi.OnlyOSS(),
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Restore(ctx.Context, &params)
+			return client.Restore(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/secret.go
+++ b/cmd/influx/secret.go
@@ -3,14 +3,14 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/secret"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newSecretCommand() *cli.Command {
-	return &cli.Command{
+func newSecretCommand() cli.Command {
+	return cli.Command{
 		Name:  "secret",
 		Usage: "Secret management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newDeleteSecretCmd(),
 			newListSecretCmd(),
 			newUpdateSecretCmd(),
@@ -18,17 +18,16 @@ func newSecretCommand() *cli.Command {
 	}
 }
 
-func newDeleteSecretCmd() *cli.Command {
+func newDeleteSecretCmd() cli.Command {
 	var params secret.DeleteParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, &cli.StringFlag{
-		Name:        "key",
+		Name:        "key, k",
 		Usage:       "The secret key (required)",
 		Required:    true,
-		Aliases:     []string{"k"},
 		Destination: &params.Key,
 	})
-	return &cli.Command{
+	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete secret",
 		Flags:  flags,
@@ -40,15 +39,15 @@ func newDeleteSecretCmd() *cli.Command {
 				SecretsApi:       api.SecretsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Delete(ctx.Context, &params)
+			return client.Delete(getContext(ctx), &params)
 		},
 	}
 }
 
-func newListSecretCmd() *cli.Command {
+func newListSecretCmd() cli.Command {
 	var params secret.ListParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List secrets",
 		Aliases: []string{"find", "ls"},
@@ -61,30 +60,28 @@ func newListSecretCmd() *cli.Command {
 				SecretsApi:       api.SecretsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newUpdateSecretCmd() *cli.Command {
+func newUpdateSecretCmd() cli.Command {
 	var params secret.UpdateParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags,
 		&cli.StringFlag{
-			Name:        "key",
+			Name:        "key, k",
 			Usage:       "The secret key (required)",
 			Required:    true,
-			Aliases:     []string{"k"},
 			Destination: &params.Key,
 		},
 		&cli.StringFlag{
-			Name:        "value",
+			Name:        "value, v",
 			Usage:       "Optional secret value for scripting convenience, using this might expose the secret to your local history",
-			Aliases:     []string{"v"},
 			Destination: &params.Value,
 		},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "update",
 		Usage:  "Update secret",
 		Flags:  flags,
@@ -96,7 +93,7 @@ func newUpdateSecretCmd() *cli.Command {
 				SecretsApi:       api.SecretsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -3,66 +3,56 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/setup"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newSetupCmd() *cli.Command {
+func newSetupCmd() cli.Command {
 	var params setup.Params
-	return &cli.Command{
+	return cli.Command{
 		Name:   "setup",
 		Usage:  "Setup instance with initial user, org, bucket",
 		Before: middleware.WithBeforeFns(withCli(), withApi(false)),
 		Flags: append(
 			commonFlagsNoToken(),
 			&cli.StringFlag{
-				Name:        "username",
+				Name:        "username, u",
 				Usage:       "Name of initial user to create",
-				Aliases:     []string{"u"},
 				Destination: &params.Username,
 			},
 			&cli.StringFlag{
-				Name:        "password",
+				Name:        "password, p",
 				Usage:       "Password to set on initial user",
-				Aliases:     []string{"p"},
 				Destination: &params.Password,
 			},
 			&cli.StringFlag{
-				Name:        tokenFlagName,
+				Name:        tokenFlagName + ", t",
 				Usage:       "Auth token to set on the initial user",
-				Aliases:     []string{"t"},
-				EnvVars:     []string{"INFLUX_TOKEN"},
-				DefaultText: "auto-generated",
+				EnvVar:      "INFLUX_TOKEN",
 				Destination: &params.AuthToken,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "Name of initial organization to create",
-				Aliases:     []string{"o"},
 				Destination: &params.Org,
 			},
 			&cli.StringFlag{
-				Name:        "bucket",
+				Name:        "bucket, b",
 				Usage:       "Name of initial bucket to create",
-				Aliases:     []string{"b"},
 				Destination: &params.Bucket,
 			},
 			&cli.StringFlag{
-				Name:        "retention",
+				Name:        "retention, r",
 				Usage:       "Duration initial bucket will retain data, or 0 for infinite",
-				Aliases:     []string{"r"},
-				DefaultText: "infinite",
 				Destination: &params.Retention,
 			},
 			&cli.BoolFlag{
-				Name:        "force",
+				Name:        "force, f",
 				Usage:       "Skip confirmation prompt",
-				Aliases:     []string{"f"},
 				Destination: &params.Force,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "Name to set on CLI config generated for the InfluxDB instance, required if other configs exist",
-				Aliases:     []string{"n"},
 				Destination: &params.ConfigName,
 			},
 		),
@@ -71,7 +61,7 @@ func newSetupCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				SetupApi: getAPINoToken(ctx).SetupApi,
 			}
-			return client.Setup(ctx.Context, &params)
+			return client.Setup(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -4,16 +4,16 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients"
 	"github.com/influxdata/influx-cli/v2/clients/task"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 const TaskMaxPageSize = 500
 
-func newTaskCommand() *cli.Command {
-	return &cli.Command{
+func newTaskCommand() cli.Command {
+	return cli.Command{
 		Name:  "task",
 		Usage: "Task management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newTaskLogCmd(),
 			newTaskRunCmd(),
 			newTaskCreateCmd(),
@@ -25,16 +25,15 @@ func newTaskCommand() *cli.Command {
 	}
 }
 
-func newTaskCreateCmd() *cli.Command {
+func newTaskCreateCmd() cli.Command {
 	var params task.CreateParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, &cli.StringFlag{
-		Name:      "file",
+		Name:      "file, f",
 		Usage:     "Path to Flux script file",
-		Aliases:   []string{"f"},
 		TakesFile: true,
 	})
-	return &cli.Command{
+	return cli.Command{
 		Name:      "create",
 		Usage:     "Create a task with a Flux script provided via the first argument or a file or stdin.",
 		ArgsUsage: "[flux script or '-' for stdin]",
@@ -51,25 +50,23 @@ func newTaskCreateCmd() *cli.Command {
 			if err != nil {
 				return err
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskFindCmd() *cli.Command {
+func newTaskFindCmd() cli.Command {
 	var params task.FindParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, []cli.Flag{
 		&cli.StringFlag{
-			Name:        "id",
+			Name:        "id, i",
 			Usage:       "task ID",
-			Aliases:     []string{"i"},
 			Destination: &params.TaskID,
 		},
 		&cli.StringFlag{
-			Name:        "user-id",
+			Name:        "user-id, n",
 			Usage:       "task owner ID",
-			Aliases:     []string{"n"},
 			Destination: &params.UserID,
 		},
 		&cli.IntFlag{
@@ -79,7 +76,7 @@ func newTaskFindCmd() *cli.Command {
 			Value:       TaskMaxPageSize,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List tasks",
 		Aliases: []string{"find", "ls"},
@@ -91,19 +88,18 @@ func newTaskFindCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			return client.Find(ctx.Context, &params)
+			return client.Find(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskRetryFailedCmd() *cli.Command {
+func newTaskRetryFailedCmd() cli.Command {
 	var params task.RetryFailedParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, []cli.Flag{
 		&cli.StringFlag{
-			Name:        "id",
+			Name:        "id, i",
 			Usage:       "task ID",
-			Aliases:     []string{"i"},
 			Destination: &params.TaskID,
 		},
 		&cli.StringFlag{
@@ -134,7 +130,7 @@ func newTaskRetryFailedCmd() *cli.Command {
 			Value:       100,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:    "retry-failed",
 		Usage:   "Retry failed runs",
 		Aliases: []string{"rtf"},
@@ -146,19 +142,18 @@ func newTaskRetryFailedCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			return client.RetryFailed(ctx.Context, &params)
+			return client.RetryFailed(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskUpdateCmd() *cli.Command {
+func newTaskUpdateCmd() cli.Command {
 	var params task.UpdateParams
 	flags := commonFlags()
 	flags = append(flags, []cli.Flag{
 		&cli.StringFlag{
-			Name:        "id",
+			Name:        "id, i",
 			Usage:       "task ID (required)",
-			Aliases:     []string{"i"},
 			Destination: &params.TaskID,
 			Required:    true,
 		},
@@ -168,13 +163,12 @@ func newTaskUpdateCmd() *cli.Command {
 			Destination: &params.Status,
 		},
 		&cli.StringFlag{
-			Name:      "file",
+			Name:      "file, f",
 			Usage:     "Path to Flux script file",
-			Aliases:   []string{"f"},
 			TakesFile: true,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:      "update",
 		Usage:     "Update task status or script. Provide a Flux script via the first argument or a file.",
 		ArgsUsage: "[flux script or '-' for stdin]",
@@ -193,24 +187,23 @@ func newTaskUpdateCmd() *cli.Command {
 					return err
 				}
 			}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskDeleteCmd() *cli.Command {
+func newTaskDeleteCmd() cli.Command {
 	var params task.DeleteParams
 	flags := commonFlags()
 	flags = append(flags, []cli.Flag{
 		&cli.StringFlag{
-			Name:        "id",
+			Name:        "id, i",
 			Usage:       "task ID (required)",
-			Aliases:     []string{"i"},
 			Destination: &params.TaskID,
 			Required:    true,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete tasks",
 		Flags:  flags,
@@ -221,22 +214,22 @@ func newTaskDeleteCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			return client.Delete(ctx.Context, &params)
+			return client.Delete(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskLogCmd() *cli.Command {
-	return &cli.Command{
+func newTaskLogCmd() cli.Command {
+	return cli.Command{
 		Name:  "log",
 		Usage: "Log related commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newTaskLogFindCmd(),
 		},
 	}
 }
 
-func newTaskLogFindCmd() *cli.Command {
+func newTaskLogFindCmd() cli.Command {
 	var params task.LogFindParams
 	flags := commonFlags()
 	flags = append(flags, []cli.Flag{
@@ -252,7 +245,7 @@ func newTaskLogFindCmd() *cli.Command {
 			Destination: &params.RunID,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List logs for a task",
 		Aliases: []string{"find", "ls"},
@@ -264,23 +257,23 @@ func newTaskLogFindCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			return client.FindLogs(ctx.Context, &params)
+			return client.FindLogs(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskRunCmd() *cli.Command {
-	return &cli.Command{
+func newTaskRunCmd() cli.Command {
+	return cli.Command{
 		Name:  "run",
 		Usage: "Run related commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newTaskRunFindCmd(),
 			newTaskRunRetryCmd(),
 		},
 	}
 }
 
-func newTaskRunFindCmd() *cli.Command {
+func newTaskRunFindCmd() cli.Command {
 	var params task.RunFindParams
 	flags := commonFlags()
 	flags = append(flags, []cli.Flag{
@@ -312,7 +305,7 @@ func newTaskRunFindCmd() *cli.Command {
 			Value:       100,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List runs for a tasks",
 		Aliases: []string{"find", "ls"},
@@ -324,31 +317,29 @@ func newTaskRunFindCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			return client.FindRuns(ctx.Context, &params)
+			return client.FindRuns(getContext(ctx), &params)
 		},
 	}
 }
 
-func newTaskRunRetryCmd() *cli.Command {
+func newTaskRunRetryCmd() cli.Command {
 	var params task.RunRetryParams
 	flags := commonFlags()
 	flags = append(flags, []cli.Flag{
 		&cli.StringFlag{
-			Name:        "task-id",
+			Name:        "task-id, i",
 			Usage:       "task ID (required)",
-			Aliases:     []string{"i"},
 			Destination: &params.TaskID,
 			Required:    true,
 		},
 		&cli.StringFlag{
-			Name:        "run-id",
+			Name:        "run-id, r",
 			Usage:       "run ID (required)",
-			Aliases:     []string{"r"},
 			Destination: &params.RunID,
 			Required:    true,
 		},
 	}...)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "retry",
 		Usage:  "Retry a run",
 		Flags:  flags,
@@ -359,7 +350,7 @@ func newTaskRunRetryCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			return client.RetryRun(ctx.Context, &params)
+			return client.RetryRun(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -46,7 +46,7 @@ func newTaskCreateCmd() cli.Command {
 				TasksApi: api.TasksApi,
 			}
 			var err error
-			params.FluxQuery, err = clients.ReadQuery(ctx)
+			params.FluxQuery, err = clients.ReadQuery(ctx.String("file"), ctx.Args())
 			if err != nil {
 				return err
 			}
@@ -182,7 +182,7 @@ func newTaskUpdateCmd() cli.Command {
 			}
 			var err error
 			if ctx.String("file") != "" || ctx.NArg() != 0 {
-				params.FluxQuery, err = clients.ReadQuery(ctx)
+				params.FluxQuery, err = clients.ReadQuery(ctx.String("file"), ctx.Args())
 				if err != nil {
 					return err
 				}

--- a/cmd/influx/telegrafs.go
+++ b/cmd/influx/telegrafs.go
@@ -7,19 +7,18 @@ import (
 
 	"github.com/influxdata/influx-cli/v2/clients/telegrafs"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newTelegrafsCommand() *cli.Command {
+func newTelegrafsCommand() cli.Command {
 	var params telegrafs.ListParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, &cli.StringFlag{
-		Name:        "id",
+		Name:        "id, i",
 		Usage:       "Telegraf configuration ID to retrieve",
-		Aliases:     []string{"i"},
 		Destination: &params.Id,
 	})
-	return &cli.Command{
+	return cli.Command{
 		Name:  "telegrafs",
 		Usage: "List Telegraf configuration(s). Subcommands manage Telegraf configurations.",
 		Description: `List Telegraf configuration(s). Subcommands manage Telegraf configurations.
@@ -34,7 +33,7 @@ Examples:
 	# list Telegraf configuration corresponding to specific ID shorts
 	influx telegrafs -i $ID
 `,
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newCreateTelegrafCmd(),
 			newRemoveTelegrafCmd(),
 			newUpdateTelegrafCmd(),
@@ -48,34 +47,31 @@ Examples:
 				TelegrafsApi:     api.TelegrafsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newCreateTelegrafCmd() *cli.Command {
+func newCreateTelegrafCmd() cli.Command {
 	var params telegrafs.CreateParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags,
 		&cli.StringFlag{
-			Name:        "description",
+			Name:        "description, d",
 			Usage:       "Description for Telegraf configuration",
-			Aliases:     []string{"d"},
 			Destination: &params.Desc,
 		},
 		&cli.StringFlag{
-			Name:    "file",
-			Usage:   "Path to Telegraf configuration",
-			Aliases: []string{"f"},
+			Name:  "file, f",
+			Usage: "Path to Telegraf configuration",
 		},
 		&cli.StringFlag{
-			Name:        "name",
+			Name:        "name, n",
 			Usage:       "Name of Telegraf configuration",
-			Aliases:     []string{"n"},
 			Destination: &params.Name,
 		},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:  "create",
 		Usage: "The telegrafs create command creates a new Telegraf configuration.",
 		Description: `The telegrafs create command creates a new Telegraf configuration.
@@ -104,24 +100,23 @@ Examples:
 				TelegrafsApi:     api.TelegrafsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newRemoveTelegrafCmd() *cli.Command {
+func newRemoveTelegrafCmd() cli.Command {
 	var params telegrafs.RemoveParams
 	flags := commonFlags()
 	flags = append(flags,
 		&cli.StringSliceFlag{
-			Name:    "id",
-			Usage:   "Telegraf configuration ID(s) to remove",
-			Aliases: []string{"i"},
+			Name:  "id, i",
+			Usage: "Telegraf configuration ID(s) to remove",
 		},
 		&cli.StringFlag{Name: "org", Hidden: true},
 		&cli.StringFlag{Name: "org-id", Hidden: true},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:  "rm",
 		Usage: "The telegrafs rm command removes Telegraf configuration(s).",
 		Description: `The telegrafs rm command removes Telegraf configuration(s).
@@ -149,42 +144,38 @@ Examples:
 				TelegrafsApi:     api.TelegrafsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Remove(ctx.Context, &params)
+			return client.Remove(getContext(ctx), &params)
 		},
 	}
 }
 
-func newUpdateTelegrafCmd() *cli.Command {
+func newUpdateTelegrafCmd() cli.Command {
 	var params telegrafs.UpdateParams
 	flags := commonFlags()
 	flags = append(flags,
 		&cli.StringFlag{
-			Name:        "description",
+			Name:        "description, d",
 			Usage:       "Description for Telegraf configuration",
-			Aliases:     []string{"d"},
 			Destination: &params.Desc,
 		},
 		&cli.StringFlag{
-			Name:    "file",
-			Usage:   "Path to Telegraf configuration",
-			Aliases: []string{"f"},
+			Name:  "file, f",
+			Usage: "Path to Telegraf configuration",
 		},
 		&cli.StringFlag{
-			Name:        "name",
+			Name:        "name, n",
 			Usage:       "Name of Telegraf configuration",
-			Aliases:     []string{"n"},
 			Destination: &params.Name,
 		},
 		&cli.StringFlag{
-			Name:        "id",
+			Name:        "id, i",
 			Usage:       "Telegraf configuration ID to retrieve",
-			Aliases:     []string{"i"},
 			Destination: &params.Id,
 		},
 		&cli.StringFlag{Name: "org", Hidden: true},
 		&cli.StringFlag{Name: "org-id", Hidden: true},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:  "update",
 		Usage: "Update a Telegraf configuration.",
 		Description: `The telegrafs update command updates a Telegraf configuration to match the
@@ -215,7 +206,7 @@ Examples:
 				TelegrafsApi:     api.TelegrafsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -4,14 +4,14 @@ import (
 	"github.com/influxdata/influx-cli/v2/clients/user"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/influxdata/influx-cli/v2/pkg/influxid"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newUserCmd() *cli.Command {
-	return &cli.Command{
+func newUserCmd() cli.Command {
+	return cli.Command{
 		Name:  "user",
 		Usage: "User management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newUserCreateCmd(),
 			newUserDeleteCmd(),
 			newUserListCmd(),
@@ -21,38 +21,35 @@ func newUserCmd() *cli.Command {
 	}
 }
 
-func newUserCreateCmd() *cli.Command {
+func newUserCreateCmd() cli.Command {
 	var params user.CreateParams
-	return &cli.Command{
+	return cli.Command{
 		Name:  "create",
 		Usage: "Create user",
 		Flags: append(
 			commonFlags(),
 			&cli.GenericFlag{
-				Name:    "org-id",
-				Usage:   "The ID of the organization",
-				EnvVars: []string{"INFLUX_ORG_ID"},
-				Value:   &params.OrgID,
+				Name:   "org-id",
+				Usage:  "The ID of the organization",
+				EnvVar: "INFLUX_ORG_ID",
+				Value:  &params.OrgID,
 			},
 			&cli.StringFlag{
-				Name:        "org",
+				Name:        "org, o",
 				Usage:       "The name of the organization",
-				Aliases:     []string{"o"},
-				EnvVars:     []string{"INFLUX_ORG"},
+				EnvVar:      "INFLUX_ORG",
 				Destination: &params.OrgName,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The user name",
-				Aliases:     []string{"n"},
-				EnvVars:     []string{"INFLUX_NAME"},
+				EnvVar:      "INFLUX_NAME",
 				Required:    true,
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
-				Name:        "password",
+				Name:        "password, p",
 				Usage:       "The user password",
-				Aliases:     []string{"p"},
 				Destination: &params.Password,
 			},
 		),
@@ -64,22 +61,21 @@ func newUserCreateCmd() *cli.Command {
 				UsersApi:         api.UsersApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newUserDeleteCmd() *cli.Command {
+func newUserDeleteCmd() cli.Command {
 	var id influxid.ID
-	return &cli.Command{
+	return cli.Command{
 		Name:  "delete",
 		Usage: "Delete user",
 		Flags: append(
 			commonFlags(),
 			&cli.GenericFlag{
-				Name:     "id",
+				Name:     "id, i",
 				Usage:    "The user ID",
-				Aliases:  []string{"i"},
 				Required: true,
 				Value:    &id,
 			},
@@ -87,91 +83,85 @@ func newUserDeleteCmd() *cli.Command {
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
 			client := user.Client{CLI: getCLI(ctx), UsersApi: getAPI(ctx).UsersApi}
-			return client.Delete(ctx.Context, id)
+			return client.Delete(getContext(ctx), id)
 		},
 	}
 }
 
-func newUserListCmd() *cli.Command {
+func newUserListCmd() cli.Command {
 	var params user.ListParams
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Aliases: []string{"find", "ls"},
 		Usage:   "List users",
 		Flags: append(
 			commonFlags(),
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The user ID",
-				Aliases: []string{"i"},
-				Value:   &params.Id,
+				Name:  "id, i",
+				Usage: "The user ID",
+				Value: &params.Id,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The user name",
-				Aliases:     []string{"n"},
 				Destination: &params.Name,
 			},
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
 			client := user.Client{CLI: getCLI(ctx), UsersApi: getAPI(ctx).UsersApi}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newUserUpdateCmd() *cli.Command {
+func newUserUpdateCmd() cli.Command {
 	var params user.UpdateParmas
-	return &cli.Command{
+	return cli.Command{
 		Name: "update",
 		Flags: append(
 			commonFlags(),
 			&cli.GenericFlag{
-				Name:     "id",
+				Name:     "id, i",
 				Usage:    "The user ID",
-				Aliases:  []string{"i"},
 				Required: true,
 				Value:    &params.Id,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The user name",
-				Aliases:     []string{"n"},
 				Destination: &params.Name,
 			},
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
 			client := user.Client{CLI: getCLI(ctx), UsersApi: getAPI(ctx).UsersApi}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }
 
-func newUserSetPasswordCmd() *cli.Command {
+func newUserSetPasswordCmd() cli.Command {
 	var params user.SetPasswordParams
-	return &cli.Command{
+	return cli.Command{
 		Name: "password",
 		Flags: append(
 			commonFlagsNoPrint(),
 			&cli.GenericFlag{
-				Name:    "id",
-				Usage:   "The user ID",
-				Aliases: []string{"i"},
-				Value:   &params.Id,
+				Name:  "id, i",
+				Usage: "The user ID",
+				Value: &params.Id,
 			},
 			&cli.StringFlag{
-				Name:        "name",
+				Name:        "name, n",
 				Usage:       "The user name",
-				Aliases:     []string{"n"},
 				Destination: &params.Name,
 			},
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
 			client := user.Client{CLI: getCLI(ctx), UsersApi: getAPI(ctx).UsersApi}
-			return client.SetPassword(ctx.Context, &params)
+			return client.SetPassword(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/v1_auth.go
+++ b/cmd/influx/v1_auth.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/influxdata/influx-cli/v2/clients/v1_auth"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 // getAuthLookupFlags returns flags used for authorization, requiring either an ID or Username,
@@ -23,12 +23,12 @@ func getAuthLookupFlags(params *v1_auth.AuthLookupParams) []cli.Flag {
 	}
 }
 
-func newV1AuthCommand() *cli.Command {
-	return &cli.Command{
+func newV1AuthCommand() cli.Command {
+	return cli.Command{
 		Name:    "auth",
 		Usage:   "Authorization management commands for v1 APIs",
 		Aliases: []string{"authorization"},
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newCreateV1AuthCmd(),
 			newRemoveV1AuthCmd(),
 			newListV1AuthCmd(),
@@ -39,14 +39,13 @@ func newV1AuthCommand() *cli.Command {
 	}
 }
 
-func newCreateV1AuthCmd() *cli.Command {
+func newCreateV1AuthCmd() cli.Command {
 	var params v1_auth.CreateParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags,
-		&cli.StringFlag{
-			Name:        "description",
+		cli.StringFlag{
+			Name:        "description, d",
 			Usage:       "Token description",
-			Aliases:     []string{"d"},
 			Destination: &params.Desc,
 		},
 		&cli.StringFlag{
@@ -74,7 +73,7 @@ func newCreateV1AuthCmd() *cli.Command {
 			Usage: "The bucket id",
 		},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "create",
 		Usage:  "Create authorization",
 		Flags:  flags,
@@ -89,15 +88,15 @@ func newCreateV1AuthCmd() *cli.Command {
 				UsersApi:                api.UsersApi,
 				OrganizationsApi:        api.OrganizationsApi,
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newRemoveV1AuthCmd() *cli.Command {
+func newRemoveV1AuthCmd() cli.Command {
 	var params v1_auth.RemoveParams
 	flags := append(commonFlags(), getAuthLookupFlags(&params.AuthLookupParams)...)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete authorization",
 		Flags:  flags,
@@ -114,20 +113,19 @@ func newRemoveV1AuthCmd() *cli.Command {
 				UsersApi:                api.UsersApi,
 				OrganizationsApi:        api.OrganizationsApi,
 			}
-			return client.Remove(ctx.Context, &params)
+			return client.Remove(getContext(ctx), &params)
 		},
 	}
 }
 
-func newListV1AuthCmd() *cli.Command {
+func newListV1AuthCmd() cli.Command {
 	var params v1_auth.ListParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 	flags = append(flags, getAuthLookupFlags(&params.AuthLookupParams)...)
 	flags = append(flags,
 		&cli.StringFlag{
-			Name:        "user",
+			Name:        "user, u",
 			Usage:       "The user",
-			Aliases:     []string{"u"},
 			Destination: &params.User,
 		},
 		&cli.StringFlag{
@@ -136,7 +134,7 @@ func newListV1AuthCmd() *cli.Command {
 			Destination: &params.UserID,
 		},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List authorizations",
 		Aliases: []string{"ls", "find"},
@@ -150,15 +148,15 @@ func newListV1AuthCmd() *cli.Command {
 				UsersApi:                api.UsersApi,
 				OrganizationsApi:        api.OrganizationsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newSetActiveV1AuthCmd() *cli.Command {
+func newSetActiveV1AuthCmd() cli.Command {
 	var params v1_auth.ActiveParams
 	flags := append(commonFlags(), getAuthLookupFlags(&params.AuthLookupParams)...)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "set-active",
 		Usage:  "Change the status of an authorization to active",
 		Flags:  flags,
@@ -175,15 +173,15 @@ func newSetActiveV1AuthCmd() *cli.Command {
 				UsersApi:                api.UsersApi,
 				OrganizationsApi:        api.OrganizationsApi,
 			}
-			return client.SetActive(ctx.Context, &params, true)
+			return client.SetActive(getContext(ctx), &params, true)
 		},
 	}
 }
 
-func newSetInactiveV1AuthCmd() *cli.Command {
+func newSetInactiveV1AuthCmd() cli.Command {
 	var params v1_auth.ActiveParams
 	flags := append(commonFlags(), getAuthLookupFlags(&params.AuthLookupParams)...)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "set-inactive",
 		Usage:  "Change the status of an authorization to inactive",
 		Flags:  flags,
@@ -200,12 +198,12 @@ func newSetInactiveV1AuthCmd() *cli.Command {
 				UsersApi:                api.UsersApi,
 				OrganizationsApi:        api.OrganizationsApi,
 			}
-			return client.SetActive(ctx.Context, &params, false)
+			return client.SetActive(getContext(ctx), &params, false)
 		},
 	}
 }
 
-func newSetPswdV1AuthCmd() *cli.Command {
+func newSetPswdV1AuthCmd() cli.Command {
 	var params v1_auth.SetPasswordParams
 	flags := append(coreFlags(), commonTokenFlag())
 	flags = append(flags, getAuthLookupFlags(&params.AuthLookupParams)...)
@@ -216,7 +214,7 @@ func newSetPswdV1AuthCmd() *cli.Command {
 			Destination: &params.Password,
 		},
 	)
-	return &cli.Command{
+	return cli.Command{
 		Name:   "set-password",
 		Usage:  "Set a password for an existing authorization",
 		Flags:  flags,
@@ -227,7 +225,7 @@ func newSetPswdV1AuthCmd() *cli.Command {
 				CLI:                     getCLI(ctx),
 				LegacyAuthorizationsApi: api.LegacyAuthorizationsApi,
 			}
-			return client.SetPassword(ctx.Context, &params)
+			return client.SetPassword(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/v1_commands.go
+++ b/cmd/influx/v1_commands.go
@@ -1,12 +1,12 @@
 package main
 
-import "github.com/urfave/cli/v2"
+import "github.com/urfave/cli"
 
-func newV1SubCommand() *cli.Command {
-	return &cli.Command{
+func newV1SubCommand() cli.Command {
+	return cli.Command{
 		Name:  "v1",
 		Usage: "InfluxDB v1 management commands",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newV1DBRPCmd(),
 			newV1AuthCommand(),
 		},

--- a/cmd/influx/v1_dbrp.go
+++ b/cmd/influx/v1_dbrp.go
@@ -3,14 +3,14 @@ package main
 import (
 	v1dbrps "github.com/influxdata/influx-cli/v2/clients/v1_dbrps"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newV1DBRPCmd() *cli.Command {
-	return &cli.Command{
+func newV1DBRPCmd() cli.Command {
+	return cli.Command{
 		Name:  "dbrp",
 		Usage: "Commands to manage database and retention policy mappings for v1 APIs",
-		Subcommands: []*cli.Command{
+		Subcommands: []cli.Command{
 			newV1DBRPListCmd(),
 			newV1DBRPCreateCmd(),
 			newV1DBRPDeleteCmd(),
@@ -19,11 +19,11 @@ func newV1DBRPCmd() *cli.Command {
 	}
 }
 
-func newV1DBRPListCmd() *cli.Command {
+func newV1DBRPListCmd() cli.Command {
 	var params v1dbrps.ListParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 
-	return &cli.Command{
+	return cli.Command{
 		Name:    "list",
 		Usage:   "List database and retention policy mappings",
 		Aliases: []string{"find", "ls"},
@@ -62,16 +62,16 @@ func newV1DBRPListCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				DBRPsApi: api.DBRPsApi,
 			}
-			return client.List(ctx.Context, &params)
+			return client.List(getContext(ctx), &params)
 		},
 	}
 }
 
-func newV1DBRPCreateCmd() *cli.Command {
+func newV1DBRPCreateCmd() cli.Command {
 	var params v1dbrps.CreateParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 
-	return &cli.Command{
+	return cli.Command{
 		Name:  "create",
 		Usage: "Create a database and retention policy mapping to an existing bucket",
 		Flags: append(
@@ -108,16 +108,16 @@ func newV1DBRPCreateCmd() *cli.Command {
 				DBRPsApi:         api.DBRPsApi,
 				OrganizationsApi: api.OrganizationsApi,
 			}
-			return client.Create(ctx.Context, &params)
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }
 
-func newV1DBRPDeleteCmd() *cli.Command {
+func newV1DBRPDeleteCmd() cli.Command {
 	var params v1dbrps.DeleteParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 
-	return &cli.Command{
+	return cli.Command{
 		Name:  "delete",
 		Usage: "Delete a database and retention policy mapping",
 		Flags: append(
@@ -136,16 +136,16 @@ func newV1DBRPDeleteCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				DBRPsApi: api.DBRPsApi,
 			}
-			return client.Delete(ctx.Context, &params)
+			return client.Delete(getContext(ctx), &params)
 		},
 	}
 }
 
-func newV1DBRPUpdateCmd() *cli.Command {
+func newV1DBRPUpdateCmd() cli.Command {
 	var params v1dbrps.UpdateParams
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 
-	return &cli.Command{
+	return cli.Command{
 		Name:  "update",
 		Usage: "Update a database and retention policy mapping",
 		Flags: append(
@@ -174,7 +174,7 @@ func newV1DBRPUpdateCmd() *cli.Command {
 				CLI:      getCLI(ctx),
 				DBRPsApi: api.DBRPsApi,
 			}
-			return client.Update(ctx.Context, &params)
+			return client.Update(getContext(ctx), &params)
 		},
 	}
 }

--- a/cmd/influx/version.go
+++ b/cmd/influx/version.go
@@ -3,11 +3,11 @@ package main
 import (
 	"fmt"
 
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
-func newVersionCmd() *cli.Command {
-	return &cli.Command{
+func newVersionCmd() cli.Command {
+	return cli.Command{
 		Name:  "version",
 		Usage: "Print the influx CLI version",
 		Action: func(*cli.Context) error {

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/mattn/go-isatty v0.0.13
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/urfave/cli/v2 v2.3.0
+	github.com/urfave/cli v1.22.5
 	golang.org/x/text v0.3.3
 	golang.org/x/tools v0.1.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c

--- a/go.sum
+++ b/go.sum
@@ -66,8 +66,8 @@ github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
-github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
+github.com/urfave/cli v1.22.5 h1:lNq9sAHXK2qfdI8W+GRItjCEkI+2oR4d+MEHy1CKXoU=
+github.com/urfave/cli v1.22.5/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -109,7 +109,6 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/cli/middleware/middleware.go
+++ b/pkg/cli/middleware/middleware.go
@@ -1,7 +1,7 @@
 package middleware
 
 import (
-	"github.com/urfave/cli/v2"
+	"github.com/urfave/cli"
 )
 
 // WithBeforeFns returns a cli.BeforeFunc that calls each of the provided


### PR DESCRIPTION
Closes #147

I've confirmed that rebasing #150 onto this branch fixes the breaking change (I can pass the stack ID before or after the `-f` flag).