### PR TITLE
build: upgrade staticcheck to latest version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,12 +40,8 @@ bin/$(GOOS)/influx: $(SOURCES)
 .DEFAULT_GOAL := influx
 influx: bin/$(GOOS)/influx
 
-vendor: go.mod go.sum
-	go mod vendor
-
 clean:
 	$(RM) -r bin
-	$(RM) -r vendor
 
 ### Linters
 checkfmt:
@@ -57,7 +53,7 @@ checktidy:
 checkopenapi:
 	./etc/checkopenapi.sh
 
-staticcheck: $(SOURCES) vendor
+staticcheck: $(SOURCES)
 	go run honnef.co/go/tools/cmd/staticcheck -go $(GOVERSION) ./...
 
 vet:

--- a/go.mod
+++ b/go.mod
@@ -21,5 +21,5 @@ require (
 	golang.org/x/text v0.3.3
 	golang.org/x/tools v0.1.0
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
-	honnef.co/go/tools v0.1.3
+	honnef.co/go/tools v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -122,5 +122,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-honnef.co/go/tools v0.1.3 h1:qTakTkI6ni6LFD5sBwwsdSO+AQqbSIxOauHTTQKZ/7o=
-honnef.co/go/tools v0.1.3/go.mod h1:NgwopIslSNH47DimFoV78dnkksY2EFtX0ajyb3K/las=
+honnef.co/go/tools v0.2.0 h1:ws8AfbgTX3oIczLPNPCu5166oBg9ST2vNs0rcht+mDE=
+honnef.co/go/tools v0.2.0/go.mod h1:lPVVZ2BS5TfnjLyizF7o7hv7j9/L+8cZY2hLyjP9cGY=


### PR DESCRIPTION
I was curious what might get flushed out by the upgrade, but looks like there weren't any lurking issues. Upgrading lets us get rid of the `go mod vendor` requirement, which is nice.