### PR TITLE
fix: allow explicit empty request bodies

### DIFF
--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -478,15 +478,14 @@ func setBody(body interface{}, contentType string) (io.ReadCloser, error) {
 		err = json.NewEncoder(bodyBuf).Encode(body)
 	} else if xmlCheck.MatchString(contentType) {
 		err = xml.NewEncoder(bodyBuf).Encode(body)
+	} else {
+		err = fmt.Errorf("invalid body type %s", contentType)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	if bodyBuf.Len() == 0 {
-		return nil, fmt.Errorf("invalid body type %s", contentType)
-	}
 	return io.NopCloser(bodyBuf), nil
 }
 

--- a/api/templates/client.mustache
+++ b/api/templates/client.mustache
@@ -468,15 +468,14 @@ func setBody(body interface{}, contentType string) (io.ReadCloser, error) {
 		err = json.NewEncoder(bodyBuf).Encode(body)
 	} else if xmlCheck.MatchString(contentType) {
 		err = xml.NewEncoder(bodyBuf).Encode(body)
+	} else {
+		err = fmt.Errorf("invalid body type %s", contentType)
 	}
 
 	if err != nil {
 		return nil, err
 	}
 
-	if bodyBuf.Len() == 0 {
-		return nil, fmt.Errorf("invalid body type %s", contentType)
-	}
 	return io.NopCloser(bodyBuf), nil
 }
 


### PR DESCRIPTION
For some use-cases (i.e. sending a no-op write request) it's useful to be able to specify a body of `[]byte{}`. This refactors our codegen template to allow that.