### PR TITLE
fix: correct mismatches between template-apply spec and impl

### DIFF
--- a/api/contract/overrides/schemas/TemplateApply.yml
+++ b/api/contract/overrides/schemas/TemplateApply.yml
@@ -14,7 +14,8 @@ properties:
       $ref: "./TemplateApplyTemplate.yml"
   envRefs:
     type: object
-    additionalProperties: true
+    additionalProperties:
+      type: string
   secrets:
     type: object
     additionalProperties:
@@ -27,4 +28,4 @@ properties:
     type: array
     items:
       $ref: "./TemplateApplyAction.yml"
-required: [dryRun, orgID, templates, remotes, actions]
+required: [dryRun, orgID, templates, envRefs, secrets, remotes, actions]

--- a/api/contract/overrides/schemas/TemplateApplyTemplate.yml
+++ b/api/contract/overrides/schemas/TemplateApplyTemplate.yml
@@ -6,4 +6,6 @@ properties:
       type: string
   contents:
     $ref: "./Template.yml"
-required: [sources, contents]
+  contentType:
+    type: string
+required: [sources, contents, contentType]

--- a/api/contract/overrides/schemas/TemplateEntry.yml
+++ b/api/contract/overrides/schemas/TemplateEntry.yml
@@ -4,7 +4,7 @@ properties:
     type: string
   kind:
     type: string
-  meta:
+  metadata:
     type: object
     properties:
       name:
@@ -12,4 +12,4 @@ properties:
     required: [name]
   spec:
     type: object
-required: [apiVersion, kind, meta, spec]
+required: [apiVersion, kind, metadata, spec]

--- a/api/contract/overrides/schemas/TemplateSummaryBucket.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryBucket.yml
@@ -3,7 +3,9 @@ allOf:
   - type: object
     properties:
       id:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: string
       description:
@@ -12,5 +14,4 @@ allOf:
         type: integer
       schemaType:
         type: string
-
     required: [id, name, retentionPeriod]

--- a/api/contract/overrides/schemas/TemplateSummaryCheck.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryCheck.yml
@@ -3,7 +3,9 @@ allOf:
   - type: object
     properties:
       id:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: string
       description:

--- a/api/contract/overrides/schemas/TemplateSummaryDashboard.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDashboard.yml
@@ -3,7 +3,9 @@ allOf:
   - type: object
     properties:
       id:
-        type: "string"
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: "string"
       description:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffBucket.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffBucket.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffCheck.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffCheck.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffDashboard.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffDashboard.yml
@@ -3,7 +3,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   kind:
     type: string
   templateMetaName:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffLabel.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffLabel.yml
@@ -5,7 +5,9 @@ properties:
   kind:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffNotificationEndpoint.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffNotificationEndpoint.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffNotificationRule.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffNotificationRule.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffNotificationRuleFields.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffNotificationRuleFields.yml
@@ -7,7 +7,9 @@ properties:
   endpointName:
     type: string
   endpointID:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   endpointType:
     type: string
   every:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffTask.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffTask.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffTelegraf.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffTelegraf.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryDiffVariable.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryDiffVariable.yml
@@ -5,7 +5,9 @@ properties:
   stateStatus:
     type: string
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   templateMetaName:
     type: string
   new:

--- a/api/contract/overrides/schemas/TemplateSummaryLabel.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryLabel.yml
@@ -3,9 +3,13 @@ allOf:
   - type: object
     properties:
       id:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       orgID:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: string
       properties:

--- a/api/contract/overrides/schemas/TemplateSummaryLabelMapping.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryLabelMapping.yml
@@ -7,7 +7,9 @@ properties:
   resourceName:
     type: string
   resourceID:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   resourceType:
     type: string
   labelTemplateMetaName:
@@ -15,7 +17,9 @@ properties:
   labelName:
     type: string
   labelID:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
 required:
   - status
   - resourceTemplateMetaName

--- a/api/contract/overrides/schemas/TemplateSummaryNotificationEndpoint.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryNotificationEndpoint.yml
@@ -3,7 +3,9 @@ allOf:
   - type: object
     properties:
       id:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: string
       description:

--- a/api/contract/overrides/schemas/TemplateSummaryNotificationRule.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryNotificationRule.yml
@@ -9,7 +9,9 @@ allOf:
       endpointTemplateMetaName:
         type: string
       endpointID:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       endpointType:
         type: string
       every:

--- a/api/contract/overrides/schemas/TemplateSummaryTask.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryTask.yml
@@ -3,7 +3,9 @@ allOf:
   - type: object
     properties:
       id:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: string
       description:

--- a/api/contract/overrides/schemas/TemplateSummaryTelegrafConfig.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryTelegrafConfig.yml
@@ -1,7 +1,9 @@
 type: object
 properties:
   id:
-    type: string
+    type: integer
+    format: int64
+    x-go-field-type: uint64
   name:
     type: string
   description:

--- a/api/contract/overrides/schemas/TemplateSummaryVariable.yml
+++ b/api/contract/overrides/schemas/TemplateSummaryVariable.yml
@@ -3,7 +3,9 @@ allOf:
   - type: object
     properties:
       id:
-        type: string
+        type: integer
+        format: int64
+        x-go-field-type: uint64
       name:
         type: string
       description:

--- a/api/model_template_apply.gen.go
+++ b/api/model_template_apply.gen.go
@@ -16,26 +16,28 @@ import (
 
 // TemplateApply struct for TemplateApply
 type TemplateApply struct {
-	DryRun    bool                               `json:"dryRun" yaml:"dryRun"`
-	OrgID     string                             `json:"orgID" yaml:"orgID"`
-	StackID   *string                            `json:"stackID,omitempty" yaml:"stackID,omitempty"`
-	Template  *TemplateApplyTemplate             `json:"template,omitempty" yaml:"template,omitempty"`
-	Templates []TemplateApplyTemplate            `json:"templates" yaml:"templates"`
-	EnvRefs   *map[string]map[string]interface{} `json:"envRefs,omitempty" yaml:"envRefs,omitempty"`
-	Secrets   *map[string]string                 `json:"secrets,omitempty" yaml:"secrets,omitempty"`
-	Remotes   []TemplateApplyRemoteRef           `json:"remotes" yaml:"remotes"`
-	Actions   []TemplateApplyAction              `json:"actions" yaml:"actions"`
+	DryRun    bool                     `json:"dryRun" yaml:"dryRun"`
+	OrgID     string                   `json:"orgID" yaml:"orgID"`
+	StackID   *string                  `json:"stackID,omitempty" yaml:"stackID,omitempty"`
+	Template  *TemplateApplyTemplate   `json:"template,omitempty" yaml:"template,omitempty"`
+	Templates []TemplateApplyTemplate  `json:"templates" yaml:"templates"`
+	EnvRefs   map[string]string        `json:"envRefs" yaml:"envRefs"`
+	Secrets   map[string]string        `json:"secrets" yaml:"secrets"`
+	Remotes   []TemplateApplyRemoteRef `json:"remotes" yaml:"remotes"`
+	Actions   []TemplateApplyAction    `json:"actions" yaml:"actions"`
 }
 
 // NewTemplateApply instantiates a new TemplateApply object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateApply(dryRun bool, orgID string, templates []TemplateApplyTemplate, remotes []TemplateApplyRemoteRef, actions []TemplateApplyAction) *TemplateApply {
+func NewTemplateApply(dryRun bool, orgID string, templates []TemplateApplyTemplate, envRefs map[string]string, secrets map[string]string, remotes []TemplateApplyRemoteRef, actions []TemplateApplyAction) *TemplateApply {
 	this := TemplateApply{}
 	this.DryRun = dryRun
 	this.OrgID = orgID
 	this.Templates = templates
+	this.EnvRefs = envRefs
+	this.Secrets = secrets
 	this.Remotes = remotes
 	this.Actions = actions
 	return &this
@@ -185,68 +187,52 @@ func (o *TemplateApply) SetTemplates(v []TemplateApplyTemplate) {
 	o.Templates = v
 }
 
-// GetEnvRefs returns the EnvRefs field value if set, zero value otherwise.
-func (o *TemplateApply) GetEnvRefs() map[string]map[string]interface{} {
-	if o == nil || o.EnvRefs == nil {
-		var ret map[string]map[string]interface{}
-		return ret
-	}
-	return *o.EnvRefs
-}
-
-// GetEnvRefsOk returns a tuple with the EnvRefs field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *TemplateApply) GetEnvRefsOk() (*map[string]map[string]interface{}, bool) {
-	if o == nil || o.EnvRefs == nil {
-		return nil, false
-	}
-	return o.EnvRefs, true
-}
-
-// HasEnvRefs returns a boolean if a field has been set.
-func (o *TemplateApply) HasEnvRefs() bool {
-	if o != nil && o.EnvRefs != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetEnvRefs gets a reference to the given map[string]map[string]interface{} and assigns it to the EnvRefs field.
-func (o *TemplateApply) SetEnvRefs(v map[string]map[string]interface{}) {
-	o.EnvRefs = &v
-}
-
-// GetSecrets returns the Secrets field value if set, zero value otherwise.
-func (o *TemplateApply) GetSecrets() map[string]string {
-	if o == nil || o.Secrets == nil {
+// GetEnvRefs returns the EnvRefs field value
+func (o *TemplateApply) GetEnvRefs() map[string]string {
+	if o == nil {
 		var ret map[string]string
 		return ret
 	}
-	return *o.Secrets
+
+	return o.EnvRefs
 }
 
-// GetSecretsOk returns a tuple with the Secrets field value if set, nil otherwise
+// GetEnvRefsOk returns a tuple with the EnvRefs field value
 // and a boolean to check if the value has been set.
-func (o *TemplateApply) GetSecretsOk() (*map[string]string, bool) {
-	if o == nil || o.Secrets == nil {
+func (o *TemplateApply) GetEnvRefsOk() (*map[string]string, bool) {
+	if o == nil {
 		return nil, false
 	}
-	return o.Secrets, true
+	return &o.EnvRefs, true
 }
 
-// HasSecrets returns a boolean if a field has been set.
-func (o *TemplateApply) HasSecrets() bool {
-	if o != nil && o.Secrets != nil {
-		return true
+// SetEnvRefs sets field value
+func (o *TemplateApply) SetEnvRefs(v map[string]string) {
+	o.EnvRefs = v
+}
+
+// GetSecrets returns the Secrets field value
+func (o *TemplateApply) GetSecrets() map[string]string {
+	if o == nil {
+		var ret map[string]string
+		return ret
 	}
 
-	return false
+	return o.Secrets
 }
 
-// SetSecrets gets a reference to the given map[string]string and assigns it to the Secrets field.
+// GetSecretsOk returns a tuple with the Secrets field value
+// and a boolean to check if the value has been set.
+func (o *TemplateApply) GetSecretsOk() (*map[string]string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.Secrets, true
+}
+
+// SetSecrets sets field value
 func (o *TemplateApply) SetSecrets(v map[string]string) {
-	o.Secrets = &v
+	o.Secrets = v
 }
 
 // GetRemotes returns the Remotes field value
@@ -314,10 +300,10 @@ func (o TemplateApply) MarshalJSON() ([]byte, error) {
 	if true {
 		toSerialize["templates"] = o.Templates
 	}
-	if o.EnvRefs != nil {
+	if true {
 		toSerialize["envRefs"] = o.EnvRefs
 	}
-	if o.Secrets != nil {
+	if true {
 		toSerialize["secrets"] = o.Secrets
 	}
 	if true {

--- a/api/model_template_apply_template.gen.go
+++ b/api/model_template_apply_template.gen.go
@@ -16,18 +16,20 @@ import (
 
 // TemplateApplyTemplate struct for TemplateApplyTemplate
 type TemplateApplyTemplate struct {
-	Sources  []string        `json:"sources" yaml:"sources"`
-	Contents []TemplateEntry `json:"contents" yaml:"contents"`
+	Sources     []string        `json:"sources" yaml:"sources"`
+	Contents    []TemplateEntry `json:"contents" yaml:"contents"`
+	ContentType string          `json:"contentType" yaml:"contentType"`
 }
 
 // NewTemplateApplyTemplate instantiates a new TemplateApplyTemplate object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateApplyTemplate(sources []string, contents []TemplateEntry) *TemplateApplyTemplate {
+func NewTemplateApplyTemplate(sources []string, contents []TemplateEntry, contentType string) *TemplateApplyTemplate {
 	this := TemplateApplyTemplate{}
 	this.Sources = sources
 	this.Contents = contents
+	this.ContentType = contentType
 	return &this
 }
 
@@ -87,6 +89,30 @@ func (o *TemplateApplyTemplate) SetContents(v []TemplateEntry) {
 	o.Contents = v
 }
 
+// GetContentType returns the ContentType field value
+func (o *TemplateApplyTemplate) GetContentType() string {
+	if o == nil {
+		var ret string
+		return ret
+	}
+
+	return o.ContentType
+}
+
+// GetContentTypeOk returns a tuple with the ContentType field value
+// and a boolean to check if the value has been set.
+func (o *TemplateApplyTemplate) GetContentTypeOk() (*string, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.ContentType, true
+}
+
+// SetContentType sets field value
+func (o *TemplateApplyTemplate) SetContentType(v string) {
+	o.ContentType = v
+}
+
 func (o TemplateApplyTemplate) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -94,6 +120,9 @@ func (o TemplateApplyTemplate) MarshalJSON() ([]byte, error) {
 	}
 	if true {
 		toSerialize["contents"] = o.Contents
+	}
+	if true {
+		toSerialize["contentType"] = o.ContentType
 	}
 	return json.Marshal(toSerialize)
 }

--- a/api/model_template_entry.gen.go
+++ b/api/model_template_entry.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateEntry struct {
 	ApiVersion string                 `json:"apiVersion" yaml:"apiVersion"`
 	Kind       string                 `json:"kind" yaml:"kind"`
-	Meta       TemplateEntryMeta      `json:"meta" yaml:"meta"`
+	Metadata   TemplateEntryMetadata  `json:"metadata" yaml:"metadata"`
 	Spec       map[string]interface{} `json:"spec" yaml:"spec"`
 }
 
@@ -26,11 +26,11 @@ type TemplateEntry struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateEntry(apiVersion string, kind string, meta TemplateEntryMeta, spec map[string]interface{}) *TemplateEntry {
+func NewTemplateEntry(apiVersion string, kind string, metadata TemplateEntryMetadata, spec map[string]interface{}) *TemplateEntry {
 	this := TemplateEntry{}
 	this.ApiVersion = apiVersion
 	this.Kind = kind
-	this.Meta = meta
+	this.Metadata = metadata
 	this.Spec = spec
 	return &this
 }
@@ -91,28 +91,28 @@ func (o *TemplateEntry) SetKind(v string) {
 	o.Kind = v
 }
 
-// GetMeta returns the Meta field value
-func (o *TemplateEntry) GetMeta() TemplateEntryMeta {
+// GetMetadata returns the Metadata field value
+func (o *TemplateEntry) GetMetadata() TemplateEntryMetadata {
 	if o == nil {
-		var ret TemplateEntryMeta
+		var ret TemplateEntryMetadata
 		return ret
 	}
 
-	return o.Meta
+	return o.Metadata
 }
 
-// GetMetaOk returns a tuple with the Meta field value
+// GetMetadataOk returns a tuple with the Metadata field value
 // and a boolean to check if the value has been set.
-func (o *TemplateEntry) GetMetaOk() (*TemplateEntryMeta, bool) {
+func (o *TemplateEntry) GetMetadataOk() (*TemplateEntryMetadata, bool) {
 	if o == nil {
 		return nil, false
 	}
-	return &o.Meta, true
+	return &o.Metadata, true
 }
 
-// SetMeta sets field value
-func (o *TemplateEntry) SetMeta(v TemplateEntryMeta) {
-	o.Meta = v
+// SetMetadata sets field value
+func (o *TemplateEntry) SetMetadata(v TemplateEntryMetadata) {
+	o.Metadata = v
 }
 
 // GetSpec returns the Spec field value
@@ -148,7 +148,7 @@ func (o TemplateEntry) MarshalJSON() ([]byte, error) {
 		toSerialize["kind"] = o.Kind
 	}
 	if true {
-		toSerialize["meta"] = o.Meta
+		toSerialize["metadata"] = o.Metadata
 	}
 	if true {
 		toSerialize["spec"] = o.Spec

--- a/api/model_template_entry_metadata.gen.go
+++ b/api/model_template_entry_metadata.gen.go
@@ -14,31 +14,31 @@ import (
 	"encoding/json"
 )
 
-// TemplateEntryMeta struct for TemplateEntryMeta
-type TemplateEntryMeta struct {
+// TemplateEntryMetadata struct for TemplateEntryMetadata
+type TemplateEntryMetadata struct {
 	Name string `json:"name" yaml:"name"`
 }
 
-// NewTemplateEntryMeta instantiates a new TemplateEntryMeta object
+// NewTemplateEntryMetadata instantiates a new TemplateEntryMetadata object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateEntryMeta(name string) *TemplateEntryMeta {
-	this := TemplateEntryMeta{}
+func NewTemplateEntryMetadata(name string) *TemplateEntryMetadata {
+	this := TemplateEntryMetadata{}
 	this.Name = name
 	return &this
 }
 
-// NewTemplateEntryMetaWithDefaults instantiates a new TemplateEntryMeta object
+// NewTemplateEntryMetadataWithDefaults instantiates a new TemplateEntryMetadata object
 // This constructor will only assign default values to properties that have it defined,
 // but it doesn't guarantee that properties required by API are set
-func NewTemplateEntryMetaWithDefaults() *TemplateEntryMeta {
-	this := TemplateEntryMeta{}
+func NewTemplateEntryMetadataWithDefaults() *TemplateEntryMetadata {
+	this := TemplateEntryMetadata{}
 	return &this
 }
 
 // GetName returns the Name field value
-func (o *TemplateEntryMeta) GetName() string {
+func (o *TemplateEntryMetadata) GetName() string {
 	if o == nil {
 		var ret string
 		return ret
@@ -49,7 +49,7 @@ func (o *TemplateEntryMeta) GetName() string {
 
 // GetNameOk returns a tuple with the Name field value
 // and a boolean to check if the value has been set.
-func (o *TemplateEntryMeta) GetNameOk() (*string, bool) {
+func (o *TemplateEntryMetadata) GetNameOk() (*string, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -57,11 +57,11 @@ func (o *TemplateEntryMeta) GetNameOk() (*string, bool) {
 }
 
 // SetName sets field value
-func (o *TemplateEntryMeta) SetName(v string) {
+func (o *TemplateEntryMetadata) SetName(v string) {
 	o.Name = v
 }
 
-func (o TemplateEntryMeta) MarshalJSON() ([]byte, error) {
+func (o TemplateEntryMetadata) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["name"] = o.Name
@@ -69,38 +69,38 @@ func (o TemplateEntryMeta) MarshalJSON() ([]byte, error) {
 	return json.Marshal(toSerialize)
 }
 
-type NullableTemplateEntryMeta struct {
-	value *TemplateEntryMeta
+type NullableTemplateEntryMetadata struct {
+	value *TemplateEntryMetadata
 	isSet bool
 }
 
-func (v NullableTemplateEntryMeta) Get() *TemplateEntryMeta {
+func (v NullableTemplateEntryMetadata) Get() *TemplateEntryMetadata {
 	return v.value
 }
 
-func (v *NullableTemplateEntryMeta) Set(val *TemplateEntryMeta) {
+func (v *NullableTemplateEntryMetadata) Set(val *TemplateEntryMetadata) {
 	v.value = val
 	v.isSet = true
 }
 
-func (v NullableTemplateEntryMeta) IsSet() bool {
+func (v NullableTemplateEntryMetadata) IsSet() bool {
 	return v.isSet
 }
 
-func (v *NullableTemplateEntryMeta) Unset() {
+func (v *NullableTemplateEntryMetadata) Unset() {
 	v.value = nil
 	v.isSet = false
 }
 
-func NewNullableTemplateEntryMeta(val *TemplateEntryMeta) *NullableTemplateEntryMeta {
-	return &NullableTemplateEntryMeta{value: val, isSet: true}
+func NewNullableTemplateEntryMetadata(val *TemplateEntryMetadata) *NullableTemplateEntryMetadata {
+	return &NullableTemplateEntryMetadata{value: val, isSet: true}
 }
 
-func (v NullableTemplateEntryMeta) MarshalJSON() ([]byte, error) {
+func (v NullableTemplateEntryMetadata) MarshalJSON() ([]byte, error) {
 	return json.Marshal(v.value)
 }
 
-func (v *NullableTemplateEntryMeta) UnmarshalJSON(src []byte) error {
+func (v *NullableTemplateEntryMetadata) UnmarshalJSON(src []byte) error {
 	v.isSet = true
 	return json.Unmarshal(src, &v.value)
 }

--- a/api/model_template_summary_bucket.gen.go
+++ b/api/model_template_summary_bucket.gen.go
@@ -20,7 +20,7 @@ type TemplateSummaryBucket struct {
 	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
 	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
-	Id                string                 `json:"id" yaml:"id"`
+	Id                uint64                 `json:"id" yaml:"id"`
 	Name              string                 `json:"name" yaml:"name"`
 	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 	RetentionPeriod   int32                  `json:"retentionPeriod" yaml:"retentionPeriod"`
@@ -31,7 +31,7 @@ type TemplateSummaryBucket struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryBucket(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id string, name string, retentionPeriod int32) *TemplateSummaryBucket {
+func NewTemplateSummaryBucket(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id uint64, name string, retentionPeriod int32) *TemplateSummaryBucket {
 	this := TemplateSummaryBucket{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -155,9 +155,9 @@ func (o *TemplateSummaryBucket) SetLabelAssociations(v []TemplateSummaryLabel) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryBucket) GetId() string {
+func (o *TemplateSummaryBucket) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -166,7 +166,7 @@ func (o *TemplateSummaryBucket) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryBucket) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryBucket) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -174,7 +174,7 @@ func (o *TemplateSummaryBucket) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryBucket) SetId(v string) {
+func (o *TemplateSummaryBucket) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_bucket_all_of.gen.go
+++ b/api/model_template_summary_bucket_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryBucketAllOf struct for TemplateSummaryBucketAllOf
 type TemplateSummaryBucketAllOf struct {
-	Id              string  `json:"id" yaml:"id"`
+	Id              uint64  `json:"id" yaml:"id"`
 	Name            string  `json:"name" yaml:"name"`
 	Description     *string `json:"description,omitempty" yaml:"description,omitempty"`
 	RetentionPeriod int32   `json:"retentionPeriod" yaml:"retentionPeriod"`
@@ -27,7 +27,7 @@ type TemplateSummaryBucketAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryBucketAllOf(id string, name string, retentionPeriod int32) *TemplateSummaryBucketAllOf {
+func NewTemplateSummaryBucketAllOf(id uint64, name string, retentionPeriod int32) *TemplateSummaryBucketAllOf {
 	this := TemplateSummaryBucketAllOf{}
 	this.Id = id
 	this.Name = name
@@ -44,9 +44,9 @@ func NewTemplateSummaryBucketAllOfWithDefaults() *TemplateSummaryBucketAllOf {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryBucketAllOf) GetId() string {
+func (o *TemplateSummaryBucketAllOf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -55,7 +55,7 @@ func (o *TemplateSummaryBucketAllOf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryBucketAllOf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryBucketAllOf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -63,7 +63,7 @@ func (o *TemplateSummaryBucketAllOf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryBucketAllOf) SetId(v string) {
+func (o *TemplateSummaryBucketAllOf) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_check.gen.go
+++ b/api/model_template_summary_check.gen.go
@@ -20,7 +20,7 @@ type TemplateSummaryCheck struct {
 	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
 	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
-	Id                string                 `json:"id" yaml:"id"`
+	Id                uint64                 `json:"id" yaml:"id"`
 	Name              string                 `json:"name" yaml:"name"`
 	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 }
@@ -29,7 +29,7 @@ type TemplateSummaryCheck struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryCheck(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id string, name string) *TemplateSummaryCheck {
+func NewTemplateSummaryCheck(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id uint64, name string) *TemplateSummaryCheck {
 	this := TemplateSummaryCheck{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -152,9 +152,9 @@ func (o *TemplateSummaryCheck) SetLabelAssociations(v []TemplateSummaryLabel) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryCheck) GetId() string {
+func (o *TemplateSummaryCheck) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -163,7 +163,7 @@ func (o *TemplateSummaryCheck) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryCheck) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryCheck) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -171,7 +171,7 @@ func (o *TemplateSummaryCheck) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryCheck) SetId(v string) {
+func (o *TemplateSummaryCheck) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_check_all_of.gen.go
+++ b/api/model_template_summary_check_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryCheckAllOf struct for TemplateSummaryCheckAllOf
 type TemplateSummaryCheckAllOf struct {
-	Id          string  `json:"id" yaml:"id"`
+	Id          uint64  `json:"id" yaml:"id"`
 	Name        string  `json:"name" yaml:"name"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
@@ -25,7 +25,7 @@ type TemplateSummaryCheckAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryCheckAllOf(id string, name string) *TemplateSummaryCheckAllOf {
+func NewTemplateSummaryCheckAllOf(id uint64, name string) *TemplateSummaryCheckAllOf {
 	this := TemplateSummaryCheckAllOf{}
 	this.Id = id
 	this.Name = name
@@ -41,9 +41,9 @@ func NewTemplateSummaryCheckAllOfWithDefaults() *TemplateSummaryCheckAllOf {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryCheckAllOf) GetId() string {
+func (o *TemplateSummaryCheckAllOf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -52,7 +52,7 @@ func (o *TemplateSummaryCheckAllOf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryCheckAllOf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryCheckAllOf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -60,7 +60,7 @@ func (o *TemplateSummaryCheckAllOf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryCheckAllOf) SetId(v string) {
+func (o *TemplateSummaryCheckAllOf) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_dashboard.gen.go
+++ b/api/model_template_summary_dashboard.gen.go
@@ -20,7 +20,7 @@ type TemplateSummaryDashboard struct {
 	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
 	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
-	Id                string                 `json:"id" yaml:"id"`
+	Id                uint64                 `json:"id" yaml:"id"`
 	Name              string                 `json:"name" yaml:"name"`
 	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 }
@@ -29,7 +29,7 @@ type TemplateSummaryDashboard struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDashboard(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id string, name string) *TemplateSummaryDashboard {
+func NewTemplateSummaryDashboard(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id uint64, name string) *TemplateSummaryDashboard {
 	this := TemplateSummaryDashboard{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -152,9 +152,9 @@ func (o *TemplateSummaryDashboard) SetLabelAssociations(v []TemplateSummaryLabel
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDashboard) GetId() string {
+func (o *TemplateSummaryDashboard) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -163,7 +163,7 @@ func (o *TemplateSummaryDashboard) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDashboard) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDashboard) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -171,7 +171,7 @@ func (o *TemplateSummaryDashboard) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDashboard) SetId(v string) {
+func (o *TemplateSummaryDashboard) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_bucket.gen.go
+++ b/api/model_template_summary_diff_bucket.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffBucket struct {
 	Kind             string                           `json:"kind" yaml:"kind"`
 	StateStatus      string                           `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                           `json:"id" yaml:"id"`
+	Id               uint64                           `json:"id" yaml:"id"`
 	TemplateMetaName string                           `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffBucketFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffBucketFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffBucket struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffBucket(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffBucket {
+func NewTemplateSummaryDiffBucket(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffBucket {
 	this := TemplateSummaryDiffBucket{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffBucket) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffBucket) GetId() string {
+func (o *TemplateSummaryDiffBucket) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffBucket) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffBucket) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffBucket) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffBucket) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffBucket) SetId(v string) {
+func (o *TemplateSummaryDiffBucket) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_check.gen.go
+++ b/api/model_template_summary_diff_check.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffCheck struct {
 	Kind             string                          `json:"kind" yaml:"kind"`
 	StateStatus      string                          `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                          `json:"id" yaml:"id"`
+	Id               uint64                          `json:"id" yaml:"id"`
 	TemplateMetaName string                          `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffCheckFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffCheckFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffCheck struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffCheck(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffCheck {
+func NewTemplateSummaryDiffCheck(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffCheck {
 	this := TemplateSummaryDiffCheck{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffCheck) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffCheck) GetId() string {
+func (o *TemplateSummaryDiffCheck) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffCheck) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffCheck) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffCheck) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffCheck) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffCheck) SetId(v string) {
+func (o *TemplateSummaryDiffCheck) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_dashboard.gen.go
+++ b/api/model_template_summary_diff_dashboard.gen.go
@@ -17,7 +17,7 @@ import (
 // TemplateSummaryDiffDashboard struct for TemplateSummaryDiffDashboard
 type TemplateSummaryDiffDashboard struct {
 	StateStatus      string                              `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                              `json:"id" yaml:"id"`
+	Id               uint64                              `json:"id" yaml:"id"`
 	Kind             string                              `json:"kind" yaml:"kind"`
 	TemplateMetaName string                              `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffDashboardFields `json:"new,omitempty" yaml:"new,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffDashboard struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffDashboard(stateStatus string, id string, kind string, templateMetaName string) *TemplateSummaryDiffDashboard {
+func NewTemplateSummaryDiffDashboard(stateStatus string, id uint64, kind string, templateMetaName string) *TemplateSummaryDiffDashboard {
 	this := TemplateSummaryDiffDashboard{}
 	this.StateStatus = stateStatus
 	this.Id = id
@@ -70,9 +70,9 @@ func (o *TemplateSummaryDiffDashboard) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffDashboard) GetId() string {
+func (o *TemplateSummaryDiffDashboard) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -81,7 +81,7 @@ func (o *TemplateSummaryDiffDashboard) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffDashboard) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffDashboard) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -89,7 +89,7 @@ func (o *TemplateSummaryDiffDashboard) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffDashboard) SetId(v string) {
+func (o *TemplateSummaryDiffDashboard) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_label.gen.go
+++ b/api/model_template_summary_diff_label.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffLabel struct {
 	StateStatus      string                          `json:"stateStatus" yaml:"stateStatus"`
 	Kind             string                          `json:"kind" yaml:"kind"`
-	Id               string                          `json:"id" yaml:"id"`
+	Id               uint64                          `json:"id" yaml:"id"`
 	TemplateMetaName string                          `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffLabelFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffLabelFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffLabel struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffLabel(stateStatus string, kind string, id string, templateMetaName string) *TemplateSummaryDiffLabel {
+func NewTemplateSummaryDiffLabel(stateStatus string, kind string, id uint64, templateMetaName string) *TemplateSummaryDiffLabel {
 	this := TemplateSummaryDiffLabel{}
 	this.StateStatus = stateStatus
 	this.Kind = kind
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffLabel) SetKind(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffLabel) GetId() string {
+func (o *TemplateSummaryDiffLabel) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffLabel) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffLabel) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffLabel) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffLabel) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffLabel) SetId(v string) {
+func (o *TemplateSummaryDiffLabel) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_notification_endpoint.gen.go
+++ b/api/model_template_summary_diff_notification_endpoint.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffNotificationEndpoint struct {
 	Kind             string                                         `json:"kind" yaml:"kind"`
 	StateStatus      string                                         `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                                         `json:"id" yaml:"id"`
+	Id               uint64                                         `json:"id" yaml:"id"`
 	TemplateMetaName string                                         `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffNotificationEndpointFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffNotificationEndpointFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffNotificationEndpoint struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffNotificationEndpoint(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffNotificationEndpoint {
+func NewTemplateSummaryDiffNotificationEndpoint(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffNotificationEndpoint {
 	this := TemplateSummaryDiffNotificationEndpoint{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffNotificationEndpoint) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffNotificationEndpoint) GetId() string {
+func (o *TemplateSummaryDiffNotificationEndpoint) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffNotificationEndpoint) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffNotificationEndpoint) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffNotificationEndpoint) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffNotificationEndpoint) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffNotificationEndpoint) SetId(v string) {
+func (o *TemplateSummaryDiffNotificationEndpoint) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_notification_rule.gen.go
+++ b/api/model_template_summary_diff_notification_rule.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffNotificationRule struct {
 	Kind             string                                     `json:"kind" yaml:"kind"`
 	StateStatus      string                                     `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                                     `json:"id" yaml:"id"`
+	Id               uint64                                     `json:"id" yaml:"id"`
 	TemplateMetaName string                                     `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffNotificationRuleFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffNotificationRuleFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffNotificationRule struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffNotificationRule(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffNotificationRule {
+func NewTemplateSummaryDiffNotificationRule(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffNotificationRule {
 	this := TemplateSummaryDiffNotificationRule{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffNotificationRule) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffNotificationRule) GetId() string {
+func (o *TemplateSummaryDiffNotificationRule) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffNotificationRule) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffNotificationRule) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffNotificationRule) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffNotificationRule) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffNotificationRule) SetId(v string) {
+func (o *TemplateSummaryDiffNotificationRule) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_notification_rule_fields.gen.go
+++ b/api/model_template_summary_diff_notification_rule_fields.gen.go
@@ -19,7 +19,7 @@ type TemplateSummaryDiffNotificationRuleFields struct {
 	Name            string  `json:"name" yaml:"name"`
 	Description     *string `json:"description,omitempty" yaml:"description,omitempty"`
 	EndpointName    string  `json:"endpointName" yaml:"endpointName"`
-	EndpointID      string  `json:"endpointID" yaml:"endpointID"`
+	EndpointID      uint64  `json:"endpointID" yaml:"endpointID"`
 	EndpointType    string  `json:"endpointType" yaml:"endpointType"`
 	Every           string  `json:"every" yaml:"every"`
 	Offset          string  `json:"offset" yaml:"offset"`
@@ -30,7 +30,7 @@ type TemplateSummaryDiffNotificationRuleFields struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffNotificationRuleFields(name string, endpointName string, endpointID string, endpointType string, every string, offset string) *TemplateSummaryDiffNotificationRuleFields {
+func NewTemplateSummaryDiffNotificationRuleFields(name string, endpointName string, endpointID uint64, endpointType string, every string, offset string) *TemplateSummaryDiffNotificationRuleFields {
 	this := TemplateSummaryDiffNotificationRuleFields{}
 	this.Name = name
 	this.EndpointName = endpointName
@@ -130,9 +130,9 @@ func (o *TemplateSummaryDiffNotificationRuleFields) SetEndpointName(v string) {
 }
 
 // GetEndpointID returns the EndpointID field value
-func (o *TemplateSummaryDiffNotificationRuleFields) GetEndpointID() string {
+func (o *TemplateSummaryDiffNotificationRuleFields) GetEndpointID() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -141,7 +141,7 @@ func (o *TemplateSummaryDiffNotificationRuleFields) GetEndpointID() string {
 
 // GetEndpointIDOk returns a tuple with the EndpointID field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffNotificationRuleFields) GetEndpointIDOk() (*string, bool) {
+func (o *TemplateSummaryDiffNotificationRuleFields) GetEndpointIDOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -149,7 +149,7 @@ func (o *TemplateSummaryDiffNotificationRuleFields) GetEndpointIDOk() (*string, 
 }
 
 // SetEndpointID sets field value
-func (o *TemplateSummaryDiffNotificationRuleFields) SetEndpointID(v string) {
+func (o *TemplateSummaryDiffNotificationRuleFields) SetEndpointID(v uint64) {
 	o.EndpointID = v
 }
 

--- a/api/model_template_summary_diff_task.gen.go
+++ b/api/model_template_summary_diff_task.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffTask struct {
 	Kind             string                         `json:"kind" yaml:"kind"`
 	StateStatus      string                         `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                         `json:"id" yaml:"id"`
+	Id               uint64                         `json:"id" yaml:"id"`
 	TemplateMetaName string                         `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffTaskFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffTaskFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffTask struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffTask(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffTask {
+func NewTemplateSummaryDiffTask(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffTask {
 	this := TemplateSummaryDiffTask{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffTask) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffTask) GetId() string {
+func (o *TemplateSummaryDiffTask) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffTask) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffTask) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffTask) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffTask) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffTask) SetId(v string) {
+func (o *TemplateSummaryDiffTask) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_telegraf.gen.go
+++ b/api/model_template_summary_diff_telegraf.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffTelegraf struct {
 	Kind             string                         `json:"kind" yaml:"kind"`
 	StateStatus      string                         `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                         `json:"id" yaml:"id"`
+	Id               uint64                         `json:"id" yaml:"id"`
 	TemplateMetaName string                         `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryTelegrafConfig `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryTelegrafConfig `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffTelegraf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffTelegraf(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffTelegraf {
+func NewTemplateSummaryDiffTelegraf(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffTelegraf {
 	this := TemplateSummaryDiffTelegraf{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffTelegraf) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffTelegraf) GetId() string {
+func (o *TemplateSummaryDiffTelegraf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffTelegraf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffTelegraf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffTelegraf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffTelegraf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffTelegraf) SetId(v string) {
+func (o *TemplateSummaryDiffTelegraf) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_diff_variable.gen.go
+++ b/api/model_template_summary_diff_variable.gen.go
@@ -18,7 +18,7 @@ import (
 type TemplateSummaryDiffVariable struct {
 	Kind             string                             `json:"kind" yaml:"kind"`
 	StateStatus      string                             `json:"stateStatus" yaml:"stateStatus"`
-	Id               string                             `json:"id" yaml:"id"`
+	Id               uint64                             `json:"id" yaml:"id"`
 	TemplateMetaName string                             `json:"templateMetaName" yaml:"templateMetaName"`
 	New              *TemplateSummaryDiffVariableFields `json:"new,omitempty" yaml:"new,omitempty"`
 	Old              *TemplateSummaryDiffVariableFields `json:"old,omitempty" yaml:"old,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryDiffVariable struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryDiffVariable(kind string, stateStatus string, id string, templateMetaName string) *TemplateSummaryDiffVariable {
+func NewTemplateSummaryDiffVariable(kind string, stateStatus string, id uint64, templateMetaName string) *TemplateSummaryDiffVariable {
 	this := TemplateSummaryDiffVariable{}
 	this.Kind = kind
 	this.StateStatus = stateStatus
@@ -94,9 +94,9 @@ func (o *TemplateSummaryDiffVariable) SetStateStatus(v string) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryDiffVariable) GetId() string {
+func (o *TemplateSummaryDiffVariable) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -105,7 +105,7 @@ func (o *TemplateSummaryDiffVariable) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryDiffVariable) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryDiffVariable) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -113,7 +113,7 @@ func (o *TemplateSummaryDiffVariable) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryDiffVariable) SetId(v string) {
+func (o *TemplateSummaryDiffVariable) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_label.gen.go
+++ b/api/model_template_summary_label.gen.go
@@ -19,8 +19,8 @@ type TemplateSummaryLabel struct {
 	Kind             string                              `json:"kind" yaml:"kind"`
 	TemplateMetaName *string                             `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences    []TemplateEnvReference              `json:"envReferences" yaml:"envReferences"`
-	Id               string                              `json:"id" yaml:"id"`
-	OrgID            *string                             `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Id               uint64                              `json:"id" yaml:"id"`
+	OrgID            *uint64                             `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	Name             string                              `json:"name" yaml:"name"`
 	Properties       TemplateSummaryLabelAllOfProperties `json:"properties" yaml:"properties"`
 }
@@ -29,7 +29,7 @@ type TemplateSummaryLabel struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryLabel(kind string, envReferences []TemplateEnvReference, id string, name string, properties TemplateSummaryLabelAllOfProperties) *TemplateSummaryLabel {
+func NewTemplateSummaryLabel(kind string, envReferences []TemplateEnvReference, id uint64, name string, properties TemplateSummaryLabelAllOfProperties) *TemplateSummaryLabel {
 	this := TemplateSummaryLabel{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -128,9 +128,9 @@ func (o *TemplateSummaryLabel) SetEnvReferences(v []TemplateEnvReference) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryLabel) GetId() string {
+func (o *TemplateSummaryLabel) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -139,7 +139,7 @@ func (o *TemplateSummaryLabel) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryLabel) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryLabel) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -147,14 +147,14 @@ func (o *TemplateSummaryLabel) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryLabel) SetId(v string) {
+func (o *TemplateSummaryLabel) SetId(v uint64) {
 	o.Id = v
 }
 
 // GetOrgID returns the OrgID field value if set, zero value otherwise.
-func (o *TemplateSummaryLabel) GetOrgID() string {
+func (o *TemplateSummaryLabel) GetOrgID() uint64 {
 	if o == nil || o.OrgID == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 	return *o.OrgID
@@ -162,7 +162,7 @@ func (o *TemplateSummaryLabel) GetOrgID() string {
 
 // GetOrgIDOk returns a tuple with the OrgID field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryLabel) GetOrgIDOk() (*string, bool) {
+func (o *TemplateSummaryLabel) GetOrgIDOk() (*uint64, bool) {
 	if o == nil || o.OrgID == nil {
 		return nil, false
 	}
@@ -178,8 +178,8 @@ func (o *TemplateSummaryLabel) HasOrgID() bool {
 	return false
 }
 
-// SetOrgID gets a reference to the given string and assigns it to the OrgID field.
-func (o *TemplateSummaryLabel) SetOrgID(v string) {
+// SetOrgID gets a reference to the given int64 and assigns it to the OrgID field.
+func (o *TemplateSummaryLabel) SetOrgID(v uint64) {
 	o.OrgID = &v
 }
 

--- a/api/model_template_summary_label_all_of.gen.go
+++ b/api/model_template_summary_label_all_of.gen.go
@@ -16,8 +16,8 @@ import (
 
 // TemplateSummaryLabelAllOf struct for TemplateSummaryLabelAllOf
 type TemplateSummaryLabelAllOf struct {
-	Id         string                              `json:"id" yaml:"id"`
-	OrgID      *string                             `json:"orgID,omitempty" yaml:"orgID,omitempty"`
+	Id         uint64                              `json:"id" yaml:"id"`
+	OrgID      *uint64                             `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	Name       string                              `json:"name" yaml:"name"`
 	Properties TemplateSummaryLabelAllOfProperties `json:"properties" yaml:"properties"`
 }
@@ -26,7 +26,7 @@ type TemplateSummaryLabelAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryLabelAllOf(id string, name string, properties TemplateSummaryLabelAllOfProperties) *TemplateSummaryLabelAllOf {
+func NewTemplateSummaryLabelAllOf(id uint64, name string, properties TemplateSummaryLabelAllOfProperties) *TemplateSummaryLabelAllOf {
 	this := TemplateSummaryLabelAllOf{}
 	this.Id = id
 	this.Name = name
@@ -43,9 +43,9 @@ func NewTemplateSummaryLabelAllOfWithDefaults() *TemplateSummaryLabelAllOf {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryLabelAllOf) GetId() string {
+func (o *TemplateSummaryLabelAllOf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -54,7 +54,7 @@ func (o *TemplateSummaryLabelAllOf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryLabelAllOf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryLabelAllOf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -62,14 +62,14 @@ func (o *TemplateSummaryLabelAllOf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryLabelAllOf) SetId(v string) {
+func (o *TemplateSummaryLabelAllOf) SetId(v uint64) {
 	o.Id = v
 }
 
 // GetOrgID returns the OrgID field value if set, zero value otherwise.
-func (o *TemplateSummaryLabelAllOf) GetOrgID() string {
+func (o *TemplateSummaryLabelAllOf) GetOrgID() uint64 {
 	if o == nil || o.OrgID == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 	return *o.OrgID
@@ -77,7 +77,7 @@ func (o *TemplateSummaryLabelAllOf) GetOrgID() string {
 
 // GetOrgIDOk returns a tuple with the OrgID field value if set, nil otherwise
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryLabelAllOf) GetOrgIDOk() (*string, bool) {
+func (o *TemplateSummaryLabelAllOf) GetOrgIDOk() (*uint64, bool) {
 	if o == nil || o.OrgID == nil {
 		return nil, false
 	}
@@ -93,8 +93,8 @@ func (o *TemplateSummaryLabelAllOf) HasOrgID() bool {
 	return false
 }
 
-// SetOrgID gets a reference to the given string and assigns it to the OrgID field.
-func (o *TemplateSummaryLabelAllOf) SetOrgID(v string) {
+// SetOrgID gets a reference to the given int64 and assigns it to the OrgID field.
+func (o *TemplateSummaryLabelAllOf) SetOrgID(v uint64) {
 	o.OrgID = &v
 }
 

--- a/api/model_template_summary_label_mapping.gen.go
+++ b/api/model_template_summary_label_mapping.gen.go
@@ -19,18 +19,18 @@ type TemplateSummaryLabelMapping struct {
 	Status                   string `json:"status" yaml:"status"`
 	ResourceTemplateMetaName string `json:"resourceTemplateMetaName" yaml:"resourceTemplateMetaName"`
 	ResourceName             string `json:"resourceName" yaml:"resourceName"`
-	ResourceID               string `json:"resourceID" yaml:"resourceID"`
+	ResourceID               uint64 `json:"resourceID" yaml:"resourceID"`
 	ResourceType             string `json:"resourceType" yaml:"resourceType"`
 	LabelTemplateMetaName    string `json:"labelTemplateMetaName" yaml:"labelTemplateMetaName"`
 	LabelName                string `json:"labelName" yaml:"labelName"`
-	LabelID                  string `json:"labelID" yaml:"labelID"`
+	LabelID                  uint64 `json:"labelID" yaml:"labelID"`
 }
 
 // NewTemplateSummaryLabelMapping instantiates a new TemplateSummaryLabelMapping object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryLabelMapping(status string, resourceTemplateMetaName string, resourceName string, resourceID string, resourceType string, labelTemplateMetaName string, labelName string, labelID string) *TemplateSummaryLabelMapping {
+func NewTemplateSummaryLabelMapping(status string, resourceTemplateMetaName string, resourceName string, resourceID uint64, resourceType string, labelTemplateMetaName string, labelName string, labelID uint64) *TemplateSummaryLabelMapping {
 	this := TemplateSummaryLabelMapping{}
 	this.Status = status
 	this.ResourceTemplateMetaName = resourceTemplateMetaName
@@ -124,9 +124,9 @@ func (o *TemplateSummaryLabelMapping) SetResourceName(v string) {
 }
 
 // GetResourceID returns the ResourceID field value
-func (o *TemplateSummaryLabelMapping) GetResourceID() string {
+func (o *TemplateSummaryLabelMapping) GetResourceID() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -135,7 +135,7 @@ func (o *TemplateSummaryLabelMapping) GetResourceID() string {
 
 // GetResourceIDOk returns a tuple with the ResourceID field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryLabelMapping) GetResourceIDOk() (*string, bool) {
+func (o *TemplateSummaryLabelMapping) GetResourceIDOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -143,7 +143,7 @@ func (o *TemplateSummaryLabelMapping) GetResourceIDOk() (*string, bool) {
 }
 
 // SetResourceID sets field value
-func (o *TemplateSummaryLabelMapping) SetResourceID(v string) {
+func (o *TemplateSummaryLabelMapping) SetResourceID(v uint64) {
 	o.ResourceID = v
 }
 
@@ -220,9 +220,9 @@ func (o *TemplateSummaryLabelMapping) SetLabelName(v string) {
 }
 
 // GetLabelID returns the LabelID field value
-func (o *TemplateSummaryLabelMapping) GetLabelID() string {
+func (o *TemplateSummaryLabelMapping) GetLabelID() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -231,7 +231,7 @@ func (o *TemplateSummaryLabelMapping) GetLabelID() string {
 
 // GetLabelIDOk returns a tuple with the LabelID field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryLabelMapping) GetLabelIDOk() (*string, bool) {
+func (o *TemplateSummaryLabelMapping) GetLabelIDOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -239,7 +239,7 @@ func (o *TemplateSummaryLabelMapping) GetLabelIDOk() (*string, bool) {
 }
 
 // SetLabelID sets field value
-func (o *TemplateSummaryLabelMapping) SetLabelID(v string) {
+func (o *TemplateSummaryLabelMapping) SetLabelID(v uint64) {
 	o.LabelID = v
 }
 

--- a/api/model_template_summary_notification_endpoint.gen.go
+++ b/api/model_template_summary_notification_endpoint.gen.go
@@ -20,7 +20,7 @@ type TemplateSummaryNotificationEndpoint struct {
 	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
 	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
-	Id                string                 `json:"id" yaml:"id"`
+	Id                uint64                 `json:"id" yaml:"id"`
 	Name              string                 `json:"name" yaml:"name"`
 	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 	Status            string                 `json:"status" yaml:"status"`
@@ -30,7 +30,7 @@ type TemplateSummaryNotificationEndpoint struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryNotificationEndpoint(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id string, name string, status string) *TemplateSummaryNotificationEndpoint {
+func NewTemplateSummaryNotificationEndpoint(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id uint64, name string, status string) *TemplateSummaryNotificationEndpoint {
 	this := TemplateSummaryNotificationEndpoint{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -154,9 +154,9 @@ func (o *TemplateSummaryNotificationEndpoint) SetLabelAssociations(v []TemplateS
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryNotificationEndpoint) GetId() string {
+func (o *TemplateSummaryNotificationEndpoint) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -165,7 +165,7 @@ func (o *TemplateSummaryNotificationEndpoint) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryNotificationEndpoint) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryNotificationEndpoint) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -173,7 +173,7 @@ func (o *TemplateSummaryNotificationEndpoint) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryNotificationEndpoint) SetId(v string) {
+func (o *TemplateSummaryNotificationEndpoint) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_notification_endpoint_all_of.gen.go
+++ b/api/model_template_summary_notification_endpoint_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryNotificationEndpointAllOf struct for TemplateSummaryNotificationEndpointAllOf
 type TemplateSummaryNotificationEndpointAllOf struct {
-	Id          string  `json:"id" yaml:"id"`
+	Id          uint64  `json:"id" yaml:"id"`
 	Name        string  `json:"name" yaml:"name"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	Status      string  `json:"status" yaml:"status"`
@@ -26,7 +26,7 @@ type TemplateSummaryNotificationEndpointAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryNotificationEndpointAllOf(id string, name string, status string) *TemplateSummaryNotificationEndpointAllOf {
+func NewTemplateSummaryNotificationEndpointAllOf(id uint64, name string, status string) *TemplateSummaryNotificationEndpointAllOf {
 	this := TemplateSummaryNotificationEndpointAllOf{}
 	this.Id = id
 	this.Name = name
@@ -43,9 +43,9 @@ func NewTemplateSummaryNotificationEndpointAllOfWithDefaults() *TemplateSummaryN
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryNotificationEndpointAllOf) GetId() string {
+func (o *TemplateSummaryNotificationEndpointAllOf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -54,7 +54,7 @@ func (o *TemplateSummaryNotificationEndpointAllOf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryNotificationEndpointAllOf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryNotificationEndpointAllOf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -62,7 +62,7 @@ func (o *TemplateSummaryNotificationEndpointAllOf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryNotificationEndpointAllOf) SetId(v string) {
+func (o *TemplateSummaryNotificationEndpointAllOf) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_notification_rule.gen.go
+++ b/api/model_template_summary_notification_rule.gen.go
@@ -23,7 +23,7 @@ type TemplateSummaryNotificationRule struct {
 	Name                     string                 `json:"name" yaml:"name"`
 	Description              *string                `json:"description,omitempty" yaml:"description,omitempty"`
 	EndpointTemplateMetaName string                 `json:"endpointTemplateMetaName" yaml:"endpointTemplateMetaName"`
-	EndpointID               string                 `json:"endpointID" yaml:"endpointID"`
+	EndpointID               uint64                 `json:"endpointID" yaml:"endpointID"`
 	EndpointType             string                 `json:"endpointType" yaml:"endpointType"`
 	Every                    string                 `json:"every" yaml:"every"`
 	Offset                   string                 `json:"offset" yaml:"offset"`
@@ -33,7 +33,7 @@ type TemplateSummaryNotificationRule struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryNotificationRule(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, name string, endpointTemplateMetaName string, endpointID string, endpointType string, every string, offset string) *TemplateSummaryNotificationRule {
+func NewTemplateSummaryNotificationRule(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, name string, endpointTemplateMetaName string, endpointID uint64, endpointType string, every string, offset string) *TemplateSummaryNotificationRule {
 	this := TemplateSummaryNotificationRule{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -240,9 +240,9 @@ func (o *TemplateSummaryNotificationRule) SetEndpointTemplateMetaName(v string) 
 }
 
 // GetEndpointID returns the EndpointID field value
-func (o *TemplateSummaryNotificationRule) GetEndpointID() string {
+func (o *TemplateSummaryNotificationRule) GetEndpointID() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -251,7 +251,7 @@ func (o *TemplateSummaryNotificationRule) GetEndpointID() string {
 
 // GetEndpointIDOk returns a tuple with the EndpointID field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryNotificationRule) GetEndpointIDOk() (*string, bool) {
+func (o *TemplateSummaryNotificationRule) GetEndpointIDOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -259,7 +259,7 @@ func (o *TemplateSummaryNotificationRule) GetEndpointIDOk() (*string, bool) {
 }
 
 // SetEndpointID sets field value
-func (o *TemplateSummaryNotificationRule) SetEndpointID(v string) {
+func (o *TemplateSummaryNotificationRule) SetEndpointID(v uint64) {
 	o.EndpointID = v
 }
 

--- a/api/model_template_summary_notification_rule_all_of.gen.go
+++ b/api/model_template_summary_notification_rule_all_of.gen.go
@@ -19,7 +19,7 @@ type TemplateSummaryNotificationRuleAllOf struct {
 	Name                     string  `json:"name" yaml:"name"`
 	Description              *string `json:"description,omitempty" yaml:"description,omitempty"`
 	EndpointTemplateMetaName string  `json:"endpointTemplateMetaName" yaml:"endpointTemplateMetaName"`
-	EndpointID               string  `json:"endpointID" yaml:"endpointID"`
+	EndpointID               uint64  `json:"endpointID" yaml:"endpointID"`
 	EndpointType             string  `json:"endpointType" yaml:"endpointType"`
 	Every                    string  `json:"every" yaml:"every"`
 	Offset                   string  `json:"offset" yaml:"offset"`
@@ -29,7 +29,7 @@ type TemplateSummaryNotificationRuleAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryNotificationRuleAllOf(name string, endpointTemplateMetaName string, endpointID string, endpointType string, every string, offset string) *TemplateSummaryNotificationRuleAllOf {
+func NewTemplateSummaryNotificationRuleAllOf(name string, endpointTemplateMetaName string, endpointID uint64, endpointType string, every string, offset string) *TemplateSummaryNotificationRuleAllOf {
 	this := TemplateSummaryNotificationRuleAllOf{}
 	this.Name = name
 	this.EndpointTemplateMetaName = endpointTemplateMetaName
@@ -129,9 +129,9 @@ func (o *TemplateSummaryNotificationRuleAllOf) SetEndpointTemplateMetaName(v str
 }
 
 // GetEndpointID returns the EndpointID field value
-func (o *TemplateSummaryNotificationRuleAllOf) GetEndpointID() string {
+func (o *TemplateSummaryNotificationRuleAllOf) GetEndpointID() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -140,7 +140,7 @@ func (o *TemplateSummaryNotificationRuleAllOf) GetEndpointID() string {
 
 // GetEndpointIDOk returns a tuple with the EndpointID field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryNotificationRuleAllOf) GetEndpointIDOk() (*string, bool) {
+func (o *TemplateSummaryNotificationRuleAllOf) GetEndpointIDOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -148,7 +148,7 @@ func (o *TemplateSummaryNotificationRuleAllOf) GetEndpointIDOk() (*string, bool)
 }
 
 // SetEndpointID sets field value
-func (o *TemplateSummaryNotificationRuleAllOf) SetEndpointID(v string) {
+func (o *TemplateSummaryNotificationRuleAllOf) SetEndpointID(v uint64) {
 	o.EndpointID = v
 }
 

--- a/api/model_template_summary_task.gen.go
+++ b/api/model_template_summary_task.gen.go
@@ -20,7 +20,7 @@ type TemplateSummaryTask struct {
 	TemplateMetaName  *string                `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences     []TemplateEnvReference `json:"envReferences" yaml:"envReferences"`
 	LabelAssociations []TemplateSummaryLabel `json:"labelAssociations" yaml:"labelAssociations"`
-	Id                string                 `json:"id" yaml:"id"`
+	Id                uint64                 `json:"id" yaml:"id"`
 	Name              string                 `json:"name" yaml:"name"`
 	Description       *string                `json:"description,omitempty" yaml:"description,omitempty"`
 	Cron              *string                `json:"cron,omitempty" yaml:"cron,omitempty"`
@@ -32,7 +32,7 @@ type TemplateSummaryTask struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryTask(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id string, name string) *TemplateSummaryTask {
+func NewTemplateSummaryTask(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id uint64, name string) *TemplateSummaryTask {
 	this := TemplateSummaryTask{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -155,9 +155,9 @@ func (o *TemplateSummaryTask) SetLabelAssociations(v []TemplateSummaryLabel) {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryTask) GetId() string {
+func (o *TemplateSummaryTask) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -166,7 +166,7 @@ func (o *TemplateSummaryTask) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryTask) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryTask) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -174,7 +174,7 @@ func (o *TemplateSummaryTask) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryTask) SetId(v string) {
+func (o *TemplateSummaryTask) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_task_all_of.gen.go
+++ b/api/model_template_summary_task_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryTaskAllOf struct for TemplateSummaryTaskAllOf
 type TemplateSummaryTaskAllOf struct {
-	Id          string  `json:"id" yaml:"id"`
+	Id          uint64  `json:"id" yaml:"id"`
 	Name        string  `json:"name" yaml:"name"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 	Cron        *string `json:"cron,omitempty" yaml:"cron,omitempty"`
@@ -28,7 +28,7 @@ type TemplateSummaryTaskAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryTaskAllOf(id string, name string) *TemplateSummaryTaskAllOf {
+func NewTemplateSummaryTaskAllOf(id uint64, name string) *TemplateSummaryTaskAllOf {
 	this := TemplateSummaryTaskAllOf{}
 	this.Id = id
 	this.Name = name
@@ -44,9 +44,9 @@ func NewTemplateSummaryTaskAllOfWithDefaults() *TemplateSummaryTaskAllOf {
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryTaskAllOf) GetId() string {
+func (o *TemplateSummaryTaskAllOf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -55,7 +55,7 @@ func (o *TemplateSummaryTaskAllOf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryTaskAllOf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryTaskAllOf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -63,7 +63,7 @@ func (o *TemplateSummaryTaskAllOf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryTaskAllOf) SetId(v string) {
+func (o *TemplateSummaryTaskAllOf) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_telegraf_config.gen.go
+++ b/api/model_template_summary_telegraf_config.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryTelegrafConfig struct for TemplateSummaryTelegrafConfig
 type TemplateSummaryTelegrafConfig struct {
-	Id          string  `json:"id" yaml:"id"`
+	Id          uint64  `json:"id" yaml:"id"`
 	Name        string  `json:"name" yaml:"name"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
 }
@@ -25,7 +25,7 @@ type TemplateSummaryTelegrafConfig struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryTelegrafConfig(id string, name string) *TemplateSummaryTelegrafConfig {
+func NewTemplateSummaryTelegrafConfig(id uint64, name string) *TemplateSummaryTelegrafConfig {
 	this := TemplateSummaryTelegrafConfig{}
 	this.Id = id
 	this.Name = name
@@ -41,9 +41,9 @@ func NewTemplateSummaryTelegrafConfigWithDefaults() *TemplateSummaryTelegrafConf
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryTelegrafConfig) GetId() string {
+func (o *TemplateSummaryTelegrafConfig) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -52,7 +52,7 @@ func (o *TemplateSummaryTelegrafConfig) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryTelegrafConfig) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryTelegrafConfig) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -60,7 +60,7 @@ func (o *TemplateSummaryTelegrafConfig) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryTelegrafConfig) SetId(v string) {
+func (o *TemplateSummaryTelegrafConfig) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_variable.gen.go
+++ b/api/model_template_summary_variable.gen.go
@@ -20,7 +20,7 @@ type TemplateSummaryVariable struct {
 	TemplateMetaName  *string                     `json:"templateMetaName,omitempty" yaml:"templateMetaName,omitempty"`
 	EnvReferences     []TemplateEnvReference      `json:"envReferences" yaml:"envReferences"`
 	LabelAssociations []TemplateSummaryLabel      `json:"labelAssociations" yaml:"labelAssociations"`
-	Id                string                      `json:"id" yaml:"id"`
+	Id                uint64                      `json:"id" yaml:"id"`
 	Name              string                      `json:"name" yaml:"name"`
 	Description       *string                     `json:"description,omitempty" yaml:"description,omitempty"`
 	Arguments         TemplateSummaryVariableArgs `json:"arguments" yaml:"arguments"`
@@ -30,7 +30,7 @@ type TemplateSummaryVariable struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryVariable(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id string, name string, arguments TemplateSummaryVariableArgs) *TemplateSummaryVariable {
+func NewTemplateSummaryVariable(kind string, envReferences []TemplateEnvReference, labelAssociations []TemplateSummaryLabel, id uint64, name string, arguments TemplateSummaryVariableArgs) *TemplateSummaryVariable {
 	this := TemplateSummaryVariable{}
 	this.Kind = kind
 	this.EnvReferences = envReferences
@@ -154,9 +154,9 @@ func (o *TemplateSummaryVariable) SetLabelAssociations(v []TemplateSummaryLabel)
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryVariable) GetId() string {
+func (o *TemplateSummaryVariable) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -165,7 +165,7 @@ func (o *TemplateSummaryVariable) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryVariable) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryVariable) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -173,7 +173,7 @@ func (o *TemplateSummaryVariable) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryVariable) SetId(v string) {
+func (o *TemplateSummaryVariable) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/model_template_summary_variable_all_of.gen.go
+++ b/api/model_template_summary_variable_all_of.gen.go
@@ -16,7 +16,7 @@ import (
 
 // TemplateSummaryVariableAllOf struct for TemplateSummaryVariableAllOf
 type TemplateSummaryVariableAllOf struct {
-	Id          string                      `json:"id" yaml:"id"`
+	Id          uint64                      `json:"id" yaml:"id"`
 	Name        string                      `json:"name" yaml:"name"`
 	Description *string                     `json:"description,omitempty" yaml:"description,omitempty"`
 	Arguments   TemplateSummaryVariableArgs `json:"arguments" yaml:"arguments"`
@@ -26,7 +26,7 @@ type TemplateSummaryVariableAllOf struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTemplateSummaryVariableAllOf(id string, name string, arguments TemplateSummaryVariableArgs) *TemplateSummaryVariableAllOf {
+func NewTemplateSummaryVariableAllOf(id uint64, name string, arguments TemplateSummaryVariableArgs) *TemplateSummaryVariableAllOf {
 	this := TemplateSummaryVariableAllOf{}
 	this.Id = id
 	this.Name = name
@@ -43,9 +43,9 @@ func NewTemplateSummaryVariableAllOfWithDefaults() *TemplateSummaryVariableAllOf
 }
 
 // GetId returns the Id field value
-func (o *TemplateSummaryVariableAllOf) GetId() string {
+func (o *TemplateSummaryVariableAllOf) GetId() uint64 {
 	if o == nil {
-		var ret string
+		var ret uint64
 		return ret
 	}
 
@@ -54,7 +54,7 @@ func (o *TemplateSummaryVariableAllOf) GetId() string {
 
 // GetIdOk returns a tuple with the Id field value
 // and a boolean to check if the value has been set.
-func (o *TemplateSummaryVariableAllOf) GetIdOk() (*string, bool) {
+func (o *TemplateSummaryVariableAllOf) GetIdOk() (*uint64, bool) {
 	if o == nil {
 		return nil, false
 	}
@@ -62,7 +62,7 @@ func (o *TemplateSummaryVariableAllOf) GetIdOk() (*string, bool) {
 }
 
 // SetId sets field value
-func (o *TemplateSummaryVariableAllOf) SetId(v string) {
+func (o *TemplateSummaryVariableAllOf) SetId(v uint64) {
 	o.Id = v
 }
 

--- a/api/templates/README.md
+++ b/api/templates/README.md
@@ -37,3 +37,4 @@ multiple locations.
 
 `model_simple.mustache`
 * Added `yaml:` tags to all model fields to support unmarshalling camelCase
+* Added support for `x-go-field-type` vendor extension, to explicitly override the type generated for model fields

--- a/api/templates/model_simple.mustache
+++ b/api/templates/model_simple.mustache
@@ -16,7 +16,7 @@ type {{classname}} struct {
     {{#description}}
         // {{{description}}}
     {{/description}}
-    {{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}" yaml:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+    {{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{{dataType}}}{{/vendorExtensions.x-go-field-type}} `json:"{{baseName}}{{^required}},omitempty{{/required}}" yaml:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
 {{/vars}}
 {{#isAdditionalPropertiesTrue}}
     AdditionalProperties map[string]interface{}
@@ -31,7 +31,7 @@ type {{classname}} struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{dataType}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
+func New{{classname}}({{#requiredVars}}{{nameInCamelCase}} {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{dataType}}{{/vendorExtensions.x-go-field-type}}{{^-last}}, {{/-last}}{{/requiredVars}}) *{{classname}} {
 this := {{classname}}{}
 {{#allVars}}
     {{#required}}
@@ -84,9 +84,9 @@ return &this
         {{#isNullable}}
             // If the value is explicit nil, the zero value for {{vendorExtensions.x-go-base-type}} will be returned
         {{/isNullable}}
-        func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+        func (o *{{classname}}) Get{{name}}() {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}} {
         if o == nil{{#isNullable}}{{^vendorExtensions.x-golang-is-container}} || o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
-        var ret {{vendorExtensions.x-go-base-type}}
+        var ret {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}}
         return ret
         }
 
@@ -108,7 +108,7 @@ return &this
         {{#isNullable}}
             // NOTE: If the value is an explicit nil, `nil, true` will be returned
         {{/isNullable}}
-        func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
+        func (o *{{classname}}) Get{{name}}Ok() (*{{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}}, bool) {
         if o == nil {{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
         return nil, false
         }
@@ -126,7 +126,7 @@ return &this
         }
 
         // Set{{name}} sets field value
-        func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+        func (o *{{classname}}) Set{{name}}(v {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}}) {
         {{#isNullable}}
             {{#vendorExtensions.x-golang-is-container}}
                 o.{{name}} = v
@@ -143,9 +143,9 @@ return &this
     {{/required}}
     {{^required}}
         // Get{{name}} returns the {{name}} field value if set, zero value otherwise{{#isNullable}} (both if not set or set to explicit null){{/isNullable}}.
-        func (o *{{classname}}) Get{{name}}() {{vendorExtensions.x-go-base-type}} {
+        func (o *{{classname}}) Get{{name}}() {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}} {
         if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{^vendorExtensions.x-golang-is-container}}|| o.{{name}}.Get() == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
-        var ret {{vendorExtensions.x-go-base-type}}
+        var ret {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}}
         return ret
         }
         {{#isNullable}}
@@ -166,7 +166,7 @@ return &this
         {{#isNullable}}
             // NOTE: If the value is an explicit nil, `nil, true` will be returned
         {{/isNullable}}
-        func (o *{{classname}}) Get{{name}}Ok() (*{{vendorExtensions.x-go-base-type}}, bool) {
+        func (o *{{classname}}) Get{{name}}Ok() (*{{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}}, bool) {
         if o == nil {{^isNullable}}|| o.{{name}} == nil{{/isNullable}}{{#isNullable}}{{#vendorExtensions.x-golang-is-container}}|| o.{{name}} == nil{{/vendorExtensions.x-golang-is-container}}{{/isNullable}} {
         return nil, false
         }
@@ -193,7 +193,7 @@ return &this
         }
 
         // Set{{name}} gets a reference to the given {{dataType}} and assigns it to the {{name}} field.
-        func (o *{{classname}}) Set{{name}}(v {{vendorExtensions.x-go-base-type}}) {
+        func (o *{{classname}}) Set{{name}}(v {{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-base-type}}{{/vendorExtensions.x-go-field-type}}) {
         {{#isNullable}}
             {{#vendorExtensions.x-golang-is-container}}
                 o.{{name}} = v
@@ -286,7 +286,7 @@ return json.Marshal(toSerialize)
                 {{#description}}
                     // {{{description}}}
                 {{/description}}
-                {{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{{dataType}}} `json:"{{baseName}}{{^required}},omitempty{{/required}}" yaml:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
+                {{name}} {{^required}}{{^isNullable}}*{{/isNullable}}{{/required}}{{#vendorExtensions.x-go-field-type}}{{vendorExtensions.x-go-field-type}}{{/vendorExtensions.x-go-field-type}}{{^vendorExtensions.x-go-field-type}}{{{dataType}}}{{/vendorExtensions.x-go-field-type}} `json:"{{baseName}}{{^required}},omitempty{{/required}}" yaml:"{{baseName}}{{^required}},omitempty{{/required}}"{{#withXml}} xml:"{{baseName}}{{#isXmlAttribute}},attr{{/isXmlAttribute}}"{{/withXml}}{{#vendorExtensions.x-go-custom-tag}} {{{.}}}{{/vendorExtensions.x-go-custom-tag}}`
             {{/vars}}
             }
 


### PR DESCRIPTION
Part of #4 

Experimenting with the dry-run piece of `apply` flushed out a few issues:
* Some collection fields needed to be marked as required for ergonomics (`map` is more usable than `*map`, and the pointer doesn't give us much)
* A missing required field in template application
* A misnamed field in template application
* Most significantly, all IDs returned by template application come back as large ints, not strings
   * I opened influxdata/openapi#158 to track the problem in the source-of-truth. For now, Greg and I decided to leave the server-side impls as they are and work around it in the CLI.
   * The ints that are returned from the server are random `unit64`s, so the usual trick of `type: integer` + `format: int64` doesn't work (I saw overflows when unmarshalling)
   * To fix the above, I introduced a new vendor extension for setting an explicit type. This required making changes to our codegen template