### PR TITLE
chore(Makefile): allow specifying -gcflags via env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,15 @@ endif
 ifdef COMMIT
 	LDFLAGS += -X main.commit=$(COMMIT)
 endif
-export GO_BUILD=go build -ldflags "$(LDFLAGS)"
+
+# Use default flags, but allow adding -gcflags "..." if desired. Eg, for debug
+# builds, may want to use GCFLAGS="all=-N -l" in the build environment.
+GCFLAGS ?=
+ifneq ($(GCFLAGS),)
+GCFLAGS := -gcflags "$(GCFLAGS)"
+endif
+
+export GO_BUILD=go build $(GCFLAGS) -ldflags "$(LDFLAGS)"
 
 # SOURCES are the files that affect building the main binary.
 SOURCES := $(shell find . -name '*.go' -not -name '*_test.go') go.mod go.sum


### PR DESCRIPTION
Make targets may call '$(GO_BUILD)', but there is no facility for
specifying arguments to 'go build'. As a first step, introduce the
GCFLAGS Makefile variable that when unset, operates as always, but when
set, adds '-gcflags "$(GCFLAGS)"' to go build. Eg, when unspecified,
maintain the current behavior (though with an additional space):
```
$ make
CGO_ENABLED=0 go build  -ldflags ...
```

When specified, add the specified -gcflags:
```
$ GCFLAGS="all=-N -l" make
CGO_ENABLED=0 go build -gcflags "all=-N -l" -ldflags ...
```
This could be useful in various situations such as producing unoptimized
builds (like in the above).