### PR TITLE
feat: added functionality for `remote delete` command

### DIFF
--- a/api/configuration.gen.go
+++ b/api/configuration.gen.go
@@ -109,7 +109,7 @@ func NewConfiguration() *Configuration {
 		OperationServers: map[string]ServerConfigurations{
 			"HealthApiService.GetHealth": {
 				{
-					URL:         "/",
+					URL:         "",
 					Description: "No description provided",
 				},
 			},

--- a/clients/remote/remote.go
+++ b/clients/remote/remote.go
@@ -101,6 +101,29 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 	return c.printRemote(printOpts)
 }
 
+func (c Client) Delete(ctx context.Context, remoteID string) error {
+	connection, err := c.GetRemoteConnectionByID(ctx, remoteID).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to delete remote connection %q: %w", remoteID, err)
+	}
+
+	req := c.DeleteRemoteConnectionByID(ctx, remoteID)
+
+	// send delete request
+	err = req.Execute()
+	if err != nil {
+		return fmt.Errorf("failed to delete remote connection %q: %w", remoteID, err)
+	}
+
+	// print deleted connection info
+	printOpts := printRemoteOpts{
+		remote:  &connection,
+		deleted: true,
+	}
+
+	return c.printRemote(printOpts)
+}
+
 type printRemoteOpts struct {
 	remote  *api.RemoteConnection
 	remotes []api.RemoteConnection

--- a/cmd/influx/remote.go
+++ b/cmd/influx/remote.go
@@ -92,13 +92,29 @@ func newRemoteCreateCmd() cli.Command {
 }
 
 func newRemoteDeleteCmd() cli.Command {
+	var remoteID string
 	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete an existing remote connection",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
-		Flags:  commonFlags(),
-		Action: func(ctx *cli.Context) {
-			fmt.Println("remote delete command was called")
+		Flags: append(
+			commonFlags(),
+			&cli.StringFlag{
+				Name:        "remote-id, id",
+				Usage:       "ID of the remote connection to be deleted",
+				Required:    true,
+				Destination: &remoteID,
+			},
+		),
+		Action: func(ctx *cli.Context) error {
+			api := getAPI(ctx)
+
+			client := remote.Client{
+				CLI:                  getCLI(ctx),
+				RemoteConnectionsApi: api.RemoteConnectionsApi,
+			}
+
+			return client.Delete(getContext(ctx), remoteID)
 		},
 	}
 }


### PR DESCRIPTION
Closes #244 

This command deletes an existing remote connection. Remote ID is the only flag, and it is required.