### PR TITLE
fix: make `--http-debug` flag visible in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [221](https://github.com/influxdata/influx-cli/pull/221): Fix shell completion for top-level `influx` commands.
+1. [228](https://github.com/influxdata/influx-cli/pull/228): Make global `--http-debug` flag visible in help text.
 
 ## v2.1.0 [2021-07-29]
 

--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -203,7 +203,6 @@ func coreFlags() []cli.Flag {
 		},
 		&cli.BoolFlag{
 			Name:   httpDebugFlagName,
-			Hidden: true,
 		},
 	}
 }

--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -202,7 +202,7 @@ func coreFlags() []cli.Flag {
 			EnvVar: "INFLUX_TRACE_DEBUG_ID",
 		},
 		&cli.BoolFlag{
-			Name:   httpDebugFlagName,
+			Name: httpDebugFlagName,
 		},
 	}
 }


### PR DESCRIPTION
Closes #227 