### PR TITLE
chore: add shorthand for `--bucket` to `influx delete`

### DIFF
--- a/cmd/influx/delete.go
+++ b/cmd/influx/delete.go
@@ -33,7 +33,7 @@ func newDeleteCmd() cli.Command {
 				Value:  &params.BucketID,
 			},
 			&cli.StringFlag{
-				Name:        "bucket",
+				Name:        "bucket, b",
 				Usage:       "The name of the bucket to delete from",
 				EnvVar:      "INFLUX_BUCKET_NAME",
 				Destination: &params.BucketName,


### PR DESCRIPTION
When trying to test my issue with `SHOW TAG VALUES`, I noticed that most commands (for example, `influx write`) allow for specifying either `--bucket` or `-b`, however `delete` only allowed `--bucket`. This PR adds the ability to use `-b` for `delete`