### PR TITLE
fix: removed unused `fmt` import in `remote` cmd code

### DIFF
--- a/cmd/influx/remote.go
+++ b/cmd/influx/remote.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/influxdata/influx-cli/v2/clients/remote"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/urfave/cli"


### PR DESCRIPTION
Import of `fmt` in `remote` cmd code was no longer necessary after two recent merges. This should resolve the current cross-build failure in CircleCI.