### PR TITLE
feat: added functionality for replication delete command

### DIFF
--- a/clients/replication/replication.go
+++ b/clients/replication/replication.go
@@ -105,16 +105,14 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 }
 
 func (c Client) Delete(ctx context.Context, replicationID string) error {
+	// get replication stream via ID
 	connection, err := c.GetReplicationByID(ctx, replicationID).Execute()
 	if err != nil {
-		return fmt.Errorf("failed to delete replication stream %q: %w", replicationID, err)
+		return fmt.Errorf("could not find replication stream with ID %q: %w", replicationID, err)
 	}
 
-	req := c.DeleteReplicationByID(ctx, replicationID)
-
 	// send delete request
-	err = req.Execute()
-	if err != nil {
+	if err := c.DeleteReplicationByID(ctx, replicationID).Execute(); err != nil {
 		return fmt.Errorf("failed to delete replication stream %q: %w", replicationID, err)
 	}
 

--- a/clients/replication/replication.go
+++ b/clients/replication/replication.go
@@ -104,6 +104,29 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 	return c.printReplication(printOpts)
 }
 
+func (c Client) Delete(ctx context.Context, replicationID string) error {
+	connection, err := c.GetReplicationByID(ctx, replicationID).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to delete replication stream %q: %w", replicationID, err)
+	}
+
+	req := c.DeleteReplicationByID(ctx, replicationID)
+
+	// send delete request
+	err = req.Execute()
+	if err != nil {
+		return fmt.Errorf("failed to delete replication stream %q: %w", replicationID, err)
+	}
+
+	// print deleted replication stream info
+	printOpts := printReplicationOpts{
+		replication: &connection,
+		deleted:     true,
+	}
+
+	return c.printReplication(printOpts)
+}
+
 type printReplicationOpts struct {
 	replication  *api.Replication
 	replications []api.Replication

--- a/cmd/influx/remote.go
+++ b/cmd/influx/remote.go
@@ -98,7 +98,7 @@ func newRemoteDeleteCmd() cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "remote-id, id",
+				Name:        "id, i",
 				Usage:       "ID of the remote connection to be deleted",
 				Required:    true,
 				Destination: &remoteID,
@@ -172,7 +172,7 @@ func newRemoteUpdateCmd() cli.Command {
 		Flags: append(
 			commonFlags(),
 			&cli.StringFlag{
-				Name:        "remote-id, id",
+				Name:        "id, i",
 				Usage:       "Remote connection ID",
 				Required:    true,
 				Destination: &params.RemoteID,

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -93,13 +93,29 @@ func newReplicationCreateCmd() cli.Command {
 }
 
 func newReplicationDeleteCmd() cli.Command {
+	var replicationID string
 	return cli.Command{
 		Name:   "delete",
 		Usage:  "Delete an existing replication stream",
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
-		Flags:  commonFlags(),
-		Action: func(ctx *cli.Context) {
-			fmt.Println("replication delete command was called")
+		Flags: append(
+			commonFlags(),
+			&cli.StringFlag{
+				Name:        "id, i",
+				Usage:       "ID of the replication stream to be deleted",
+				Required:    true,
+				Destination: &replicationID,
+			},
+		),
+		Action: func(ctx *cli.Context) error {
+			api := getAPI(ctx)
+
+			client := replication.Client{
+				CLI:             getCLI(ctx),
+				ReplicationsApi: api.ReplicationsApi,
+			}
+
+			return client.Delete(getContext(ctx), replicationID)
 		},
 	}
 }


### PR DESCRIPTION
Closes #248 

This command deletes an existing replication stream, given its ID. This command will also delete data still in the stream, if any. `id` is the only option for this command, and it is required.

![Screen Shot 2021-10-07 at 10 04 36 AM](https://user-images.githubusercontent.com/58636946/136431254-e15779c4-639b-4287-b354-20a3c3a99947.png)

**Note:** This PR also changes the naming of the `remote-id` flag for `remote update` and `remote delete` subcommands.
`--remote-id, -id` --> `--id, -i`
This was done to maintain consistency with other `influx` CLI commands.