### PR TITLE
fix: fix env var used for configs path

### DIFF
--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -173,7 +173,7 @@ func configPathFlag() cli.Flag {
 	return &cli.StringFlag{
 		Name:   configPathFlagName,
 		Usage:  "Path to the influx CLI configurations",
-		EnvVar: "INFLUX_CLI_CONFIGS_PATH",
+		EnvVar: "INFLUX_CONFIGS_PATH",
 	}
 }
 


### PR DESCRIPTION
Making the env var match what's used in the old CLI