### PR TITLE
fix: don't set empty strings for IDs in permission resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [221](https://github.com/influxdata/influx-cli/pull/221): Fix shell completion for top-level `influx` commands.
 1. [228](https://github.com/influxdata/influx-cli/pull/228): Make global `--http-debug` flag visible in help text.
+1. [232](https://github.com/influxdata/influx-cli/pull/232): Don't set empty strings for IDs in permission resources.
 
 ## v2.1.0 [2021-07-29]
 

--- a/clients/auth/auth.go
+++ b/clients/auth/auth.go
@@ -413,11 +413,14 @@ func (c Client) printAuth(opts printParams) error {
 }
 
 func makePermResource(permType string, id string, orgId string) api.PermissionResource {
-	return api.PermissionResource{
-		Type:  permType,
-		Id:    &id,
-		OrgID: &orgId,
+	pr := api.PermissionResource{Type: permType}
+	if id != "" {
+		pr.Id = &id
 	}
+	if orgId != "" {
+		pr.OrgID = &orgId
+	}
+	return pr
 }
 
 func (c Client) getOrgID(ctx context.Context, params clients.OrgParams) (string, error) {

--- a/clients/auth/auth_internal_test.go
+++ b/clients/auth/auth_internal_test.go
@@ -1,0 +1,53 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/influxdata/influx-cli/v2/api"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_makePermResource(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		inType   string
+		inId     string
+		inOrgId  string
+		expected api.PermissionResource
+	}{
+		{
+			name:     "only type",
+			inType:   "foo",
+			expected: api.PermissionResource{Type: "foo"},
+		},
+		{
+			name:     "type and ID",
+			inType:   "bar",
+			inId:     "12345",
+			expected: api.PermissionResource{Type: "bar", Id: api.PtrString("12345")},
+		},
+		{
+			name:     "type and org ID",
+			inType:   "baz",
+			inOrgId:  "45678",
+			expected: api.PermissionResource{Type: "baz", OrgID: api.PtrString("45678")},
+		},
+		{
+			name:     "type, ID, and org ID",
+			inType:   "qux",
+			inId:     "12345",
+			inOrgId:  "45678",
+			expected: api.PermissionResource{Type: "qux", Id: api.PtrString("12345"), OrgID: api.PtrString("45678")},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, makePermResource(tc.inType, tc.inId, tc.inOrgId))
+		})
+	}
+}


### PR DESCRIPTION
Closes #229 