### PR TITLE
feat: Bind skip-verify flag to INFLUX_SKIP_VERIFY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,13 +32,15 @@ The command now uses lowerCamelCase consistently for all objects keys, matching 
 ### Features
 
 1. [33](https://github.com/influxdata/influx-cli/pull/33): Add global `--http-debug` flag to help inspect communication with InfluxDB servers.
-1. [52](https://github.com/influxdata/influx-cli/pull/52): Add `bucket-schema` commands to manage explicit measurement schemas in InfluxDB Cloud.
-1. [52](https://github.com/influxdata/influx-cli/pull/52): Update `bucket create` to allow setting a schema type.
-1. [52](https://github.com/influxdata/influx-cli/pull/52): Update `bucket list` to display schema types.
-1. [116](https://github.com/influxdata/influx-cli/pull/116): Reimplement `backup` to support downloading embedded SQL store from InfluxDB v2.1.x.
-1. [116](https://github.com/influxdata/influx-cli/pull/116): Add `--compression` flag to `backup` to support enabling/disabling GZIP compression of downloaded files.
-1. [121](https://github.com/influxdata/influx-cli/pull/121): Reimplement `restore` to support uploading embedded SQL store from InfluxDB v2.1.x.
-1. [191](https://github.com/influxdata/influx-cli/pull/191): Add `--password` flag to `user password` command to allow bypassing interactive prompt.
+2. [52](https://github.com/influxdata/influx-cli/pull/52): Add `bucket-schema` commands to manage explicit measurement schemas in InfluxDB Cloud.
+3. [52](https://github.com/influxdata/influx-cli/pull/52): Update `bucket create` to allow setting a schema type.
+4. [52](https://github.com/influxdata/influx-cli/pull/52): Update `bucket list` to display schema types.
+5. [116](https://github.com/influxdata/influx-cli/pull/116): Reimplement `backup` to support downloading embedded SQL store from InfluxDB v2.1.x.
+6. [116](https://github.com/influxdata/influx-cli/pull/116): Add `--compression` flag to `backup` to support enabling/disabling GZIP compression of downloaded files.
+7. [121](https://github.com/influxdata/influx-cli/pull/121): Reimplement `restore` to support uploading embedded SQL store from InfluxDB v2.1.x.
+8. [191](https://github.com/influxdata/influx-cli/pull/191): Add `--password` flag to `user password` command to allow bypassing interactive prompt.
+9. [208](https://github.com/influxdata/influx-cli/pull/208): Bind `--skip-verify` flag to `INFLUX_SKIP_VERIFY` environment variable.
+
 
 ### Bug Fixes
 

--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -186,8 +186,9 @@ func coreFlags() []cli.Flag {
 			EnvVar: "INFLUX_HOST",
 		},
 		&cli.BoolFlag{
-			Name:  skipVerifyFlagName,
-			Usage: "Skip TLS certificate chain and host name verification",
+			Name:   skipVerifyFlagName,
+			Usage:  "Skip TLS certificate chain and host name verification",
+			EnvVar: "INFLUX_SKIP_VERIFY",
 		},
 		configPathFlag(),
 		&cli.StringFlag{


### PR DESCRIPTION
This PR binds the `--skip-verify` flag to the `INFLUX_SKIP_VERIFY` environment variable. This allows a user to omit specifying the flag for every invocation of the `influx` command, and is particularly useful when using the `influx` command in development environments.