### PR TITLE
refactor: replace uses of `ioutil` with `io` and `os`

### DIFF
--- a/api/api_authorizations.gen.go
+++ b/api/api_authorizations.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -225,7 +225,7 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuth
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -394,7 +394,7 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -419,7 +419,7 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -546,7 +546,7 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -571,7 +571,7 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -712,7 +712,7 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -737,7 +737,7 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -866,7 +866,7 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -902,7 +902,7 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_backup.gen.go
+++ b/api/api_backup.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -189,7 +189,7 @@ func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethtt
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -324,7 +324,7 @@ func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataReques
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -483,7 +483,7 @@ func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest)
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_bucket_schemas.gen.go
+++ b/api/api_bucket_schemas.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -241,7 +241,7 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -268,7 +268,7 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -419,7 +419,7 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -436,7 +436,7 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -587,7 +587,7 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -614,7 +614,7 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -776,7 +776,7 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -803,7 +803,7 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_buckets.gen.go
+++ b/api/api_buckets.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -225,7 +225,7 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -441,7 +441,7 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -466,7 +466,7 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -593,7 +593,7 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -618,7 +618,7 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -759,7 +759,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -784,7 +784,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -913,7 +913,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -949,7 +949,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_dashboards.gen.go
+++ b/api/api_dashboards.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"reflect"
@@ -265,7 +265,7 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -290,7 +290,7 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_dbrps.gen.go
+++ b/api/api_dbrps.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -249,7 +249,7 @@ func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -465,7 +465,7 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -501,7 +501,7 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -652,7 +652,7 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -688,7 +688,7 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -853,7 +853,7 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -900,7 +900,7 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1029,7 +1029,7 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1065,7 +1065,7 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_delete.gen.go
+++ b/api/api_delete.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -219,7 +219,7 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_health.gen.go
+++ b/api/api_health.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -160,7 +160,7 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -196,7 +196,7 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_legacy_authorizations.gen.go
+++ b/api/api_legacy_authorizations.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -238,7 +238,7 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r A
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -431,7 +431,7 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -456,7 +456,7 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -583,7 +583,7 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -608,7 +608,7 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -749,7 +749,7 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -774,7 +774,7 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -903,7 +903,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -939,7 +939,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1078,7 +1078,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_organizations.gen.go
+++ b/api/api_organizations.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -267,7 +267,7 @@ func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) 
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -421,7 +421,7 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsID
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -614,7 +614,7 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -639,7 +639,7 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -766,7 +766,7 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -791,7 +791,7 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -918,7 +918,7 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -954,7 +954,7 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1095,7 +1095,7 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1120,7 +1120,7 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1249,7 +1249,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1274,7 +1274,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1415,7 +1415,7 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1440,7 +1440,7 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_query.gen.go
+++ b/api/api_query.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -219,7 +219,7 @@ func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Res
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_restore.gen.go
+++ b/api/api_restore.gen.go
@@ -14,7 +14,6 @@ import (
 	_context "context"
 	_fmt "fmt"
 	_io "io"
-	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -251,7 +250,7 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -276,7 +275,7 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -405,7 +404,7 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -430,7 +429,7 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -581,7 +580,7 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) erro
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -738,7 +737,7 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -907,7 +906,7 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_secrets.gen.go
+++ b/api/api_secrets.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -200,7 +200,7 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -225,7 +225,7 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -364,7 +364,7 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -509,7 +509,7 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_setup.gen.go
+++ b/api/api_setup.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -176,7 +176,7 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -193,7 +193,7 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -323,7 +323,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -348,7 +348,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_stacks.gen.go
+++ b/api/api_stacks.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"reflect"
@@ -218,7 +218,7 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -243,7 +243,7 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -369,7 +369,7 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -531,7 +531,7 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -556,7 +556,7 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -671,7 +671,7 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -696,7 +696,7 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -825,7 +825,7 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -850,7 +850,7 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_tasks.gen.go
+++ b/api/api_tasks.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -330,7 +330,7 @@ func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error 
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -473,7 +473,7 @@ func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDReq
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -678,7 +678,7 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -703,7 +703,7 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -830,7 +830,7 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -855,7 +855,7 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -982,7 +982,7 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1007,7 +1007,7 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1182,7 +1182,7 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1207,7 +1207,7 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1346,7 +1346,7 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1371,7 +1371,7 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1510,7 +1510,7 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1535,7 +1535,7 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1677,7 +1677,7 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1702,7 +1702,7 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1831,7 +1831,7 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1856,7 +1856,7 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1994,7 +1994,7 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -2019,7 +2019,7 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -2169,7 +2169,7 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -2194,7 +2194,7 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_telegrafs.gen.go
+++ b/api/api_telegrafs.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -225,7 +225,7 @@ func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDReq
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -358,7 +358,7 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -383,7 +383,7 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -522,7 +522,7 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -547,7 +547,7 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -676,7 +676,7 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -701,7 +701,7 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -842,7 +842,7 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -867,7 +867,7 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_templates.gen.go
+++ b/api/api_templates.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -175,7 +175,7 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -211,7 +211,7 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -325,7 +325,7 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -350,7 +350,7 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_users.gen.go
+++ b/api/api_users.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 	"strings"
@@ -238,7 +238,7 @@ func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error 
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)
@@ -419,7 +419,7 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -444,7 +444,7 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -571,7 +571,7 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -596,7 +596,7 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -737,7 +737,7 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -762,7 +762,7 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -891,7 +891,7 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 			body.Close()
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -916,7 +916,7 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 		body.Close()
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
@@ -1055,7 +1055,7 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -13,7 +13,7 @@ package api
 import (
 	_context "context"
 	_fmt "fmt"
-	_ioutil "io/ioutil"
+	_io "io"
 	_nethttp "net/http"
 	_neturl "net/url"
 )
@@ -269,7 +269,7 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 			body.Close()
 			return _fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return _fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -313,7 +312,7 @@ func (c *APIClient) prepareRequest(
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", buf.Len())
 		w.Close()
-		body = ioutil.NopCloser(buf)
+		body = io.NopCloser(buf)
 	}
 
 	if strings.HasPrefix(headerParams["Content-Type"], "application/x-www-form-urlencoded") && len(formParams) > 0 {
@@ -322,7 +321,7 @@ func (c *APIClient) prepareRequest(
 		}
 		buf := &bytes.Buffer{}
 		buf.WriteString(formParams.Encode())
-		body = ioutil.NopCloser(buf)
+		body = io.NopCloser(buf)
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", buf.Len())
 	}
@@ -455,7 +454,7 @@ func setBody(body interface{}, contentType string) (io.ReadCloser, error) {
 	if rc, ok := body.(io.ReadCloser); ok {
 		return rc, nil
 	} else if reader, ok := body.(io.Reader); ok {
-		return ioutil.NopCloser(reader), nil
+		return io.NopCloser(reader), nil
 	} else if fp, ok := body.(**os.File); ok {
 		return *fp, nil
 	}
@@ -482,7 +481,7 @@ func setBody(body interface{}, contentType string) (io.ReadCloser, error) {
 	if bodyBuf.Len() == 0 {
 		return nil, fmt.Errorf("invalid body type %s", contentType)
 	}
-	return ioutil.NopCloser(bodyBuf), nil
+	return io.NopCloser(bodyBuf), nil
 }
 
 // detectContentType method is used to figure out `Request.Body` content type for request header

--- a/api/gunzip_test.go
+++ b/api/gunzip_test.go
@@ -3,7 +3,6 @@ package api_test
 import (
 	"compress/gzip"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -28,7 +27,7 @@ func TestGunzipIfNeeded(t *testing.T) {
 		{
 			name: "no gzip",
 			getBody: func(t *testing.T) io.ReadCloser {
-				return ioutil.NopCloser(strings.NewReader(exampleResponse))
+				return io.NopCloser(strings.NewReader(exampleResponse))
 			},
 		},
 		{
@@ -67,7 +66,7 @@ func TestGunzipIfNeeded(t *testing.T) {
 			raw, err := api.GunzipIfNeeded(&resp)
 			require.NoError(t, err)
 			defer raw.Close()
-			body, err := ioutil.ReadAll(raw)
+			body, err := io.ReadAll(raw)
 			require.NoError(t, err)
 			require.Equal(t, exampleResponse, string(body))
 		})

--- a/api/templates/api.mustache
+++ b/api/templates/api.mustache
@@ -6,7 +6,6 @@ import (
 	"bytes"
 	_context "context"
 	_io "io"
-	_ioutil "io/ioutil"
 	_nethttp "net/http"
 	_neturl "net/url"
 	_fmt "fmt"
@@ -278,7 +277,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	}
 {{/required}}
 	if localVarFile != nil {
-		fbs, _ := _ioutil.ReadAll(localVarFile)
+		fbs, _ := _io.ReadAll(localVarFile)
 		localVarFileBytes = fbs
 		localVarFileName = localVarFile.Name()
 		localVarFile.Close()
@@ -369,7 +368,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 			body.Close()
 			return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
 		}
-		localVarBody, err := _ioutil.ReadAll(body)
+		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
 			return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
@@ -416,7 +415,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		body.Close()
 		return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
 	}
-	localVarBody, err := _ioutil.ReadAll(body)
+	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
 		return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)

--- a/api/templates/client.mustache
+++ b/api/templates/client.mustache
@@ -9,7 +9,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"mime/multipart"
 	"net/http"
@@ -268,7 +267,7 @@ func (c *APIClient) prepareRequest(
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", buf.Len())
 		w.Close()
-		body = ioutil.NopCloser(buf)
+		body = io.NopCloser(buf)
 	}
 
 	if strings.HasPrefix(headerParams["Content-Type"], "application/x-www-form-urlencoded") && len(formParams) > 0 {
@@ -277,7 +276,7 @@ func (c *APIClient) prepareRequest(
 		}
 		buf := &bytes.Buffer{}
 		buf.WriteString(formParams.Encode())
-		body = ioutil.NopCloser(buf)
+		body = io.NopCloser(buf)
 		// Set Content-Length
 		headerParams["Content-Length"] = fmt.Sprintf("%d", buf.Len())
 	}
@@ -451,7 +450,7 @@ func setBody(body interface{}, contentType string) (io.ReadCloser, error) {
 	if rc, ok := body.(io.ReadCloser); ok {
 		return rc, nil
 	} else if reader, ok := body.(io.Reader); ok {
-		return ioutil.NopCloser(reader), nil
+		return io.NopCloser(reader), nil
 	} else if fp, ok := body.(**os.File); ok {
 		return *fp, nil
 	}
@@ -478,7 +477,7 @@ func setBody(body interface{}, contentType string) (io.ReadCloser, error) {
 	if bodyBuf.Len() == 0 {
 		return nil, fmt.Errorf("invalid body type %s", contentType)
 	}
-	return ioutil.NopCloser(bodyBuf), nil
+	return io.NopCloser(bodyBuf), nil
 }
 
 // detectContentType method is used to figure out `Request.Body` content type for request header

--- a/clients/backup/backup_internal_test.go
+++ b/clients/backup/backup_internal_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -143,7 +142,7 @@ func TestBackup_DownloadMetadata(t *testing.T) {
 					}
 					require.NoError(t, writer.Close())
 
-					res := http.Response{Header: http.Header{}, Body: ioutil.NopCloser(&out)}
+					res := http.Response{Header: http.Header{}, Body: io.NopCloser(&out)}
 					res.Header.Add("Content-Type", fmt.Sprintf("multipart/mixed; boundary=%s", writer.Boundary()))
 					if tc.responseCompression == br.GzipCompression {
 						res.Header.Add("Content-Encoding", "gzip")
@@ -157,7 +156,7 @@ func TestBackup_DownloadMetadata(t *testing.T) {
 				baseName:  "test",
 			}
 
-			out, err := ioutil.TempDir("", "")
+			out, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(out)
 
@@ -180,7 +179,7 @@ func TestBackup_DownloadMetadata(t *testing.T) {
 				defer gzr.Close()
 				kvReader = gzr
 			}
-			kvBytes, err := ioutil.ReadAll(kvReader)
+			kvBytes, err := io.ReadAll(kvReader)
 			require.NoError(t, err)
 			require.Equal(t, fakeKV, string(kvBytes))
 
@@ -195,7 +194,7 @@ func TestBackup_DownloadMetadata(t *testing.T) {
 				defer gzr.Close()
 				sqlReader = gzr
 			}
-			sqlBytes, err := ioutil.ReadAll(sqlReader)
+			sqlBytes, err := io.ReadAll(sqlReader)
 			require.NoError(t, err)
 			require.Equal(t, fakeSQL, string(sqlBytes))
 		})
@@ -255,7 +254,7 @@ func TestBackup_DownloadShardData(t *testing.T) {
 					}
 					_, err := outW.Write([]byte(fakeTsm))
 					require.NoError(t, err)
-					res := http.Response{Header: http.Header{}, Body: ioutil.NopCloser(&out)}
+					res := http.Response{Header: http.Header{}, Body: io.NopCloser(&out)}
 					res.Header.Add("Content-Type", "application/octet-stream")
 					if tc.responseCompression == br.GzipCompression {
 						res.Header.Add("Content-Encoding", "gzip")
@@ -269,7 +268,7 @@ func TestBackup_DownloadShardData(t *testing.T) {
 				baseName:  "test",
 			}
 
-			out, err := ioutil.TempDir("", "")
+			out, err := os.MkdirTemp("", "")
 			require.NoError(t, err)
 			defer os.RemoveAll(out)
 
@@ -292,7 +291,7 @@ func TestBackup_DownloadShardData(t *testing.T) {
 				defer gzr.Close()
 				shardReader = gzr
 			}
-			shardBytes, err := ioutil.ReadAll(shardReader)
+			shardBytes, err := io.ReadAll(shardReader)
 			require.NoError(t, err)
 			require.Equal(t, fakeTsm, string(shardBytes))
 		})
@@ -314,7 +313,7 @@ func TestBackup_DownloadShardData(t *testing.T) {
 			baseName:  "test",
 		}
 
-		out, err := ioutil.TempDir("", "")
+		out, err := os.MkdirTemp("", "")
 		require.NoError(t, err)
 		defer os.RemoveAll(out)
 

--- a/clients/helpers.go
+++ b/clients/helpers.go
@@ -2,7 +2,7 @@ package clients
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 )
@@ -19,7 +19,7 @@ func ReadQuery(filepath string, args []string) (string, error) {
 	}
 
 	readFile := func(path string) (string, error) {
-		queryBytes, err := ioutil.ReadFile(path)
+		queryBytes, err := os.ReadFile(path)
 		if err != nil {
 			return "", fmt.Errorf("failed to read query from %q: %w", path, err)
 		}
@@ -27,7 +27,7 @@ func ReadQuery(filepath string, args []string) (string, error) {
 	}
 
 	readStdin := func() (string, error) {
-		queryBytes, err := ioutil.ReadAll(os.Stdin)
+		queryBytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return "", fmt.Errorf("failed to read query from stdin: %w", err)
 		}

--- a/clients/query/formatting_printer_test.go
+++ b/clients/query/formatting_printer_test.go
@@ -2,7 +2,7 @@ package query_test
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -141,7 +141,7 @@ Table: keys: [_start, _stop, _field, _measurement, bar]
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			in := ioutil.NopCloser(strings.NewReader(tc.in))
+			in := io.NopCloser(strings.NewReader(tc.in))
 			out := bytes.Buffer{}
 			require.NoError(t, query.NewFormattingPrinter().PrintQueryResults(in, &out))
 			require.Equal(t, tc.expected, out.String())

--- a/clients/query/query_test.go
+++ b/clients/query/query_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -76,7 +75,7 @@ func TestRawResultPrinter_PrintQueryResults(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			in := ioutil.NopCloser(strings.NewReader(tc.rawTable))
+			in := io.NopCloser(strings.NewReader(tc.rawTable))
 			out := bytes.Buffer{}
 			require.NoError(t, query.RawResultPrinter.PrintQueryResults(in, &out))
 			require.Equal(t, tc.rawTable, out.String())
@@ -120,7 +119,7 @@ func TestQuery(t *testing.T) {
 						assert.Equal(t, fakeQuery, *body) &&
 						assert.Equal(t, orgID.String(), *in.GetOrgID()) &&
 						assert.Nil(t, in.GetOrg())
-				})).Return(&http.Response{Body: ioutil.NopCloser(strings.NewReader(fakeResults))}, nil)
+				})).Return(&http.Response{Body: io.NopCloser(strings.NewReader(fakeResults))}, nil)
 			},
 		},
 		{
@@ -140,7 +139,7 @@ func TestQuery(t *testing.T) {
 						assert.Equal(t, fakeQuery, *body) &&
 						assert.Equal(t, "my-org", *in.GetOrg()) &&
 						assert.Nil(t, in.GetOrgID())
-				})).Return(&http.Response{Body: ioutil.NopCloser(strings.NewReader(fakeResults))}, nil)
+				})).Return(&http.Response{Body: io.NopCloser(strings.NewReader(fakeResults))}, nil)
 			},
 		},
 		{
@@ -158,7 +157,7 @@ func TestQuery(t *testing.T) {
 						assert.Equal(t, fakeQuery, *body) &&
 						assert.Equal(t, "default-org", *in.GetOrg()) &&
 						assert.Nil(t, in.GetOrgID())
-				})).Return(&http.Response{Body: ioutil.NopCloser(strings.NewReader(fakeResults))}, nil)
+				})).Return(&http.Response{Body: io.NopCloser(strings.NewReader(fakeResults))}, nil)
 			},
 		},
 		{
@@ -189,7 +188,7 @@ func TestQuery(t *testing.T) {
 						assert.Equal(t, expectedBody, *body) &&
 						assert.Equal(t, "default-org", *in.GetOrg()) &&
 						assert.Nil(t, in.GetOrgID())
-				})).Return(&http.Response{Body: ioutil.NopCloser(strings.NewReader(fakeResults))}, nil)
+				})).Return(&http.Response{Body: io.NopCloser(strings.NewReader(fakeResults))}, nil)
 			},
 		},
 		{

--- a/clients/write/multi_reader_test.go
+++ b/clients/write/multi_reader_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"os"
@@ -30,7 +29,7 @@ func readLines(reader io.Reader) []string {
 func createTempFile(t *testing.T, suffix string, contents []byte, compress bool) string {
 	t.Helper()
 
-	file, err := ioutil.TempFile("", "influx_writeTest*."+suffix)
+	file, err := os.CreateTemp("", "influx_writeTest*."+suffix)
 	require.NoError(t, err)
 	defer file.Close()
 
@@ -77,7 +76,7 @@ func (c *mockClient) Do(req *http.Request) (*http.Response, error) {
 		}
 		_, err := writer.Write([]byte(data))
 		require.NoError(c.t, err)
-		resp.Body = ioutil.NopCloser(&body)
+		resp.Body = io.NopCloser(&body)
 	}
 
 	return &resp, nil

--- a/clients/write/write_test.go
+++ b/clients/write/write_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"context"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -25,7 +24,7 @@ type bufferReader struct {
 }
 
 func (pr *bufferReader) Open(context.Context) (io.Reader, io.Closer, error) {
-	return &pr.buf, ioutil.NopCloser(nil), nil
+	return &pr.buf, io.NopCloser(nil), nil
 }
 
 type noopThrottler struct {

--- a/cmd/influx/telegrafs.go
+++ b/cmd/influx/telegrafs.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 
 	"github.com/influxdata/influx-cli/v2/clients/telegrafs"
@@ -213,7 +213,7 @@ Examples:
 
 func readConfig(file string) (string, error) {
 	if file != "" {
-		bb, err := ioutil.ReadFile(file)
+		bb, err := os.ReadFile(file)
 		if err != nil {
 			return "", fmt.Errorf("failed to read telegraf config from %q: %w", file, err)
 		}
@@ -221,7 +221,7 @@ func readConfig(file string) (string, error) {
 		return string(bb), nil
 	}
 
-	bb, err := ioutil.ReadAll(os.Stdin)
+	bb, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		return "", fmt.Errorf("failed to read telegraf config from stdin: %w", err)
 	}

--- a/config/local.go
+++ b/config/local.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -285,5 +284,5 @@ func (s ioStore) writeConfigs(cfgs Configs) error {
 	if err := (baseRW{w: &b1}).writeConfigs(cfgs); err != nil {
 		return err
 	}
-	return ioutil.WriteFile(s.Path, b1.Bytes(), 0600)
+	return os.WriteFile(s.Path, b1.Bytes(), 0600)
 }

--- a/pkg/csv2lp/csv2lp_test.go
+++ b/pkg/csv2lp/csv2lp_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"errors"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -200,7 +199,7 @@ func Test_CsvToLineProtocol_LogTableColumns(t *testing.T) {
 	require.False(t, reader.skipRowOnError)
 	require.True(t, reader.logTableDataColumns)
 	// read all the data
-	ioutil.ReadAll(reader)
+	io.ReadAll(reader)
 
 	out := buf.String()
 	// fmt.Println(out)
@@ -228,7 +227,7 @@ func Test_CsvToLineProtocol_LogTimeZoneWarning(t *testing.T) {
 		"_measurement,a,b\ncpu,1,1"
 
 	reader := CsvToLineProtocol(strings.NewReader(csv))
-	bytes, _ := ioutil.ReadAll(reader)
+	bytes, _ := io.ReadAll(reader)
 
 	out := buf.String()
 	// fmt.Println(out) // "::PREFIX::WARNING:  #timezone annotation: unknown time zone 1
@@ -258,7 +257,7 @@ func Test_CsvToLineProtocol_SkipRowOnError(t *testing.T) {
 	require.Equal(t, reader.skipRowOnError, true)
 	require.Equal(t, reader.logTableDataColumns, false)
 	// read all the data
-	ioutil.ReadAll(reader)
+	io.ReadAll(reader)
 
 	out := buf.String()
 	// fmt.Println(out)
@@ -315,7 +314,7 @@ func Test_CsvToLineProtocol_RowSkipped(t *testing.T) {
 		})
 	}
 	// read all the data
-	ioutil.ReadAll(reader)
+	io.ReadAll(reader)
 
 	out := buf.String()
 	require.Empty(t, out, "No log messages expected because RowSkipped handler is set")
@@ -410,7 +409,7 @@ cpu;3a
 		})
 	}
 	// read all the data
-	ioutil.ReadAll(reader)
+	io.ReadAll(reader)
 
 	out := buf.String()
 	require.Empty(t, out, "No log messages expected because RowSkipped handler is set")
@@ -445,7 +444,7 @@ func Test_CsvToLineProtocol_LineEndingWarning(t *testing.T) {
 		"1549240000000000000,xx:xx:xx:xx:xx:xx,2nd Floor Open Plan DS,0,test"
 
 	reader := CsvToLineProtocol(strings.NewReader(csv))
-	bytes, _ := ioutil.ReadAll(reader)
+	bytes, _ := io.ReadAll(reader)
 
 	out := buf.String()
 	messages := strings.Count(out, prefix)
@@ -475,7 +474,7 @@ func Test_CsvToLineProtocol_WindowsLineEndings(t *testing.T) {
 		"1549240000000000000,a,b,0,test"
 
 	reader := CsvToLineProtocol(strings.NewReader(csv))
-	bytes, _ := ioutil.ReadAll(reader)
+	bytes, _ := io.ReadAll(reader)
 
 	out := buf.String()
 	messages := strings.Count(out, prefix)

--- a/pkg/csv2lp/data_conversion_test.go
+++ b/pkg/csv2lp/data_conversion_test.go
@@ -3,7 +3,7 @@ package csv2lp
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"os"
@@ -283,7 +283,7 @@ func Test_NormalizeNumberString(t *testing.T) {
 func Test_CreateDecoder(t *testing.T) {
 	decoder, err := CreateDecoder("UTF-8")
 	toUtf8 := func(in []byte) string {
-		s, _ := ioutil.ReadAll(decoder(bytes.NewReader(in)))
+		s, _ := io.ReadAll(decoder(bytes.NewReader(in)))
 		return string(s)
 	}
 	require.NotNil(t, decoder)

--- a/pkg/csv2lp/examples_test.go
+++ b/pkg/csv2lp/examples_test.go
@@ -2,7 +2,7 @@ package csv2lp
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 
@@ -184,7 +184,7 @@ func Test_Examples(t *testing.T) {
 			comma := example.normalize()
 			transformer := CsvToLineProtocol(strings.NewReader(example.csv))
 			transformer.SkipRowOnError(true)
-			result, err := ioutil.ReadAll(transformer)
+			result, err := io.ReadAll(transformer)
 			if err != nil {
 				require.Nil(t, fmt.Sprintf("%s", err))
 			}

--- a/pkg/fluxcsv/query_result_test.go
+++ b/pkg/fluxcsv/query_result_test.go
@@ -2,7 +2,7 @@ package fluxcsv_test
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -67,7 +67,7 @@ func TestQueryCVSResultSingleTable(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())
 
@@ -296,7 +296,7 @@ func TestQueryCVSResultMultiTables(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())
 
@@ -411,7 +411,7 @@ func TestQueryCVSResultSingleTableMultiColumnsNoValue(t *testing.T) {
 	require.NoError(t, err)
 
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())
 
@@ -439,7 +439,7 @@ func TestErrorInRow(t *testing.T) {
 		`,failed to create physical plan: invalid time bounds from procedure from: bounds contain zero time,897`}
 	csvTable := makeCSVstring(csvRowsError)
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
@@ -453,7 +453,7 @@ func TestErrorInRow(t *testing.T) {
 		`,failed to create physical plan: invalid time bounds from procedure from: bounds contain zero time,`}
 	csvTable = makeCSVstring(csvRowsErrorNoReference)
 	reader = strings.NewReader(csvTable)
-	queryResult = fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult = fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
@@ -467,7 +467,7 @@ func TestErrorInRow(t *testing.T) {
 		`,,`}
 	csvTable = makeCSVstring(csvRowsErrorNoMessage)
 	reader = strings.NewReader(csvTable)
-	queryResult = fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult = fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
@@ -484,7 +484,7 @@ func TestInvalidDataType(t *testing.T) {
 `
 
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "unknown data type int", queryResult.Err().Error())
@@ -546,7 +546,7 @@ func TestReorderedAnnotations(t *testing.T) {
 
 `
 	reader := strings.NewReader(csvTable1)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())
 
@@ -572,7 +572,7 @@ func TestReorderedAnnotations(t *testing.T) {
 
 `
 	reader = strings.NewReader(csvTable2)
-	queryResult = fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult = fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())
 
@@ -644,7 +644,7 @@ func TestDatatypeOnlyAnnotation(t *testing.T) {
 
 `
 	reader := strings.NewReader(csvTable1)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())
 
@@ -672,7 +672,7 @@ func TestMissingDatatypeAnnotation(t *testing.T) {
 `
 
 	reader := strings.NewReader(csvTable1)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "parsing error, datatype annotation not found", queryResult.Err().Error())
@@ -686,7 +686,7 @@ func TestMissingDatatypeAnnotation(t *testing.T) {
 `
 
 	reader = strings.NewReader(csvTable2)
-	queryResult = fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult = fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "parsing error, datatype annotation not found", queryResult.Err().Error())
@@ -700,7 +700,7 @@ func TestMissingAnnotations(t *testing.T) {
 
 `
 	reader := strings.NewReader(csvTable3)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "parsing error, annotations not found", queryResult.Err().Error())
@@ -715,7 +715,7 @@ func TestDifferentNumberOfColumns(t *testing.T) {
 `
 
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "parsing error, row has different number of columns than the table: 11 vs 10", queryResult.Err().Error())
@@ -728,7 +728,7 @@ func TestDifferentNumberOfColumns(t *testing.T) {
 `
 
 	reader = strings.NewReader(csvTable2)
-	queryResult = fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult = fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "parsing error, row has different number of columns than the table: 8 vs 10", queryResult.Err().Error())
@@ -741,7 +741,7 @@ func TestDifferentNumberOfColumns(t *testing.T) {
 `
 
 	reader = strings.NewReader(csvTable3)
-	queryResult = fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult = fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 	require.False(t, queryResult.Next())
 	require.NotNil(t, queryResult.Err())
 	require.Equal(t, "parsing error, row has different number of columns than the table: 10 vs 8", queryResult.Err().Error())
@@ -758,7 +758,7 @@ func TestEmptyValue(t *testing.T) {
 `
 
 	reader := strings.NewReader(csvTable)
-	queryResult := fluxcsv.NewQueryTableResult(ioutil.NopCloser(reader))
+	queryResult := fluxcsv.NewQueryTableResult(io.NopCloser(reader))
 
 	require.True(t, queryResult.Next(), queryResult.Err())
 	require.Nil(t, queryResult.Err())

--- a/pkg/gzip/pipe_test.go
+++ b/pkg/gzip/pipe_test.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"errors"
 	"io"
-	"io/ioutil"
 	"strings"
 	"testing"
 
@@ -21,7 +20,7 @@ func TestGzipPipe(t *testing.T) {
 
 		data := strings.Repeat("Data data I'm some data\n", 1024)
 		reader := strings.NewReader(data)
-		pipe := pgzip.NewGzipPipe(ioutil.NopCloser(reader))
+		pipe := pgzip.NewGzipPipe(io.NopCloser(reader))
 		defer pipe.Close()
 		gunzip, err := gzip.NewReader(pipe)
 		require.NoError(t, err)
@@ -38,7 +37,7 @@ func TestGzipPipe(t *testing.T) {
 		t.Parallel()
 
 		reader := &failingReader{n: 3, err: errors.New("I BROKE")}
-		pipe := pgzip.NewGzipPipe(ioutil.NopCloser(reader))
+		pipe := pgzip.NewGzipPipe(io.NopCloser(reader))
 		defer pipe.Close()
 		gunzip, err := gzip.NewReader(pipe)
 		require.NoError(t, err)

--- a/pkg/jsonnet/decode.go
+++ b/pkg/jsonnet/decode.go
@@ -3,7 +3,6 @@ package jsonnet
 import (
 	"encoding/json"
 	"io"
-	"io/ioutil"
 
 	"github.com/google/go-jsonnet"
 )
@@ -20,7 +19,7 @@ func NewDecoder(r io.Reader) *Decoder {
 
 // Decode decodes the stream into the provide value.
 func (d *Decoder) Decode(v interface{}) error {
-	b, err := ioutil.ReadAll(d.r)
+	b, err := io.ReadAll(d.r)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #141

Mostly mechanical find-and-replace, but some of the functions used to create temp files/dirs had to be updated to use new names