### PR TITLE
fix: embed tzdata into Windows builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,29 @@
 version: "2.1"
 
 executors:
+  cross-builder:
+    docker:
+      # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
+      # then update the version here to match. Until we finish the migration to using the cross-builder image,
+      # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
+      - image: quay.io/influxdb/cross-builder:go1.17.2-f7b4e805fa9588c1c2fa4562ea29e576557fb797
+    resource_class: medium
   linux-amd64:
     machine:
-      image: ubuntu-2004:202104-01
-
+      image: ubuntu-2004:202107-02
   linux-arm64:
     machine:
       image: ubuntu-2004:202104-01
-    resource_class: arm.medium
-
+      resource_class: arm.medium
   mac:
     macos:
       xcode: 12.4.0
-    resource_class: medium
+      resource_class: medium
     shell: /bin/bash -eo pipefail
-
   windows:
     machine:
       image: windows-server-2019-vs2019:stable
-    resource_class: windows.medium
+      resource_class: windows.medium
     shell: bash.exe -eo pipefail
 
 workflows:
@@ -29,14 +33,37 @@ workflows:
       - lint
       - check-openapi
       - build-all
-      - test:
+      - test-race:
+          name: test-linux-amd64
+      - test-build:
           matrix:
             parameters:
-              executor:
-                - linux-amd64
-                - linux-arm64
-                - mac
-                - windows
+              os: [ linux, darwin, windows ]
+              arch: [ amd64, arm64 ]
+            exclude:
+              - os: darwin
+                arch: arm64
+              - os: windows
+                arch: arm64
+              # linux/amd64 can be tested directly from our cross-builder image
+              # to save time & enable running with the race detector.
+              - os: linux
+                arch: amd64
+      - test-prebuilt:
+          name: test-linux-arm64
+          executor: linux-arm64
+          requires:
+            - test-build-arm64-linux
+      - test-prebuilt:
+          name: test-mac
+          executor: mac
+          requires:
+            - test-build-amd64-darwin
+      - test-prebuilt:
+          name: test-windows
+          executor: windows
+          requires:
+            - test-build-amd64-windows
   release-nightly:
     triggers:
       - schedule:
@@ -48,21 +75,46 @@ workflows:
     jobs:
       - lint
       - check-openapi
-      - test:
-          requires:
-            - lint
-            - check-openapi
+      - test-race:
+          name: test-linux-amd64
+      - test-build:
           matrix:
             parameters:
-              executor:
-                - linux-amd64
-                - linux-arm64
-                - mac
-                - windows
+              os: [ linux, darwin, windows ]
+              arch: [ amd64, arm64 ]
+            exclude:
+              - os: darwin
+                arch: arm64
+              - os: windows
+                arch: arm64
+              # linux/amd64 can be tested directly from our cross-builder image
+              # to save time & enable running with the race detector.
+              - os: linux
+                arch: amd64
+      - test-prebuilt:
+          name: test-linux-arm64
+          executor: linux-arm64
+          requires:
+            - test-build-arm64-linux
+      - test-prebuilt:
+          name: test-mac
+          executor: mac
+          requires:
+            - test-build-amd64-darwin
+      - test-prebuilt:
+          name: test-windows
+          executor: windows
+          requires:
+            - test-build-amd64-windows
       - release:
           is-nightly: true
           requires:
-            - test
+            - lint
+            - check-openapi
+            - test-linux-amd64
+            - test-linux-arm64
+            - test-mac
+            - test-windows
   release-tag:
     jobs:
       - lint:
@@ -77,10 +129,14 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
-      - test:
-          requires:
-            - lint
-            - check-openapi
+      - test-race:
+          name: test-linux-amd64
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
+      - test-build:
           filters:
             branches:
               ignore: /.*/
@@ -88,11 +144,47 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
           matrix:
             parameters:
-              executor:
-                - linux-amd64
-                - linux-arm64
-                - mac
-                - windows
+              os: [ linux, darwin, windows ]
+              arch: [ amd64, arm64 ]
+            exclude:
+              - os: darwin
+                arch: arm64
+              - os: windows
+                arch: arm64
+              # linux/amd64 can be tested directly from our cross-builder image
+              # to save time & enable running with the race detector.
+              - os: linux
+                arch: amd64
+      - test-prebuilt:
+          name: test-linux-arm64
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
+          executor: linux-arm64
+          requires:
+            - test-build-arm64-linux
+      - test-prebuilt:
+          name: test-mac
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
+          executor: mac
+          requires:
+            - test-build-amd64-darwin
+      - test-prebuilt:
+          name: test-windows
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
+          executor: windows
+          requires:
+            - test-build-amd64-windows
       - release:
           filters:
             branches:
@@ -101,7 +193,12 @@ workflows:
               only: /^v[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta)[0-9]+)?$/
           is-nightly: false
           requires:
-            - test
+            - lint
+            - check-openapi
+            - test-linux-amd64
+            - test-linux-arm64
+            - test-mac
+            - test-windows
 
 commands:
   setup:
@@ -131,14 +228,25 @@ commands:
 
 jobs:
   lint:
-    executor: linux-amd64
+    executor: cross-builder
     steps:
       - checkout
-      - setup
-      - run: make vet
-      - run: make checkfmt
-      - run: make checktidy
-      - run: make staticcheck
+      - run:
+          name: vet
+          command: make vet
+          when: always
+      - run:
+          name: Check formatting
+          command: make checkfmt
+          when: always
+      - run:
+          name: Check mod tidy
+          command: make checktidy
+          when: always
+      - run:
+          name: staticcheck
+          command: make staticcheck
+          when: always
 
   check-openapi:
     executor: linux-amd64
@@ -201,31 +309,51 @@ jobs:
       - store_artifacts:
           path: dist
 
-  test:
+  test-build:
+    executor: cross-builder
+    parameters:
+      os:
+        type: string
+      arch:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: Build test binaries
+          command: |
+            export GOOS=<< parameters.os >>
+            export GOARCH=<< parameters.arch >>
+            ./scripts/ci/build-tests.sh ./test-bin
+      - persist_to_workspace:
+          root: .
+          paths:
+            - ./test-bin
+
+  test-prebuilt:
     parameters:
       executor:
         type: executor
     executor: << parameters.executor >>
     steps:
       - checkout
-      - setup
+      - attach_workspace:
+          at: .
       - run:
-          name: Download gotestsum
-          command: |
-            GOTESTSUM_VERSION=1.6.4
-            GOTESTSUM_ARCHIVE=gotestsum_${GOTESTSUM_VERSION}_$(go env GOOS)_$(go env GOARCH).tar.gz
-            GOTESTSUM_URL=https://github.com/gotestyourself/gotestsum/releases/download/v${GOTESTSUM_VERSION}/${GOTESTSUM_ARCHIVE}
+          name: Run tests
+          command: ./scripts/ci/run-prebuilt-tests.sh $(pwd)/test-bin $(pwd)/test-results
+      - store_artifacts:
+          path: ./test-results
+          destination: raw-test-output
+      - store_test_results:
+          path: ./test-results
 
-            wget ${GOTESTSUM_URL}
-            tar xzf ${GOTESTSUM_ARCHIVE}
-            install gotestsum ${GOPATH}/bin/
+  test-race:
+    executor: cross-builder
+    steps:
+      - checkout
       - run:
-          name: Run parallel race tests
-          command: |
-            mkdir -p test-results
-            GO_TEST_CMD="gotestsum --format standard-quiet --junitfile ./test-results/gotestsum.xml --"
-            TESTFILES=($(go list ./... | circleci tests split --split-by=timings))
-            make GO_TEST="$GO_TEST_CMD" GO_TEST_PATHS="${TESTFILES[*]}" test-race
+          name: Run race tests
+          command: ./scripts/ci/run-race-tests.sh $(pwd)/test-results
       - store_artifacts:
           path: ./test-results
           destination: raw-test-output

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,8 @@ builds:
     main: ./cmd/influx
     env:
       - CGO_ENABLED=0
+    flags:
+      - -tags={{if eq .Os "windows"}}timetzdata{{end}}
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.ShortCommit}} -X main.date={{.Date}}
     binary: influx

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 1. [297](https://github.com/influxdata/influx-cli/pull/297): Detect and warn when `restore --full` changes the operator token.
 1. [302](https://github.com/influxdata/influx-cli/pull/302): Set newly-created config as active in `setup`.
+1. [305](https://github.com/influxdata/influx-cli/pull/305): Embed timezone data into Windows builds to avoid errors.
 
 ## v2.1.1 [2021-09-22]
 

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+function build_test_tools () {
+    # Copy pre-built gotestsum out of the cross-builder.
+    local ext=""
+    if [ "$(go env GOOS)" = windows ]; then
+        ext=".exe"
+    fi
+    cp "/usr/local/bin/gotestsum_$(go env GOOS)_$(go env GOARCH)${ext}" "$1/gotestsum${ext}"
+
+    # Build test2json from the installed Go distribution.
+    CGO_ENABLED=0 go build -o "${1}/" -ldflags="-s -w" cmd/test2json
+}
+
+function write_test_metadata () {
+    # Write version that should be reported in test results.
+    echo "$(go env GOVERSION) $(go env GOOS)/$(go env GOARCH)" > "${1}/go.version"
+
+    # Write list of all packages.
+    go list ./... > "${1}/tests.list"
+}
+
+function main () {
+    if [[ $# != 1 ]]; then
+        >&2 echo Usage: $0 '<output-dir>'
+        exit 1
+    fi
+    local -r out_dir="$1"
+
+    mkdir -p "$out_dir"
+
+    # Build all test binaries.
+    CGO_ENABLED=0 go-test-compile -o "${out_dir}/" ./...
+
+    # Build gotestsum and test2json so downstream jobs can use it without needing `go`.
+    build_test_tools "$out_dir"
+    # Write other metadata needed for testing.
+    write_test_metadata "$out_dir"
+}
+
+main ${@}

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -1,6 +1,15 @@
 #!/usr/bin/env bash
 set -exo pipefail
 
+function build_test_binaries () {
+    local tags=""
+    if [ "$(go env GOOS)" = windows ]; then
+        tags="-tags timetzdata"
+    fi
+
+    CGO_ENABLED=0 go-test-compile ${tags} -o "${1}/" ./...
+}
+
 function build_test_tools () {
     # Copy pre-built gotestsum out of the cross-builder.
     local ext=""
@@ -31,8 +40,7 @@ function main () {
     mkdir -p "$out_dir"
 
     # Build all test binaries.
-    CGO_ENABLED=0 go-test-compile -o "${out_dir}/" ./...
-
+    build_test_binaries "${out_dir}/"
     # Build gotestsum and test2json so downstream jobs can use it without needing `go`.
     build_test_tools "$out_dir"
     # Write other metadata needed for testing.

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -33,6 +33,7 @@ function write_test_metadata () {
 function main () {
     if [[ $# != 1 ]]; then
         >&2 echo Usage: $0 '<output-dir>'
+        >&2 echo '<output-dir>' will be created if it does not already exist
         exit 1
     fi
     local -r out_dir="$1"

--- a/scripts/ci/run-prebuilt-tests.sh
+++ b/scripts/ci/run-prebuilt-tests.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+function test_package () {
+    local -r pkg="$1" bin_dir="$2" result_dir="$3"
+
+    local -r test_file="${bin_dir}/${pkg}.test"
+    if [ ! -f "$test_file" ]; then
+        return
+    fi
+
+    out_dir="${result_dir}/${pkg}"
+    mkdir -p "${out_dir}"
+
+    # Run test files from within their original packages so any relative references
+    # to data files resolve properly.
+    local source_dir="${pkg##github.com/influxdata/influx-cli/v2}"
+    source_dir="${source_dir##/}"
+    if [ -z "$source_dir" ]; then
+        source_dir="."
+    fi
+    (
+        set +e
+        cd "$source_dir"
+        GOVERSION="$(cat ${bin_dir}/go.version)" "${bin_dir}/gotestsum" --junitfile "${out_dir}/report.xml" --raw-command -- \
+            "${bin_dir}/test2json" -t -p "$pkg" "$test_file" -test.v
+        if [ $? != 0 ]; then
+            echo 1 > "${result_dir}/rc"
+        fi
+    )
+}
+
+function main () {
+    if [[ $# != 2 ]]; then
+        >&2 echo Usage: $0 '<test-bin-dir>' '<result-dir>'
+        exit 1
+    fi
+    local -r bin_dir="$1" result_dir="$2"
+
+    mkdir -p "$result_dir"
+
+    local -r test_packages="$(cat "${bin_dir}/tests.list" | circleci tests split --split-by=timings --timings-type=classname)"
+
+    echo 0 > "${result_dir}/rc"
+    for pkg in ${test_packages[@]}; do
+        test_package "$pkg" "$bin_dir" "$result_dir"
+    done
+
+    exit $(cat "${result_dir}/rc")
+}
+
+main ${@}

--- a/scripts/ci/run-prebuilt-tests.sh
+++ b/scripts/ci/run-prebuilt-tests.sh
@@ -33,6 +33,7 @@ function test_package () {
 function main () {
     if [[ $# != 2 ]]; then
         >&2 echo Usage: $0 '<test-bin-dir>' '<result-dir>'
+        >&2 echo '<result-dir>' will be created if it does not already exist
         exit 1
     fi
     local -r bin_dir="$1" result_dir="$2"

--- a/scripts/ci/run-prebuilt-tests.sh
+++ b/scripts/ci/run-prebuilt-tests.sh
@@ -42,6 +42,11 @@ function main () {
 
     local -r test_packages="$(cat "${bin_dir}/tests.list" | circleci tests split --split-by=timings --timings-type=classname)"
 
+    # Pre-built test binaries will exit with a nonzero return code if the tests they encapsulate fail.
+    # We don't want to fail-fast the first time a test fails, so (elsewhere in the script) we `set +e` before running
+    # anything. By default that would cause the script to exit with success even when tests fail, which we don't want
+    # either. To work around this, we track the final return code for this script in the `rc` file. The code is
+    # initialized to 0, and overwritten to be 1 if any test binary fails.
     echo 0 > "${result_dir}/rc"
     for pkg in ${test_packages[@]}; do
         test_package "$pkg" "$bin_dir" "$result_dir"

--- a/scripts/ci/run-race-tests.sh
+++ b/scripts/ci/run-race-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -exo pipefail
+
+function main () {
+    if [[ $# != 1 ]]; then
+        >&2 echo Usage: $0 '<output-dir>'
+        exit 1
+    fi
+    if [[ $(go env GOOS) != linux || $(go env GOARCH) != amd64 ]]; then
+        >&2 echo Race tests only supported on linux/amd64
+        exit 1
+    fi
+
+    local -r out_dir="$1"
+    mkdir -p "$out_dir"
+
+    gotestsum --junitfile "${out_dir}/report.xml" -- -race ./...
+}
+
+main ${@}


### PR DESCRIPTION
Closes #304

This PR was originally meant to be build-only, aligning a piece of the `influx-cli` CI setup with `influxdb`. In the process I rediscovered golang/go#38453. We work around that issue here in the same way we did in influxdata/influxdb#22447, setting a build tag when `GOOS=windows` so TZ data is embedded in the binary.