### PR TITLE
fix: set content-encoding: gzip for non-legacy KV restore

### DIFF
--- a/clients/restore/restore.go
+++ b/clients/restore/restore.go
@@ -166,7 +166,7 @@ func (c Client) fullRestore(ctx context.Context, path string, legacy bool) error
 	// Upload metadata snapshots to the server.
 	log.Println("INFO: Restoring KV snapshot")
 	kvReq := c.PostRestoreKV(ctx).ContentType("application/octet-stream").Body(kvBytes)
-	if legacy {
+	if !legacy {
 		kvReq = kvReq.ContentEncoding("gzip")
 	}
 	if err := kvReq.Execute(); err != nil {


### PR DESCRIPTION
And this is why automated tests are a good thing...