### PR TITLE
feat: nicer error when command not found

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -58,6 +58,14 @@ var app = cli.App{
 		newReplicationCmd(),
 	},
 	Before: withContext(),
+	CommandNotFound: func(c *cli.Context, command string) {
+		_, _ = fmt.Fprintf(
+			os.Stderr,
+			"Error: command %q not recognized. Run `%v --help` to see the list of commands\n",
+			command,
+			os.Args[0],
+		)
+	},
 }
 
 func main() {

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
 	"github.com/urfave/cli"
 )
 
@@ -57,15 +58,7 @@ var app = cli.App{
 		newRemoteCmd(),
 		newReplicationCmd(),
 	},
-	Before: withContext(),
-	CommandNotFound: func(c *cli.Context, command string) {
-		_, _ = fmt.Fprintf(
-			os.Stderr,
-			"Error: command %q not recognized. Run `%v --help` to see the list of commands\n",
-			command,
-			os.Args[0],
-		)
-	},
+	Before: middleware.WithBeforeFns(withContext(), middleware.NoArgs),
 }
 
 func main() {


### PR DESCRIPTION
Currently, when you try to use an unrecognized command, you get -

```
❯ ./influx hello
No help topic for 'hello'
```

This isn't particularly clear, and you might wonder how you triggered the help mode.

This PR changes that to something more explicit -

```
❯ ./influx hello
Error: command "hello" not recognized. Run `./influx --help` to see the list of commands
```
