### PR TITLE
feat: added functionality for `replication create` command

### DIFF
--- a/clients/replication/replication.go
+++ b/clients/replication/replication.go
@@ -3,6 +3,7 @@ package replication
 import (
 	"context"
 	"fmt"
+
 	"github.com/influxdata/influx-cli/v2/api"
 	"github.com/influxdata/influx-cli/v2/clients"
 )
@@ -14,14 +15,14 @@ type Client struct {
 }
 
 type CreateParams struct {
-	Name             string
-	Description      string
-	OrgID			 string
-	OrgName			 string
-	RemoteID         string
-	LocalBucketID	 string
-	RemoteBucketID   string
-	MaxQueueSize	 int64
+	Name           string
+	Description    string
+	OrgID          string
+	OrgName        string
+	RemoteID       string
+	LocalBucketID  string
+	RemoteBucketID string
+	MaxQueueSize   int64
 }
 
 func (c Client) Create(ctx context.Context, params *CreateParams) error {
@@ -32,43 +33,33 @@ func (c Client) Create(ctx context.Context, params *CreateParams) error {
 
 	// set up a struct with required params
 	body := api.ReplicationCreationRequest{
-		Name:params.Name,
-		OrgID: orgID,
-		RemoteID: params.RemoteID,
+		Name:              params.Name,
+		OrgID:             orgID,
+		RemoteID:          params.RemoteID,
+		LocalBucketID:     params.LocalBucketID,
+		RemoteBucketID:    params.RemoteBucketID,
 		MaxQueueSizeBytes: params.MaxQueueSize,
 	}
-
-	fmt.Printf("body: %+v\n", body)
-	fmt.Printf("length of remote-id: %+v\n", len(body.RemoteID))
-	fmt.Printf("length of org-id: %+v\n", len(body.OrgID))
 
 	// set optional params if specified
 	if params.Description != "" {
 		body.Description = &params.Description
 	}
 
-	if params.LocalBucketID != "" {
-		body.LocalBucketID = params.LocalBucketID
-	}
-	fmt.Printf("length of local bucket: %+v\n", len(body.LocalBucketID))
-	if params.RemoteBucketID != "" {
-		body.RemoteBucketID = params.RemoteBucketID
-	}
-	fmt.Printf("length of remote bucket: %+v\n", len(body.RemoteBucketID))
 	// send post request
 	res, err := c.PostReplication(ctx).ReplicationCreationRequest(body).Execute()
 	if err != nil {
 		return fmt.Errorf("failed to create replication stream %q: %w", params.Name, err)
 	}
 
-	// print confirmation of new connection
+	// print confirmation of new replication stream
 	return c.printReplication(printReplicationOpts{replication: &res})
 }
 
 type printReplicationOpts struct {
 	replication  *api.Replication
 	replications []api.Replication
-	deleted bool
+	deleted      bool
 }
 
 func (c Client) printReplication(opts printReplicationOpts) error {
@@ -94,14 +85,14 @@ func (c Client) printReplication(opts printReplicationOpts) error {
 	var rows []map[string]interface{}
 	for _, r := range opts.replications {
 		row := map[string]interface{}{
-			"ID":                 		r.GetId(),
-			"Name":               		r.GetName(),
-			"Description":		  		r.GetDescription(),
-			"Org ID":             		r.GetOrgID(),
-			"Remote Connection ID":		r.GetRemoteID(),
-			"Local Bucket":		  		r.GetLocalBucketID(),
-			"Remote Bucket":      		r.GetRemoteBucketID(),
-			"Max Queue Size Bytes":			r.GetMaxQueueSizeBytes(),
+			"ID":                   r.GetId(),
+			"Name":                 r.GetName(),
+			"Description":          r.GetDescription(),
+			"Org ID":               r.GetOrgID(),
+			"Remote Connection ID": r.GetRemoteID(),
+			"Local Bucket":         r.GetLocalBucketID(),
+			"Remote Bucket":        r.GetRemoteBucketID(),
+			"Max Queue Size Bytes": r.GetMaxQueueSizeBytes(),
 		}
 		if opts.deleted {
 			row["Deleted"] = true

--- a/clients/replication/replication.go
+++ b/clients/replication/replication.go
@@ -1,0 +1,113 @@
+package replication
+
+import (
+	"context"
+	"fmt"
+	"github.com/influxdata/influx-cli/v2/api"
+	"github.com/influxdata/influx-cli/v2/clients"
+)
+
+type Client struct {
+	clients.CLI
+	api.ReplicationsApi
+	api.OrganizationsApi
+}
+
+type CreateParams struct {
+	Name             string
+	Description      string
+	OrgID			 string
+	OrgName			 string
+	RemoteID         string
+	LocalBucketID	 string
+	RemoteBucketID   string
+	MaxQueueSize	 int64
+}
+
+func (c Client) Create(ctx context.Context, params *CreateParams) error {
+	orgID, err := c.GetOrgId(ctx, params.OrgID, params.OrgName, c.OrganizationsApi)
+	if err != nil {
+		return err
+	}
+
+	// set up a struct with required params
+	body := api.ReplicationCreationRequest{
+		Name:params.Name,
+		OrgID: orgID,
+		RemoteID: params.RemoteID,
+		MaxQueueSizeBytes: params.MaxQueueSize,
+	}
+
+	fmt.Printf("body: %+v\n", body)
+	fmt.Printf("length of remote-id: %+v\n", len(body.RemoteID))
+	fmt.Printf("length of org-id: %+v\n", len(body.OrgID))
+
+	// set optional params if specified
+	if params.Description != "" {
+		body.Description = &params.Description
+	}
+
+	if params.LocalBucketID != "" {
+		body.LocalBucketID = params.LocalBucketID
+	}
+	fmt.Printf("length of local bucket: %+v\n", len(body.LocalBucketID))
+	if params.RemoteBucketID != "" {
+		body.RemoteBucketID = params.RemoteBucketID
+	}
+	fmt.Printf("length of remote bucket: %+v\n", len(body.RemoteBucketID))
+	// send post request
+	res, err := c.PostReplication(ctx).ReplicationCreationRequest(body).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to create replication stream %q: %w", params.Name, err)
+	}
+
+	// print confirmation of new connection
+	return c.printReplication(printReplicationOpts{replication: &res})
+}
+
+type printReplicationOpts struct {
+	replication  *api.Replication
+	replications []api.Replication
+	deleted bool
+}
+
+func (c Client) printReplication(opts printReplicationOpts) error {
+	if c.PrintAsJSON {
+		var v interface{}
+		if opts.replication != nil {
+			v = opts.replication
+		} else {
+			v = opts.replications
+		}
+		return c.PrintJSON(v)
+	}
+
+	headers := []string{"ID", "Name", "Description", "Org ID", "Remote Connection ID", "Local Bucket", "Remote Bucket", "Max Queue Size Bytes"}
+	if opts.deleted {
+		headers = append(headers, "Deleted")
+	}
+
+	if opts.replication != nil {
+		opts.replications = append(opts.replications, *opts.replication)
+	}
+
+	var rows []map[string]interface{}
+	for _, r := range opts.replications {
+		row := map[string]interface{}{
+			"ID":                 		r.GetId(),
+			"Name":               		r.GetName(),
+			"Description":		  		r.GetDescription(),
+			"Org ID":             		r.GetOrgID(),
+			"Remote Connection ID":		r.GetRemoteID(),
+			"Local Bucket":		  		r.GetLocalBucketID(),
+			"Remote Bucket":      		r.GetRemoteBucketID(),
+			"Max Queue Size Bytes":			r.GetMaxQueueSizeBytes(),
+		}
+		if opts.deleted {
+			row["Deleted"] = true
+		}
+		rows = append(rows, row)
+	}
+
+	return c.PrintTable(headers, rows...)
+}

--- a/clients/replication/replication.go
+++ b/clients/replication/replication.go
@@ -73,7 +73,8 @@ func (c Client) printReplication(opts printReplicationOpts) error {
 		return c.PrintJSON(v)
 	}
 
-	headers := []string{"ID", "Name", "Description", "Org ID", "Remote Connection ID", "Local Bucket", "Remote Bucket", "Max Queue Size Bytes"}
+	headers := []string{"ID", "Name", "Org ID", "Remote ID", "Local Bucket ID", "Remote Bucket ID", "Max Queue Bytes",
+		"Current Queue Bytes", "Latest Status Code"}
 	if opts.deleted {
 		headers = append(headers, "Deleted")
 	}
@@ -85,14 +86,15 @@ func (c Client) printReplication(opts printReplicationOpts) error {
 	var rows []map[string]interface{}
 	for _, r := range opts.replications {
 		row := map[string]interface{}{
-			"ID":                   r.GetId(),
-			"Name":                 r.GetName(),
-			"Description":          r.GetDescription(),
-			"Org ID":               r.GetOrgID(),
-			"Remote Connection ID": r.GetRemoteID(),
-			"Local Bucket":         r.GetLocalBucketID(),
-			"Remote Bucket":        r.GetRemoteBucketID(),
-			"Max Queue Size Bytes": r.GetMaxQueueSizeBytes(),
+			"ID":                  r.GetId(),
+			"Name":                r.GetName(),
+			"Org ID":              r.GetOrgID(),
+			"Remote ID":           r.GetRemoteID(),
+			"Local Bucket ID":     r.GetLocalBucketID(),
+			"Remote Bucket ID":    r.GetRemoteBucketID(),
+			"Max Queue Bytes":     r.GetMaxQueueSizeBytes(),
+			"Current Queue Bytes": r.GetCurrentQueueSizeBytes(),
+			"Latest Status Code":  r.GetLatestResponseCode(),
 		}
 		if opts.deleted {
 			row["Deleted"] = true

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -74,7 +74,7 @@ func newReplicationCreateCmd() cli.Command {
 			&cli.Int64Flag{
 				Name:        "max-queue-bytes",
 				Usage:       "Max queue size in bytes",
-				Value:       67108860, // source: http://localhost:8086/docs#operation/PostReplication
+				Value:       67108860, // source: https://github.com/influxdata/openapi/blob/588064fe68e7dfeebd019695aa805832632cbfb6/src/oss/schemas/ReplicationCreationRequest.yml#L19
 				Destination: &params.MaxQueueSize,
 			},
 		),

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"fmt"
-	"github.com/influxdata/influx-cli/v2/clients/replication"
 
+	"github.com/influxdata/influx-cli/v2/clients/replication"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/urfave/cli"
 )
@@ -32,13 +32,13 @@ func newReplicationCreateCmd() cli.Command {
 			commonFlags(),
 			&cli.StringFlag{
 				Name:        "name, n",
-				Usage:       "Name for the new replication stream",
+				Usage:       "Name for new replication stream",
 				Required:    true,
 				Destination: &params.Name,
 			},
 			&cli.StringFlag{
 				Name:        "description, d",
-				Usage:       "Description for the new replication stream",
+				Usage:       "Description for new replication stream",
 				Destination: &params.Description,
 			},
 			&cli.StringFlag{
@@ -54,27 +54,27 @@ func newReplicationCreateCmd() cli.Command {
 				Destination: &params.OrgName,
 			},
 			&cli.StringFlag{
-				Name:        "remote-id, id",
-				Usage:       "Remote connection ID that new replication stream will be registered with",
+				Name:        "remote-id",
+				Usage:       "Remote connection ID new replication stream will be registered with",
 				Required:    true,
 				Destination: &params.RemoteID,
 			},
 			&cli.StringFlag{
-				Name:        "local-bucket-id",
+				Name:        "local-bucket",
 				Usage:       "Local bucket ID for new replication stream",
 				Required:    true,
 				Destination: &params.LocalBucketID,
 			},
 			&cli.StringFlag{
-				Name:        "remote-bucket-id",
+				Name:        "remote-bucket",
 				Usage:       "Remote bucket ID for new replication stream",
 				Required:    true,
 				Destination: &params.RemoteBucketID,
 			},
 			&cli.Int64Flag{
-				Name:		 "max-queue",
-				Usage: 		 "Max queue size in bytes",
-				Value: 		 67108860,
+				Name:        "max-queue",
+				Usage:       "Max queue size in bytes",
+				Value:       67108860,
 				Destination: &params.MaxQueueSize,
 			},
 		),
@@ -82,9 +82,9 @@ func newReplicationCreateCmd() cli.Command {
 			api := getAPI(ctx)
 
 			client := replication.Client{
-				CLI:                  getCLI(ctx),
-				ReplicationsApi: 	  api.ReplicationsApi,
-				OrganizationsApi:     api.OrganizationsApi,
+				CLI:              getCLI(ctx),
+				ReplicationsApi:  api.ReplicationsApi,
+				OrganizationsApi: api.OrganizationsApi,
 			}
 
 			return client.Create(getContext(ctx), &params)

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -55,26 +55,26 @@ func newReplicationCreateCmd() cli.Command {
 			},
 			&cli.StringFlag{
 				Name:        "remote-id",
-				Usage:       "Remote connection ID new replication stream will be registered with",
+				Usage:       "Remote connection the new replication stream should send data to",
 				Required:    true,
 				Destination: &params.RemoteID,
 			},
 			&cli.StringFlag{
 				Name:        "local-bucket",
-				Usage:       "Local bucket ID for new replication stream",
+				Usage:       "ID of local bucket data should be replicated from",
 				Required:    true,
 				Destination: &params.LocalBucketID,
 			},
 			&cli.StringFlag{
 				Name:        "remote-bucket",
-				Usage:       "Remote bucket ID for new replication stream",
+				Usage:       "ID of remote bucket data should be replicated to",
 				Required:    true,
 				Destination: &params.RemoteBucketID,
 			},
 			&cli.Int64Flag{
-				Name:        "max-queue",
+				Name:        "max-queue-bytes",
 				Usage:       "Max queue size in bytes",
-				Value:       67108860,
+				Value:       67108860, // source: http://localhost:8086/docs#operation/PostReplication
 				Destination: &params.MaxQueueSize,
 			},
 		),

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"github.com/influxdata/influx-cli/v2/clients/replication"
 
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/urfave/cli"
@@ -22,13 +23,71 @@ func newReplicationCmd() cli.Command {
 }
 
 func newReplicationCreateCmd() cli.Command {
+	var params replication.CreateParams
 	return cli.Command{
 		Name:   "create",
 		Usage:  "Create a new replication stream",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
-		Flags:  commonFlags(),
-		Action: func(ctx *cli.Context) {
-			fmt.Println("replication create command was called")
+		Flags: append(
+			commonFlags(),
+			&cli.StringFlag{
+				Name:        "name, n",
+				Usage:       "Name for the new replication stream",
+				Required:    true,
+				Destination: &params.Name,
+			},
+			&cli.StringFlag{
+				Name:        "description, d",
+				Usage:       "Description for the new replication stream",
+				Destination: &params.Description,
+			},
+			&cli.StringFlag{
+				Name:        "org-id",
+				Usage:       "The ID of the local organization",
+				EnvVar:      "INFLUX_ORG_ID",
+				Destination: &params.OrgID,
+			},
+			&cli.StringFlag{
+				Name:        "org, o",
+				Usage:       "The name of the local organization",
+				EnvVar:      "INFLUX_ORG",
+				Destination: &params.OrgName,
+			},
+			&cli.StringFlag{
+				Name:        "remote-id, id",
+				Usage:       "Remote connection ID that new replication stream will be registered with",
+				Required:    true,
+				Destination: &params.RemoteID,
+			},
+			&cli.StringFlag{
+				Name:        "local-bucket-id",
+				Usage:       "Local bucket ID for new replication stream",
+				Required:    true,
+				Destination: &params.LocalBucketID,
+			},
+			&cli.StringFlag{
+				Name:        "remote-bucket-id",
+				Usage:       "Remote bucket ID for new replication stream",
+				Required:    true,
+				Destination: &params.RemoteBucketID,
+			},
+			&cli.Int64Flag{
+				Name:		 "max-queue",
+				Usage: 		 "Max queue size in bytes",
+				Value: 		 67108860,
+				Destination: &params.MaxQueueSize,
+			},
+		),
+		Action: func(ctx *cli.Context) error {
+			api := getAPI(ctx)
+
+			client := replication.Client{
+				CLI:                  getCLI(ctx),
+				ReplicationsApi: 	  api.ReplicationsApi,
+				OrganizationsApi:     api.OrganizationsApi,
+			}
+
+			return client.Create(getContext(ctx), &params)
 		},
 	}
 }


### PR DESCRIPTION
Closes #246 

The `replication create` subcommand registers a new replication stream. This configures an existing bucket to replicate all future points to one or more remote InfluxDB instances. 

**Required Flags**

`--name, -n` (Name for new replication stream)
`-- remote-id` (Remote connection the new replication stream should send data to)
`--local-bucket` (ID of local bucket data should be replicated from)
`--remote-bucket` (ID of remote bucket data should be replicated to)

**Optional Flags**

`--description, -d` (Description for new replication stream)
`--org-id` (The ID of the local organization)
`--org, -o` (The name of the local organization)
`--max-queue-bytes` (Max queue size in bytes, default 67108860)

**Note:** A user would need to start with a registered remote connection before creating a replication stream for it. The `influx remote` command can be used to view and manage remote connections. 