### PR TITLE
fix: wrong position of orgID and userID in `org members remove`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 
 1. [320](https://github.com/influxdata/influx-cli/pull/320): Return a better error message on unknown subcommands. Thanks @slai!
+1. [321](https://github.com/influxdata/influx-cli/pull/321): Fix accidental swap of userID and orgID in `org members remove` API calls. Thanks @geek981108!
 
 ## v2.2.0 [2021-10-21]
 

--- a/clients/org/org_members.go
+++ b/clients/org/org_members.go
@@ -136,7 +136,7 @@ func (c Client) RemoveMember(ctx context.Context, params *RemoveMemberParams) (e
 		}
 	}
 
-	if err = c.DeleteOrgsIDMembersID(ctx, orgID, params.MemberId.String()).Execute(); err != nil {
+	if err = c.DeleteOrgsIDMembersID(ctx, params.MemberId.String(), orgID).Execute(); err != nil {
 		return fmt.Errorf("failed to remove member %q from org %q", params.MemberId, orgID)
 	}
 

--- a/clients/org/org_members_test.go
+++ b/clients/org/org_members_test.go
@@ -352,7 +352,7 @@ func TestClient_RemoveMembers(t *testing.T) {
 			registerExpectations: func(t *testing.T, orgApi *mock.MockOrganizationsApi) {
 				req := api.ApiDeleteOrgsIDMembersIDRequest{ApiService: orgApi}.OrgID(id1.String()).UserID(id2.String())
 				orgApi.EXPECT().
-					DeleteOrgsIDMembersID(gomock.Any(), gomock.Eq(id1.String()), gomock.Eq(id2.String())).Return(req)
+					DeleteOrgsIDMembersID(gomock.Any(), gomock.Eq(id2.String()), gomock.Eq(id1.String())).Return(req)
 				orgApi.EXPECT().DeleteOrgsIDMembersIDExecute(gomock.Eq(req)).Return(nil)
 			},
 			expectedOut: "user \"2222222222222222\" has been removed from org \"1111111111111111\"",
@@ -374,7 +374,7 @@ func TestClient_RemoveMembers(t *testing.T) {
 
 				req := api.ApiDeleteOrgsIDMembersIDRequest{ApiService: orgApi}.OrgID(id1.String()).UserID(id2.String())
 				orgApi.EXPECT().
-					DeleteOrgsIDMembersID(gomock.Any(), gomock.Eq(id1.String()), gomock.Eq(id2.String())).Return(req)
+					DeleteOrgsIDMembersID(gomock.Any(), gomock.Eq(id2.String()), gomock.Eq(id1.String())).Return(req)
 				orgApi.EXPECT().DeleteOrgsIDMembersIDExecute(gomock.Eq(req)).Return(nil)
 			},
 			expectedOut: "user \"2222222222222222\" has been removed from org \"1111111111111111\"",
@@ -395,7 +395,7 @@ func TestClient_RemoveMembers(t *testing.T) {
 
 				req := api.ApiDeleteOrgsIDMembersIDRequest{ApiService: orgApi}.OrgID(id1.String()).UserID(id2.String())
 				orgApi.EXPECT().
-					DeleteOrgsIDMembersID(gomock.Any(), gomock.Eq(id1.String()), gomock.Eq(id2.String())).Return(req)
+					DeleteOrgsIDMembersID(gomock.Any(), gomock.Eq(id2.String()), gomock.Eq(id1.String()), ).Return(req)
 				orgApi.EXPECT().DeleteOrgsIDMembersIDExecute(gomock.Eq(req)).Return(nil)
 			},
 			expectedOut: "user \"2222222222222222\" has been removed from org \"1111111111111111\"",


### PR DESCRIPTION
Backports #318