### PR TITLE
refactor: expose method for building onboarding requests

### DIFF
--- a/clients/setup/setup.go
+++ b/clients/setup/setup.go
@@ -55,7 +55,7 @@ func (c Client) Setup(ctx context.Context, params *Params) error {
 	}
 
 	// Initialize the server.
-	setupBody, err := c.onboardingRequest(params)
+	setupBody, err := c.OnboardingRequest(params)
 	if err != nil {
 		return err
 	}
@@ -118,10 +118,10 @@ func (c Client) validateNoNameCollision(configName string) error {
 	return nil
 }
 
-// onboardingRequest constructs a request body for the onboarding API.
+// OnboardingRequest constructs a request body for the onboarding API.
 // Unless the 'force' parameter is set, the user will be prompted to enter any missing information
 // and to confirm the final request parameters.
-func (c Client) onboardingRequest(params *Params) (req api.OnboardingRequest, err error) {
+func (c Client) OnboardingRequest(params *Params) (req api.OnboardingRequest, err error) {
 	if (params.Force || params.Password != "") && len(params.Password) < stdio.MinPasswordLen {
 		return req, clients.ErrPasswordIsTooShort
 	}


### PR DESCRIPTION
In support of influxdata/influxdb#21838, also make the `OnboardingRequest` method public so it can be reused.