### PR TITLE
fix: make `--http-debug` flag visible in help text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [260](https://github.com/influxdata/influx-cli/pull/260): Fix shell completion for top-level `influx` commands.
+1. [261](https://github.com/influxdata/influx-cli/pull/261): Make global `--http-debug` flag visible in help text.
 
 ## v2.1.0 [2021-07-29]
 

--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -202,8 +202,7 @@ func coreFlags() []cli.Flag {
 			EnvVar: "INFLUX_TRACE_DEBUG_ID",
 		},
 		&cli.BoolFlag{
-			Name:   httpDebugFlagName,
-			Hidden: true,
+			Name: httpDebugFlagName,
 		},
 	}
 }


### PR DESCRIPTION
Backports #228 