### PR TITLE
fix: --host value passed to setup is written to generated config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This release upgrades the project to `go` version 1.17.
 1. [228](https://github.com/influxdata/influx-cli/pull/228): Make global `--http-debug` flag visible in help text.
 1. [232](https://github.com/influxdata/influx-cli/pull/232): Don't set empty strings for IDs in permission resources.
 1. [236](https://github.com/influxdata/influx-cli/pull/236): Detect and error out on incorrect positional args.
+1. [255](https://github.com/influxdata/influx-cli/pull/255): Respect value of `--host` flag when writing CLI configs in `setup`.
 
 ## v2.1.0 [2021-07-29]
 

--- a/clients/setup/setup.go
+++ b/clients/setup/setup.go
@@ -36,6 +36,7 @@ type Params struct {
 	Retention  string
 	Force      bool
 	ConfigName string
+	Host       string
 }
 
 func (c Client) Setup(ctx context.Context, params *Params) error {
@@ -66,12 +67,15 @@ func (c Client) Setup(ctx context.Context, params *Params) error {
 
 	cfg := config.Config{
 		Name:  config.DefaultConfig.Name,
-		Host:  c.ActiveConfig.Host,
+		Host:  config.DefaultConfig.Host,
 		Token: *resp.Auth.Token,
 		Org:   resp.Org.Name,
 	}
 	if params.ConfigName != "" {
 		cfg.Name = params.ConfigName
+	}
+	if params.Host != "" {
+		cfg.Host = params.Host
 	}
 
 	if _, err := c.ConfigService.CreateConfig(cfg); err != nil {

--- a/clients/setup/setup_test.go
+++ b/clients/setup/setup_test.go
@@ -139,13 +139,12 @@ func Test_SetupSuccessNoninteractive(t *testing.T) {
 			assert.Equal(t, retentionSecs, *body.RetentionPeriodSeconds)
 	})).Return(resp, nil)
 
-	host := "fake-host"
 	configSvc := mock.NewMockConfigService(ctrl)
 	configSvc.EXPECT().ListConfigs().Return(nil, nil)
 	configSvc.EXPECT().CreateConfig(tmock.MatchedBy(func(in config.Config) bool {
 		return assert.Equal(t, params.ConfigName, in.Name) &&
 			assert.Equal(t, params.AuthToken, in.Token) &&
-			assert.Equal(t, host, in.Host) &&
+			assert.Equal(t, config.DefaultConfig.Host, in.Host) &&
 			assert.Equal(t, params.Org, in.Org)
 	})).DoAndReturn(func(in config.Config) (config.Config, error) {
 		return in, nil
@@ -155,7 +154,7 @@ func Test_SetupSuccessNoninteractive(t *testing.T) {
 	bytesWritten := bytes.Buffer{}
 	stdio.EXPECT().Write(gomock.Any()).DoAndReturn(bytesWritten.Write).AnyTimes()
 	cli := setup.Client{
-		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{Host: host}, StdIO: stdio},
+		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{}, StdIO: stdio},
 		SetupApi: client,
 	}
 	require.NoError(t, cli.Setup(context.Background(), &params))
@@ -198,13 +197,12 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 			assert.Equal(t, retentionSecs, *body.RetentionPeriodSeconds)
 	})).Return(resp, nil)
 
-	host := "fake-host"
 	configSvc := mock.NewMockConfigService(ctrl)
 	configSvc.EXPECT().ListConfigs().Return(nil, nil)
 	configSvc.EXPECT().CreateConfig(tmock.MatchedBy(func(in config.Config) bool {
 		return assert.Equal(t, config.DefaultConfig.Name, in.Name) &&
 			assert.Equal(t, token, in.Token) &&
-			assert.Equal(t, host, in.Host) &&
+			assert.Equal(t, config.DefaultConfig.Host, in.Host) &&
 			assert.Equal(t, org, in.Org)
 	})).DoAndReturn(func(in config.Config) (config.Config, error) {
 		return in, nil
@@ -221,7 +219,7 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 	stdio.EXPECT().GetStringInput("Please type your retention period in hours, or 0 for infinite", gomock.Any()).Return(strconv.Itoa(retentionHrs), nil)
 	stdio.EXPECT().GetConfirm(gomock.Any()).Return(true)
 	cli := setup.Client{
-		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{Host: host}, StdIO: stdio},
+		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{}, StdIO: stdio},
 		SetupApi: client,
 	}
 	require.NoError(t, cli.Setup(context.Background(), &setup.Params{}))
@@ -231,7 +229,7 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 	}, strings.Split(bytesWritten.String(), "\n"))
 }
 
-func Test_SetupPasswordParamToShort(t *testing.T) {
+func Test_SetupPasswordParamTooShort(t *testing.T) {
 	t.Parallel()
 
 	retentionSecs := int64(duration.Week.Seconds())
@@ -250,13 +248,12 @@ func Test_SetupPasswordParamToShort(t *testing.T) {
 	client.EXPECT().GetSetup(gomock.Any()).Return(api.ApiGetSetupRequest{ApiService: client})
 	client.EXPECT().GetSetupExecute(gomock.Any()).Return(api.InlineResponse200{Allowed: api.PtrBool(true)}, nil)
 
-	host := "fake-host"
 	configSvc := mock.NewMockConfigService(ctrl)
 	configSvc.EXPECT().ListConfigs().Return(nil, nil)
 
 	stdio := mock.NewMockStdIO(ctrl)
 	cli := setup.Client{
-		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{Host: host}, StdIO: stdio},
+		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{}, StdIO: stdio},
 		SetupApi: client,
 	}
 	err := cli.Setup(context.Background(), &params)
@@ -282,7 +279,6 @@ func Test_SetupCancelAtConfirmation(t *testing.T) {
 	client.EXPECT().GetSetup(gomock.Any()).Return(api.ApiGetSetupRequest{ApiService: client})
 	client.EXPECT().GetSetupExecute(gomock.Any()).Return(api.InlineResponse200{Allowed: api.PtrBool(true)}, nil)
 
-	host := "fake-host"
 	configSvc := mock.NewMockConfigService(ctrl)
 	configSvc.EXPECT().ListConfigs().Return(nil, nil)
 
@@ -291,9 +287,72 @@ func Test_SetupCancelAtConfirmation(t *testing.T) {
 	stdio.EXPECT().GetConfirm(gomock.Any()).Return(false)
 
 	cli := setup.Client{
-		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{Host: host}, StdIO: stdio},
+		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{}, StdIO: stdio},
 		SetupApi: client,
 	}
 	err := cli.Setup(context.Background(), &params)
 	require.Equal(t, setup.ErrSetupCanceled, err)
+}
+
+func Test_SetupNonDefaultHost(t *testing.T) {
+	t.Parallel()
+
+	retentionSecs := int64(duration.Week.Seconds())
+	params := setup.Params{
+		Username:   "user",
+		Password:   "mysecretpassword",
+		AuthToken:  "mytoken",
+		Org:        "org",
+		Bucket:     "bucket",
+		Retention:  fmt.Sprintf("%ds", retentionSecs),
+		Force:      true,
+		ConfigName: "my-config",
+		Host:       "https://my-server.foo",
+	}
+	resp := api.OnboardingResponse{
+		Auth:   &api.Authorization{Token: &params.AuthToken},
+		Org:    &api.Organization{Name: params.Org},
+		User:   &api.UserResponse{Name: params.Username},
+		Bucket: &api.Bucket{Name: params.Bucket},
+	}
+
+	ctrl := gomock.NewController(t)
+	client := mock.NewMockSetupApi(ctrl)
+	client.EXPECT().GetSetup(gomock.Any()).Return(api.ApiGetSetupRequest{ApiService: client})
+	client.EXPECT().GetSetupExecute(gomock.Any()).Return(api.InlineResponse200{Allowed: api.PtrBool(true)}, nil)
+	client.EXPECT().PostSetup(gomock.Any()).Return(api.ApiPostSetupRequest{ApiService: client})
+	client.EXPECT().PostSetupExecute(tmock.MatchedBy(func(in api.ApiPostSetupRequest) bool {
+		body := in.GetOnboardingRequest()
+		return assert.NotNil(t, body) &&
+			assert.Equal(t, params.Username, body.Username) &&
+			assert.Equal(t, params.Password, *body.Password) &&
+			assert.Equal(t, params.AuthToken, *body.Token) &&
+			assert.Equal(t, params.Org, body.Org) &&
+			assert.Equal(t, params.Bucket, body.Bucket) &&
+			assert.Equal(t, retentionSecs, *body.RetentionPeriodSeconds)
+	})).Return(resp, nil)
+
+	configSvc := mock.NewMockConfigService(ctrl)
+	configSvc.EXPECT().ListConfigs().Return(nil, nil)
+	configSvc.EXPECT().CreateConfig(tmock.MatchedBy(func(in config.Config) bool {
+		return assert.Equal(t, params.ConfigName, in.Name) &&
+			assert.Equal(t, params.AuthToken, in.Token) &&
+			assert.Equal(t, params.Host, in.Host) &&
+			assert.Equal(t, params.Org, in.Org)
+	})).DoAndReturn(func(in config.Config) (config.Config, error) {
+		return in, nil
+	})
+
+	stdio := mock.NewMockStdIO(ctrl)
+	bytesWritten := bytes.Buffer{}
+	stdio.EXPECT().Write(gomock.Any()).DoAndReturn(bytesWritten.Write).AnyTimes()
+	cli := setup.Client{
+		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{}, StdIO: stdio},
+		SetupApi: client,
+	}
+	require.NoError(t, cli.Setup(context.Background(), &params))
+	testutils.MatchLines(t, []string{
+		`User\s+Organization\s+Bucket`,
+		fmt.Sprintf(`%s\s+%s\s+%s`, params.Username, params.Org, params.Bucket),
+	}, strings.Split(bytesWritten.String(), "\n"))
 }

--- a/cmd/influx/setup.go
+++ b/cmd/influx/setup.go
@@ -57,6 +57,9 @@ func newSetupCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if ctx.IsSet(hostFlagName) {
+				params.Host = ctx.String(hostFlagName)
+			}
 			client := setup.Client{
 				CLI:      getCLI(ctx),
 				SetupApi: getAPINoToken(ctx).SetupApi,


### PR DESCRIPTION
Closes #253

The previous behavior would wrongly copy the host of the currently-active config to the newly-generated config.