### PR TITLE
feat: add ExecuteWithHttpInfo methods for generated API

### DIFF
--- a/api/api_authorizations.gen.go
+++ b/api/api_authorizations.gen.go
@@ -40,7 +40,9 @@ type AuthorizationsApi interface {
 	DeleteAuthorizationsIDExecute(r ApiDeleteAuthorizationsIDRequest) error
 
 	/*
-	 * DeleteAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteAuthorizationsIDRequest) (*_nethttp.Response, error)
 
@@ -58,9 +60,11 @@ type AuthorizationsApi interface {
 	GetAuthorizationsExecute(r ApiGetAuthorizationsRequest) (Authorizations, error)
 
 	/*
-	   * GetAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorizations
-	*/
+	 * GetAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorizations
+	 */
 	GetAuthorizationsExecuteWithHttpInfo(r ApiGetAuthorizationsRequest) (Authorizations, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type AuthorizationsApi interface {
 	GetAuthorizationsIDExecute(r ApiGetAuthorizationsIDRequest) (Authorization, error)
 
 	/*
-	   * GetAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorization
-	*/
+	 * GetAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorization
+	 */
 	GetAuthorizationsIDExecuteWithHttpInfo(r ApiGetAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type AuthorizationsApi interface {
 	PatchAuthorizationsIDExecute(r ApiPatchAuthorizationsIDRequest) (Authorization, error)
 
 	/*
-	   * PatchAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorization
-	*/
+	 * PatchAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorization
+	 */
 	PatchAuthorizationsIDExecuteWithHttpInfo(r ApiPatchAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type AuthorizationsApi interface {
 	PostAuthorizationsExecute(r ApiPostAuthorizationsRequest) (Authorization, error)
 
 	/*
-	   * PostAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorization
-	*/
+	 * PostAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorization
+	 */
 	PostAuthorizationsExecuteWithHttpInfo(r ApiPostAuthorizationsRequest) (Authorization, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -200,7 +210,9 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuth
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteAuthorizationsIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -369,7 +381,9 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorizations
  */
 func (a *AuthorizationsApiService) GetAuthorizationsExecuteWithHttpInfo(r ApiGetAuthorizationsRequest) (Authorizations, *_nethttp.Response, error) {
@@ -545,7 +559,9 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorization
  */
 func (a *AuthorizationsApiService) GetAuthorizationsIDExecuteWithHttpInfo(r ApiGetAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
@@ -719,7 +735,9 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorization
  */
 func (a *AuthorizationsApiService) PatchAuthorizationsIDExecuteWithHttpInfo(r ApiPatchAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
@@ -887,7 +905,9 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorization
  */
 func (a *AuthorizationsApiService) PostAuthorizationsExecuteWithHttpInfo(r ApiPostAuthorizationsRequest) (Authorization, *_nethttp.Response, error) {

--- a/api/api_authorizations.gen.go
+++ b/api/api_authorizations.gen.go
@@ -40,6 +40,11 @@ type AuthorizationsApi interface {
 	DeleteAuthorizationsIDExecute(r ApiDeleteAuthorizationsIDRequest) error
 
 	/*
+	 * DeleteAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteAuthorizationsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetAuthorizations List all authorizations
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetAuthorizationsRequest
@@ -51,6 +56,12 @@ type AuthorizationsApi interface {
 	 * @return Authorizations
 	 */
 	GetAuthorizationsExecute(r ApiGetAuthorizationsRequest) (Authorizations, error)
+
+	/*
+	   * GetAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorizations
+	*/
+	GetAuthorizationsExecuteWithHttpInfo(r ApiGetAuthorizationsRequest) (Authorizations, *_nethttp.Response, error)
 
 	/*
 	 * GetAuthorizationsID Retrieve an authorization
@@ -67,6 +78,12 @@ type AuthorizationsApi interface {
 	GetAuthorizationsIDExecute(r ApiGetAuthorizationsIDRequest) (Authorization, error)
 
 	/*
+	   * GetAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorization
+	*/
+	GetAuthorizationsIDExecuteWithHttpInfo(r ApiGetAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
+
+	/*
 	 * PatchAuthorizationsID Update an authorization to be active or inactive
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param authID The ID of the authorization to update.
@@ -81,6 +98,12 @@ type AuthorizationsApi interface {
 	PatchAuthorizationsIDExecute(r ApiPatchAuthorizationsIDRequest) (Authorization, error)
 
 	/*
+	   * PatchAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorization
+	*/
+	PatchAuthorizationsIDExecuteWithHttpInfo(r ApiPatchAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
+
+	/*
 	 * PostAuthorizations Create an authorization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostAuthorizationsRequest
@@ -92,6 +115,12 @@ type AuthorizationsApi interface {
 	 * @return Authorization
 	 */
 	PostAuthorizationsExecute(r ApiPostAuthorizationsRequest) (Authorization, error)
+
+	/*
+	   * PostAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorization
+	*/
+	PostAuthorizationsExecuteWithHttpInfo(r ApiPostAuthorizationsRequest) (Authorization, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -144,6 +173,10 @@ func (r ApiDeleteAuthorizationsIDRequest) Execute() error {
 	return r.ApiService.DeleteAuthorizationsIDExecute(r)
 }
 
+func (r ApiDeleteAuthorizationsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteAuthorizationsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteAuthorizationsID Delete an authorization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -162,6 +195,14 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsID(ctx _context.Context, 
  * Execute executes the request
  */
 func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuthorizationsIDRequest) error {
+	_, err := a.DeleteAuthorizationsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteAuthorizationsIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -172,7 +213,7 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuth
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AuthorizationsApiService.DeleteAuthorizationsID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/authorizations/{authID}"
@@ -204,12 +245,12 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuth
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -223,12 +264,12 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuth
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -238,14 +279,14 @@ func (a *AuthorizationsApiService) DeleteAuthorizationsIDExecute(r ApiDeleteAuth
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetAuthorizationsRequest struct {
@@ -302,6 +343,10 @@ func (r ApiGetAuthorizationsRequest) Execute() (Authorizations, error) {
 	return r.ApiService.GetAuthorizationsExecute(r)
 }
 
+func (r ApiGetAuthorizationsRequest) ExecuteWithHttpInfo() (Authorizations, *_nethttp.Response, error) {
+	return r.ApiService.GetAuthorizationsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetAuthorizations List all authorizations
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -319,6 +364,15 @@ func (a *AuthorizationsApiService) GetAuthorizations(ctx _context.Context) ApiGe
  * @return Authorizations
  */
 func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizationsRequest) (Authorizations, error) {
+	returnVal, _, err := a.GetAuthorizationsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorizations
+ */
+func (a *AuthorizationsApiService) GetAuthorizationsExecuteWithHttpInfo(r ApiGetAuthorizationsRequest) (Authorizations, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -330,7 +384,7 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AuthorizationsApiService.GetAuthorizations")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/authorizations"
@@ -373,12 +427,12 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -392,12 +446,12 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -407,22 +461,22 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -430,10 +484,10 @@ func (a *AuthorizationsApiService) GetAuthorizationsExecute(r ApiGetAuthorizatio
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetAuthorizationsIDRequest struct {
@@ -463,6 +517,10 @@ func (r ApiGetAuthorizationsIDRequest) Execute() (Authorization, error) {
 	return r.ApiService.GetAuthorizationsIDExecute(r)
 }
 
+func (r ApiGetAuthorizationsIDRequest) ExecuteWithHttpInfo() (Authorization, *_nethttp.Response, error) {
+	return r.ApiService.GetAuthorizationsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetAuthorizationsID Retrieve an authorization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -482,6 +540,15 @@ func (a *AuthorizationsApiService) GetAuthorizationsID(ctx _context.Context, aut
  * @return Authorization
  */
 func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizationsIDRequest) (Authorization, error) {
+	returnVal, _, err := a.GetAuthorizationsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorization
+ */
+func (a *AuthorizationsApiService) GetAuthorizationsIDExecuteWithHttpInfo(r ApiGetAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -493,7 +560,7 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AuthorizationsApiService.GetAuthorizationsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/authorizations/{authID}"
@@ -525,12 +592,12 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -544,12 +611,12 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -559,22 +626,22 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -582,10 +649,10 @@ func (a *AuthorizationsApiService) GetAuthorizationsIDExecute(r ApiGetAuthorizat
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchAuthorizationsIDRequest struct {
@@ -624,6 +691,10 @@ func (r ApiPatchAuthorizationsIDRequest) Execute() (Authorization, error) {
 	return r.ApiService.PatchAuthorizationsIDExecute(r)
 }
 
+func (r ApiPatchAuthorizationsIDRequest) ExecuteWithHttpInfo() (Authorization, *_nethttp.Response, error) {
+	return r.ApiService.PatchAuthorizationsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchAuthorizationsID Update an authorization to be active or inactive
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -643,6 +714,15 @@ func (a *AuthorizationsApiService) PatchAuthorizationsID(ctx _context.Context, a
  * @return Authorization
  */
 func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthorizationsIDRequest) (Authorization, error) {
+	returnVal, _, err := a.PatchAuthorizationsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorization
+ */
+func (a *AuthorizationsApiService) PatchAuthorizationsIDExecuteWithHttpInfo(r ApiPatchAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -654,7 +734,7 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AuthorizationsApiService.PatchAuthorizationsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/authorizations/{authID}"
@@ -664,7 +744,7 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.authorizationUpdateRequest == nil {
-		return localVarReturnValue, reportError("authorizationUpdateRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("authorizationUpdateRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -691,12 +771,12 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 	localVarPostBody = r.authorizationUpdateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -710,12 +790,12 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -725,22 +805,22 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -748,10 +828,10 @@ func (a *AuthorizationsApiService) PatchAuthorizationsIDExecute(r ApiPatchAuthor
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostAuthorizationsRequest struct {
@@ -781,6 +861,10 @@ func (r ApiPostAuthorizationsRequest) Execute() (Authorization, error) {
 	return r.ApiService.PostAuthorizationsExecute(r)
 }
 
+func (r ApiPostAuthorizationsRequest) ExecuteWithHttpInfo() (Authorization, *_nethttp.Response, error) {
+	return r.ApiService.PostAuthorizationsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostAuthorizations Create an authorization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -798,6 +882,15 @@ func (a *AuthorizationsApiService) PostAuthorizations(ctx _context.Context) ApiP
  * @return Authorization
  */
 func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizationsRequest) (Authorization, error) {
+	returnVal, _, err := a.PostAuthorizationsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorization
+ */
+func (a *AuthorizationsApiService) PostAuthorizationsExecuteWithHttpInfo(r ApiPostAuthorizationsRequest) (Authorization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -809,7 +902,7 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "AuthorizationsApiService.PostAuthorizations")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/authorizations"
@@ -818,7 +911,7 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.authorizationPostRequest == nil {
-		return localVarReturnValue, reportError("authorizationPostRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("authorizationPostRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -845,12 +938,12 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 	localVarPostBody = r.authorizationPostRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -864,12 +957,12 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -880,32 +973,32 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -913,8 +1006,8 @@ func (a *AuthorizationsApiService) PostAuthorizationsExecute(r ApiPostAuthorizat
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_backup.gen.go
+++ b/api/api_backup.gen.go
@@ -41,9 +41,11 @@ type BackupApi interface {
 	GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethttp.Response, error)
 
 	/*
-	   * GetBackupKVExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return *os.File
-	*/
+	 * GetBackupKVExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return *os.File
+	 */
 	GetBackupKVExecuteWithHttpInfo(r ApiGetBackupKVRequest) (*_nethttp.Response, *_nethttp.Response, error)
 
 	/*
@@ -60,9 +62,11 @@ type BackupApi interface {
 	GetBackupMetadataExecute(r ApiGetBackupMetadataRequest) (*_nethttp.Response, error)
 
 	/*
-	   * GetBackupMetadataExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return *os.File
-	*/
+	 * GetBackupMetadataExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return *os.File
+	 */
 	GetBackupMetadataExecuteWithHttpInfo(r ApiGetBackupMetadataRequest) (*_nethttp.Response, *_nethttp.Response, error)
 
 	/*
@@ -80,9 +84,11 @@ type BackupApi interface {
 	GetBackupShardIdExecute(r ApiGetBackupShardIdRequest) (*_nethttp.Response, error)
 
 	/*
-	   * GetBackupShardIdExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return *os.File
-	*/
+	 * GetBackupShardIdExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return *os.File
+	 */
 	GetBackupShardIdExecuteWithHttpInfo(r ApiGetBackupShardIdRequest) (*_nethttp.Response, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -153,7 +159,9 @@ func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethtt
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return *os.File
  */
 func (a *BackupApiService) GetBackupKVExecuteWithHttpInfo(r ApiGetBackupKVRequest) (*_nethttp.Response, *_nethttp.Response, error) {
@@ -298,7 +306,9 @@ func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataReques
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return *os.File
  */
 func (a *BackupApiService) GetBackupMetadataExecuteWithHttpInfo(r ApiGetBackupMetadataRequest) (*_nethttp.Response, *_nethttp.Response, error) {
@@ -466,7 +476,9 @@ func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest)
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return *os.File
  */
 func (a *BackupApiService) GetBackupShardIdExecuteWithHttpInfo(r ApiGetBackupShardIdRequest) (*_nethttp.Response, *_nethttp.Response, error) {

--- a/api/api_backup.gen.go
+++ b/api/api_backup.gen.go
@@ -41,6 +41,12 @@ type BackupApi interface {
 	GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethttp.Response, error)
 
 	/*
+	   * GetBackupKVExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return *os.File
+	*/
+	GetBackupKVExecuteWithHttpInfo(r ApiGetBackupKVRequest) (*_nethttp.Response, *_nethttp.Response, error)
+
+	/*
 	 * GetBackupMetadata Download snapshot of all metadata in the server
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetBackupMetadataRequest
@@ -52,6 +58,12 @@ type BackupApi interface {
 	 * @return *os.File
 	 */
 	GetBackupMetadataExecute(r ApiGetBackupMetadataRequest) (*_nethttp.Response, error)
+
+	/*
+	   * GetBackupMetadataExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return *os.File
+	*/
+	GetBackupMetadataExecuteWithHttpInfo(r ApiGetBackupMetadataRequest) (*_nethttp.Response, *_nethttp.Response, error)
 
 	/*
 	 * GetBackupShardId Download snapshot of all TSM data in a shard
@@ -66,6 +78,12 @@ type BackupApi interface {
 	 * @return *os.File
 	 */
 	GetBackupShardIdExecute(r ApiGetBackupShardIdRequest) (*_nethttp.Response, error)
+
+	/*
+	   * GetBackupShardIdExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return *os.File
+	*/
+	GetBackupShardIdExecuteWithHttpInfo(r ApiGetBackupShardIdRequest) (*_nethttp.Response, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -109,6 +127,10 @@ func (r ApiGetBackupKVRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.GetBackupKVExecute(r)
 }
 
+func (r ApiGetBackupKVRequest) ExecuteWithHttpInfo() (*_nethttp.Response, *_nethttp.Response, error) {
+	return r.ApiService.GetBackupKVExecuteWithHttpInfo(r)
+}
+
 /*
  * GetBackupKV Download snapshot of metadata stored in the server's embedded KV store. Should not be used in versions greater than 2.1.x, as it doesn't include metadata stored in embedded SQL.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -126,6 +148,15 @@ func (a *BackupApiService) GetBackupKV(ctx _context.Context) ApiGetBackupKVReque
  * @return *os.File
  */
 func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethttp.Response, error) {
+	returnVal, _, err := a.GetBackupKVExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return *os.File
+ */
+func (a *BackupApiService) GetBackupKVExecuteWithHttpInfo(r ApiGetBackupKVRequest) (*_nethttp.Response, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -137,7 +168,7 @@ func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethtt
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BackupApiService.GetBackupKV")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/backup/kv"
@@ -168,12 +199,12 @@ func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethtt
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -187,12 +218,12 @@ func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethtt
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -202,16 +233,16 @@ func (a *BackupApiService) GetBackupKVExecute(r ApiGetBackupKVRequest) (*_nethtt
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	localVarReturnValue = localVarHTTPResponse
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetBackupMetadataRequest struct {
@@ -241,6 +272,10 @@ func (r ApiGetBackupMetadataRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.GetBackupMetadataExecute(r)
 }
 
+func (r ApiGetBackupMetadataRequest) ExecuteWithHttpInfo() (*_nethttp.Response, *_nethttp.Response, error) {
+	return r.ApiService.GetBackupMetadataExecuteWithHttpInfo(r)
+}
+
 /*
  * GetBackupMetadata Download snapshot of all metadata in the server
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -258,6 +293,15 @@ func (a *BackupApiService) GetBackupMetadata(ctx _context.Context) ApiGetBackupM
  * @return *os.File
  */
 func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataRequest) (*_nethttp.Response, error) {
+	returnVal, _, err := a.GetBackupMetadataExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return *os.File
+ */
+func (a *BackupApiService) GetBackupMetadataExecuteWithHttpInfo(r ApiGetBackupMetadataRequest) (*_nethttp.Response, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -269,7 +313,7 @@ func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataReques
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BackupApiService.GetBackupMetadata")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/backup/metadata"
@@ -303,12 +347,12 @@ func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataReques
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -322,12 +366,12 @@ func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataReques
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -337,16 +381,16 @@ func (a *BackupApiService) GetBackupMetadataExecute(r ApiGetBackupMetadataReques
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	localVarReturnValue = localVarHTTPResponse
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetBackupShardIdRequest struct {
@@ -394,6 +438,10 @@ func (r ApiGetBackupShardIdRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.GetBackupShardIdExecute(r)
 }
 
+func (r ApiGetBackupShardIdRequest) ExecuteWithHttpInfo() (*_nethttp.Response, *_nethttp.Response, error) {
+	return r.ApiService.GetBackupShardIdExecuteWithHttpInfo(r)
+}
+
 /*
  * GetBackupShardId Download snapshot of all TSM data in a shard
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -413,6 +461,15 @@ func (a *BackupApiService) GetBackupShardId(ctx _context.Context, shardID int64)
  * @return *os.File
  */
 func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest) (*_nethttp.Response, error) {
+	returnVal, _, err := a.GetBackupShardIdExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return *os.File
+ */
+func (a *BackupApiService) GetBackupShardIdExecuteWithHttpInfo(r ApiGetBackupShardIdRequest) (*_nethttp.Response, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -424,7 +481,7 @@ func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest)
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BackupApiService.GetBackupShardId")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/backup/shards/{shardID}"
@@ -462,12 +519,12 @@ func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest)
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -481,12 +538,12 @@ func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest)
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -497,24 +554,24 @@ func (a *BackupApiService) GetBackupShardIdExecute(r ApiGetBackupShardIdRequest)
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	localVarReturnValue = localVarHTTPResponse
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_bucket_schemas.gen.go
+++ b/api/api_bucket_schemas.gen.go
@@ -41,9 +41,11 @@ type BucketSchemasApi interface {
 	CreateMeasurementSchemaExecute(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, error)
 
 	/*
-	   * CreateMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return MeasurementSchema
-	*/
+	 * CreateMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return MeasurementSchema
+	 */
 	CreateMeasurementSchemaExecuteWithHttpInfo(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error)
 
 	/*
@@ -62,9 +64,11 @@ type BucketSchemasApi interface {
 	GetMeasurementSchemaExecute(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, error)
 
 	/*
-	   * GetMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return MeasurementSchema
-	*/
+	 * GetMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return MeasurementSchema
+	 */
 	GetMeasurementSchemaExecuteWithHttpInfo(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error)
 
 	/*
@@ -82,9 +86,11 @@ type BucketSchemasApi interface {
 	GetMeasurementSchemasExecute(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, error)
 
 	/*
-	   * GetMeasurementSchemasExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return MeasurementSchemaList
-	*/
+	 * GetMeasurementSchemasExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return MeasurementSchemaList
+	 */
 	GetMeasurementSchemasExecuteWithHttpInfo(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, *_nethttp.Response, error)
 
 	/*
@@ -103,9 +109,11 @@ type BucketSchemasApi interface {
 	UpdateMeasurementSchemaExecute(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, error)
 
 	/*
-	   * UpdateMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return MeasurementSchema
-	*/
+	 * UpdateMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return MeasurementSchema
+	 */
 	UpdateMeasurementSchemaExecuteWithHttpInfo(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -205,7 +213,9 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return MeasurementSchema
  */
 func (a *BucketSchemasApiService) CreateMeasurementSchemaExecuteWithHttpInfo(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error) {
@@ -397,7 +407,9 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return MeasurementSchema
  */
 func (a *BucketSchemasApiService) GetMeasurementSchemaExecuteWithHttpInfo(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error) {
@@ -576,7 +588,9 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return MeasurementSchemaList
  */
 func (a *BucketSchemasApiService) GetMeasurementSchemasExecuteWithHttpInfo(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, *_nethttp.Response, error) {
@@ -778,7 +792,9 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return MeasurementSchema
  */
 func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecuteWithHttpInfo(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error) {

--- a/api/api_bucket_schemas.gen.go
+++ b/api/api_bucket_schemas.gen.go
@@ -41,6 +41,12 @@ type BucketSchemasApi interface {
 	CreateMeasurementSchemaExecute(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, error)
 
 	/*
+	   * CreateMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return MeasurementSchema
+	*/
+	CreateMeasurementSchemaExecuteWithHttpInfo(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error)
+
+	/*
 	 * GetMeasurementSchema Retrieve measurement schema information
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param bucketID The identifier of the bucket.
@@ -54,6 +60,12 @@ type BucketSchemasApi interface {
 	 * @return MeasurementSchema
 	 */
 	GetMeasurementSchemaExecute(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, error)
+
+	/*
+	   * GetMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return MeasurementSchema
+	*/
+	GetMeasurementSchemaExecuteWithHttpInfo(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error)
 
 	/*
 	 * GetMeasurementSchemas List all measurement schemas of a bucket
@@ -70,6 +82,12 @@ type BucketSchemasApi interface {
 	GetMeasurementSchemasExecute(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, error)
 
 	/*
+	   * GetMeasurementSchemasExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return MeasurementSchemaList
+	*/
+	GetMeasurementSchemasExecuteWithHttpInfo(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, *_nethttp.Response, error)
+
+	/*
 	 * UpdateMeasurementSchema Update a measurement schema
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param bucketID The identifier of the bucket.
@@ -83,6 +101,12 @@ type BucketSchemasApi interface {
 	 * @return MeasurementSchema
 	 */
 	UpdateMeasurementSchemaExecute(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, error)
+
+	/*
+	   * UpdateMeasurementSchemaExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return MeasurementSchema
+	*/
+	UpdateMeasurementSchemaExecuteWithHttpInfo(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -153,6 +177,10 @@ func (r ApiCreateMeasurementSchemaRequest) Execute() (MeasurementSchema, error) 
 	return r.ApiService.CreateMeasurementSchemaExecute(r)
 }
 
+func (r ApiCreateMeasurementSchemaRequest) ExecuteWithHttpInfo() (MeasurementSchema, *_nethttp.Response, error) {
+	return r.ApiService.CreateMeasurementSchemaExecuteWithHttpInfo(r)
+}
+
 /*
  * CreateMeasurementSchema Create a measurement schema for a bucket
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -172,6 +200,15 @@ func (a *BucketSchemasApiService) CreateMeasurementSchema(ctx _context.Context, 
  * @return MeasurementSchema
  */
 func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, error) {
+	returnVal, _, err := a.CreateMeasurementSchemaExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return MeasurementSchema
+ */
+func (a *BucketSchemasApiService) CreateMeasurementSchemaExecuteWithHttpInfo(r ApiCreateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -183,7 +220,7 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketSchemasApiService.CreateMeasurementSchema")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}/schema/measurements"
@@ -220,12 +257,12 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 	localVarPostBody = r.measurementSchemaCreateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -239,12 +276,12 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -255,23 +292,23 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -279,10 +316,10 @@ func (a *BucketSchemasApiService) CreateMeasurementSchemaExecute(r ApiCreateMeas
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetMeasurementSchemaRequest struct {
@@ -330,6 +367,10 @@ func (r ApiGetMeasurementSchemaRequest) Execute() (MeasurementSchema, error) {
 	return r.ApiService.GetMeasurementSchemaExecute(r)
 }
 
+func (r ApiGetMeasurementSchemaRequest) ExecuteWithHttpInfo() (MeasurementSchema, *_nethttp.Response, error) {
+	return r.ApiService.GetMeasurementSchemaExecuteWithHttpInfo(r)
+}
+
 /*
  * GetMeasurementSchema Retrieve measurement schema information
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -351,6 +392,15 @@ func (a *BucketSchemasApiService) GetMeasurementSchema(ctx _context.Context, buc
  * @return MeasurementSchema
  */
 func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, error) {
+	returnVal, _, err := a.GetMeasurementSchemaExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return MeasurementSchema
+ */
+func (a *BucketSchemasApiService) GetMeasurementSchemaExecuteWithHttpInfo(r ApiGetMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -362,7 +412,7 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketSchemasApiService.GetMeasurementSchema")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}/schema/measurements/{measurementID}"
@@ -398,12 +448,12 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -417,29 +467,29 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -447,10 +497,10 @@ func (a *BucketSchemasApiService) GetMeasurementSchemaExecute(r ApiGetMeasuremen
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetMeasurementSchemasRequest struct {
@@ -498,6 +548,10 @@ func (r ApiGetMeasurementSchemasRequest) Execute() (MeasurementSchemaList, error
 	return r.ApiService.GetMeasurementSchemasExecute(r)
 }
 
+func (r ApiGetMeasurementSchemasRequest) ExecuteWithHttpInfo() (MeasurementSchemaList, *_nethttp.Response, error) {
+	return r.ApiService.GetMeasurementSchemasExecuteWithHttpInfo(r)
+}
+
 /*
  * GetMeasurementSchemas List all measurement schemas of a bucket
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -517,6 +571,15 @@ func (a *BucketSchemasApiService) GetMeasurementSchemas(ctx _context.Context, bu
  * @return MeasurementSchemaList
  */
 func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, error) {
+	returnVal, _, err := a.GetMeasurementSchemasExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return MeasurementSchemaList
+ */
+func (a *BucketSchemasApiService) GetMeasurementSchemasExecuteWithHttpInfo(r ApiGetMeasurementSchemasRequest) (MeasurementSchemaList, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -528,7 +591,7 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketSchemasApiService.GetMeasurementSchemas")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}/schema/measurements"
@@ -566,12 +629,12 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -585,12 +648,12 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -601,23 +664,23 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -625,10 +688,10 @@ func (a *BucketSchemasApiService) GetMeasurementSchemasExecute(r ApiGetMeasureme
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUpdateMeasurementSchemaRequest struct {
@@ -685,6 +748,10 @@ func (r ApiUpdateMeasurementSchemaRequest) Execute() (MeasurementSchema, error) 
 	return r.ApiService.UpdateMeasurementSchemaExecute(r)
 }
 
+func (r ApiUpdateMeasurementSchemaRequest) ExecuteWithHttpInfo() (MeasurementSchema, *_nethttp.Response, error) {
+	return r.ApiService.UpdateMeasurementSchemaExecuteWithHttpInfo(r)
+}
+
 /*
  * UpdateMeasurementSchema Update a measurement schema
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -706,6 +773,15 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchema(ctx _context.Context, 
  * @return MeasurementSchema
  */
 func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, error) {
+	returnVal, _, err := a.UpdateMeasurementSchemaExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return MeasurementSchema
+ */
+func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecuteWithHttpInfo(r ApiUpdateMeasurementSchemaRequest) (MeasurementSchema, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -717,7 +793,7 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketSchemasApiService.UpdateMeasurementSchema")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}/schema/measurements/{measurementID}"
@@ -755,12 +831,12 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 	localVarPostBody = r.measurementSchemaUpdateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -774,12 +850,12 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -790,23 +866,23 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -814,8 +890,8 @@ func (a *BucketSchemasApiService) UpdateMeasurementSchemaExecute(r ApiUpdateMeas
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_buckets.gen.go
+++ b/api/api_buckets.gen.go
@@ -40,7 +40,9 @@ type BucketsApi interface {
 	DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) error
 
 	/*
-	 * DeleteBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteBucketsIDExecuteWithHttpInfo(r ApiDeleteBucketsIDRequest) (*_nethttp.Response, error)
 
@@ -58,9 +60,11 @@ type BucketsApi interface {
 	GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, error)
 
 	/*
-	   * GetBucketsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Buckets
-	*/
+	 * GetBucketsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Buckets
+	 */
 	GetBucketsExecuteWithHttpInfo(r ApiGetBucketsRequest) (Buckets, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type BucketsApi interface {
 	GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, error)
 
 	/*
-	   * GetBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Bucket
-	*/
+	 * GetBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Bucket
+	 */
 	GetBucketsIDExecuteWithHttpInfo(r ApiGetBucketsIDRequest) (Bucket, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type BucketsApi interface {
 	PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, error)
 
 	/*
-	   * PatchBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Bucket
-	*/
+	 * PatchBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Bucket
+	 */
 	PatchBucketsIDExecuteWithHttpInfo(r ApiPatchBucketsIDRequest) (Bucket, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type BucketsApi interface {
 	PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, error)
 
 	/*
-	   * PostBucketsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Bucket
-	*/
+	 * PostBucketsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Bucket
+	 */
 	PostBucketsExecuteWithHttpInfo(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -200,7 +210,9 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *BucketsApiService) DeleteBucketsIDExecuteWithHttpInfo(r ApiDeleteBucketsIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -407,7 +419,9 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Buckets
  */
 func (a *BucketsApiService) GetBucketsExecuteWithHttpInfo(r ApiGetBucketsRequest) (Buckets, *_nethttp.Response, error) {
@@ -592,7 +606,9 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Bucket
  */
 func (a *BucketsApiService) GetBucketsIDExecuteWithHttpInfo(r ApiGetBucketsIDRequest) (Bucket, *_nethttp.Response, error) {
@@ -766,7 +782,9 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Bucket
  */
 func (a *BucketsApiService) PatchBucketsIDExecuteWithHttpInfo(r ApiPatchBucketsIDRequest) (Bucket, *_nethttp.Response, error) {
@@ -934,7 +952,9 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Bucket
  */
 func (a *BucketsApiService) PostBucketsExecuteWithHttpInfo(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error) {

--- a/api/api_buckets.gen.go
+++ b/api/api_buckets.gen.go
@@ -40,6 +40,11 @@ type BucketsApi interface {
 	DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) error
 
 	/*
+	 * DeleteBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteBucketsIDExecuteWithHttpInfo(r ApiDeleteBucketsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetBuckets List all buckets
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetBucketsRequest
@@ -51,6 +56,12 @@ type BucketsApi interface {
 	 * @return Buckets
 	 */
 	GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, error)
+
+	/*
+	   * GetBucketsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Buckets
+	*/
+	GetBucketsExecuteWithHttpInfo(r ApiGetBucketsRequest) (Buckets, *_nethttp.Response, error)
 
 	/*
 	 * GetBucketsID Retrieve a bucket
@@ -67,6 +78,12 @@ type BucketsApi interface {
 	GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, error)
 
 	/*
+	   * GetBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Bucket
+	*/
+	GetBucketsIDExecuteWithHttpInfo(r ApiGetBucketsIDRequest) (Bucket, *_nethttp.Response, error)
+
+	/*
 	 * PatchBucketsID Update a bucket
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param bucketID The bucket ID.
@@ -81,6 +98,12 @@ type BucketsApi interface {
 	PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, error)
 
 	/*
+	   * PatchBucketsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Bucket
+	*/
+	PatchBucketsIDExecuteWithHttpInfo(r ApiPatchBucketsIDRequest) (Bucket, *_nethttp.Response, error)
+
+	/*
 	 * PostBuckets Create a bucket
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostBucketsRequest
@@ -92,6 +115,12 @@ type BucketsApi interface {
 	 * @return Bucket
 	 */
 	PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, error)
+
+	/*
+	   * PostBucketsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Bucket
+	*/
+	PostBucketsExecuteWithHttpInfo(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -144,6 +173,10 @@ func (r ApiDeleteBucketsIDRequest) Execute() error {
 	return r.ApiService.DeleteBucketsIDExecute(r)
 }
 
+func (r ApiDeleteBucketsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteBucketsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteBucketsID Delete a bucket
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -162,6 +195,14 @@ func (a *BucketsApiService) DeleteBucketsID(ctx _context.Context, bucketID strin
  * Execute executes the request
  */
 func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) error {
+	_, err := a.DeleteBucketsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *BucketsApiService) DeleteBucketsIDExecuteWithHttpInfo(r ApiDeleteBucketsIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -172,7 +213,7 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.DeleteBucketsID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}"
@@ -204,12 +245,12 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -223,12 +264,12 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -239,24 +280,24 @@ func (a *BucketsApiService) DeleteBucketsIDExecute(r ApiDeleteBucketsIDRequest) 
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetBucketsRequest struct {
@@ -340,6 +381,10 @@ func (r ApiGetBucketsRequest) Execute() (Buckets, error) {
 	return r.ApiService.GetBucketsExecute(r)
 }
 
+func (r ApiGetBucketsRequest) ExecuteWithHttpInfo() (Buckets, *_nethttp.Response, error) {
+	return r.ApiService.GetBucketsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetBuckets List all buckets
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -357,6 +402,15 @@ func (a *BucketsApiService) GetBuckets(ctx _context.Context) ApiGetBucketsReques
  * @return Buckets
  */
 func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, error) {
+	returnVal, _, err := a.GetBucketsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Buckets
+ */
+func (a *BucketsApiService) GetBucketsExecuteWithHttpInfo(r ApiGetBucketsRequest) (Buckets, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -368,7 +422,7 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.GetBuckets")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets"
@@ -420,12 +474,12 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -439,12 +493,12 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -454,22 +508,22 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -477,10 +531,10 @@ func (a *BucketsApiService) GetBucketsExecute(r ApiGetBucketsRequest) (Buckets, 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetBucketsIDRequest struct {
@@ -510,6 +564,10 @@ func (r ApiGetBucketsIDRequest) Execute() (Bucket, error) {
 	return r.ApiService.GetBucketsIDExecute(r)
 }
 
+func (r ApiGetBucketsIDRequest) ExecuteWithHttpInfo() (Bucket, *_nethttp.Response, error) {
+	return r.ApiService.GetBucketsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetBucketsID Retrieve a bucket
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -529,6 +587,15 @@ func (a *BucketsApiService) GetBucketsID(ctx _context.Context, bucketID string) 
  * @return Bucket
  */
 func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucket, error) {
+	returnVal, _, err := a.GetBucketsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Bucket
+ */
+func (a *BucketsApiService) GetBucketsIDExecuteWithHttpInfo(r ApiGetBucketsIDRequest) (Bucket, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -540,7 +607,7 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.GetBucketsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}"
@@ -572,12 +639,12 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -591,12 +658,12 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -606,22 +673,22 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -629,10 +696,10 @@ func (a *BucketsApiService) GetBucketsIDExecute(r ApiGetBucketsIDRequest) (Bucke
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchBucketsIDRequest struct {
@@ -671,6 +738,10 @@ func (r ApiPatchBucketsIDRequest) Execute() (Bucket, error) {
 	return r.ApiService.PatchBucketsIDExecute(r)
 }
 
+func (r ApiPatchBucketsIDRequest) ExecuteWithHttpInfo() (Bucket, *_nethttp.Response, error) {
+	return r.ApiService.PatchBucketsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchBucketsID Update a bucket
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -690,6 +761,15 @@ func (a *BucketsApiService) PatchBucketsID(ctx _context.Context, bucketID string
  * @return Bucket
  */
 func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (Bucket, error) {
+	returnVal, _, err := a.PatchBucketsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Bucket
+ */
+func (a *BucketsApiService) PatchBucketsIDExecuteWithHttpInfo(r ApiPatchBucketsIDRequest) (Bucket, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -701,7 +781,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.PatchBucketsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets/{bucketID}"
@@ -711,7 +791,7 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.patchBucketRequest == nil {
-		return localVarReturnValue, reportError("patchBucketRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("patchBucketRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -738,12 +818,12 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 	localVarPostBody = r.patchBucketRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -757,12 +837,12 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -772,22 +852,22 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -795,10 +875,10 @@ func (a *BucketsApiService) PatchBucketsIDExecute(r ApiPatchBucketsIDRequest) (B
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostBucketsRequest struct {
@@ -828,6 +908,10 @@ func (r ApiPostBucketsRequest) Execute() (Bucket, error) {
 	return r.ApiService.PostBucketsExecute(r)
 }
 
+func (r ApiPostBucketsRequest) ExecuteWithHttpInfo() (Bucket, *_nethttp.Response, error) {
+	return r.ApiService.PostBucketsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostBuckets Create a bucket
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -845,6 +929,15 @@ func (a *BucketsApiService) PostBuckets(ctx _context.Context) ApiPostBucketsRequ
  * @return Bucket
  */
 func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket, error) {
+	returnVal, _, err := a.PostBucketsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Bucket
+ */
+func (a *BucketsApiService) PostBucketsExecuteWithHttpInfo(r ApiPostBucketsRequest) (Bucket, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -856,7 +949,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "BucketsApiService.PostBuckets")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/buckets"
@@ -865,7 +958,7 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.postBucketRequest == nil {
-		return localVarReturnValue, reportError("postBucketRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("postBucketRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -892,12 +985,12 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 	localVarPostBody = r.postBucketRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -911,12 +1004,12 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -927,32 +1020,32 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -960,8 +1053,8 @@ func (a *BucketsApiService) PostBucketsExecute(r ApiPostBucketsRequest) (Bucket,
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_dashboards.gen.go
+++ b/api/api_dashboards.gen.go
@@ -39,6 +39,12 @@ type DashboardsApi interface {
 	 */
 	GetDashboardsExecute(r ApiGetDashboardsRequest) (Dashboards, error)
 
+	/*
+	   * GetDashboardsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Dashboards
+	*/
+	GetDashboardsExecuteWithHttpInfo(r ApiGetDashboardsRequest) (Dashboards, *_nethttp.Response, error)
+
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
 	// servers.
@@ -153,6 +159,10 @@ func (r ApiGetDashboardsRequest) Execute() (Dashboards, error) {
 	return r.ApiService.GetDashboardsExecute(r)
 }
 
+func (r ApiGetDashboardsRequest) ExecuteWithHttpInfo() (Dashboards, *_nethttp.Response, error) {
+	return r.ApiService.GetDashboardsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetDashboards List all dashboards
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -170,6 +180,15 @@ func (a *DashboardsApiService) GetDashboards(ctx _context.Context) ApiGetDashboa
  * @return Dashboards
  */
 func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (Dashboards, error) {
+	returnVal, _, err := a.GetDashboardsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Dashboards
+ */
+func (a *DashboardsApiService) GetDashboardsExecuteWithHttpInfo(r ApiGetDashboardsRequest) (Dashboards, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -181,7 +200,7 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DashboardsApiService.GetDashboards")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/dashboards"
@@ -244,12 +263,12 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -263,12 +282,12 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -278,22 +297,22 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -301,8 +320,8 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_dashboards.gen.go
+++ b/api/api_dashboards.gen.go
@@ -40,9 +40,11 @@ type DashboardsApi interface {
 	GetDashboardsExecute(r ApiGetDashboardsRequest) (Dashboards, error)
 
 	/*
-	   * GetDashboardsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Dashboards
-	*/
+	 * GetDashboardsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Dashboards
+	 */
 	GetDashboardsExecuteWithHttpInfo(r ApiGetDashboardsRequest) (Dashboards, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -185,7 +187,9 @@ func (a *DashboardsApiService) GetDashboardsExecute(r ApiGetDashboardsRequest) (
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Dashboards
  */
 func (a *DashboardsApiService) GetDashboardsExecuteWithHttpInfo(r ApiGetDashboardsRequest) (Dashboards, *_nethttp.Response, error) {

--- a/api/api_dbrps.gen.go
+++ b/api/api_dbrps.gen.go
@@ -40,6 +40,11 @@ type DBRPsApi interface {
 	DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error
 
 	/*
+	 * DeleteDBRPIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteDBRPIDExecuteWithHttpInfo(r ApiDeleteDBRPIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetDBRPs List database retention policy mappings
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetDBRPsRequest
@@ -51,6 +56,12 @@ type DBRPsApi interface {
 	 * @return DBRPs
 	 */
 	GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error)
+
+	/*
+	   * GetDBRPsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return DBRPs
+	*/
+	GetDBRPsExecuteWithHttpInfo(r ApiGetDBRPsRequest) (DBRPs, *_nethttp.Response, error)
 
 	/*
 	 * GetDBRPsID Retrieve a database retention policy mapping
@@ -67,6 +78,12 @@ type DBRPsApi interface {
 	GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, error)
 
 	/*
+	   * GetDBRPsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return DBRPGet
+	*/
+	GetDBRPsIDExecuteWithHttpInfo(r ApiGetDBRPsIDRequest) (DBRPGet, *_nethttp.Response, error)
+
+	/*
 	 * PatchDBRPID Update a database retention policy mapping
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param dbrpID The database retention policy mapping.
@@ -81,6 +98,12 @@ type DBRPsApi interface {
 	PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, error)
 
 	/*
+	   * PatchDBRPIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return DBRPGet
+	*/
+	PatchDBRPIDExecuteWithHttpInfo(r ApiPatchDBRPIDRequest) (DBRPGet, *_nethttp.Response, error)
+
+	/*
 	 * PostDBRP Add a database retention policy mapping
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostDBRPRequest
@@ -92,6 +115,12 @@ type DBRPsApi interface {
 	 * @return DBRP
 	 */
 	PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error)
+
+	/*
+	   * PostDBRPExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return DBRP
+	*/
+	PostDBRPExecuteWithHttpInfo(r ApiPostDBRPRequest) (DBRP, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -162,6 +191,10 @@ func (r ApiDeleteDBRPIDRequest) Execute() error {
 	return r.ApiService.DeleteDBRPIDExecute(r)
 }
 
+func (r ApiDeleteDBRPIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteDBRPIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteDBRPID Delete a database retention policy
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -180,6 +213,14 @@ func (a *DBRPsApiService) DeleteDBRPID(ctx _context.Context, dbrpID string) ApiD
  * Execute executes the request
  */
 func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
+	_, err := a.DeleteDBRPIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *DBRPsApiService) DeleteDBRPIDExecuteWithHttpInfo(r ApiDeleteDBRPIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -190,7 +231,7 @@ func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DBRPsApiService.DeleteDBRPID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/dbrps/{dbrpID}"
@@ -228,12 +269,12 @@ func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -247,12 +288,12 @@ func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -263,24 +304,24 @@ func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetDBRPsRequest struct {
@@ -364,6 +405,10 @@ func (r ApiGetDBRPsRequest) Execute() (DBRPs, error) {
 	return r.ApiService.GetDBRPsExecute(r)
 }
 
+func (r ApiGetDBRPsRequest) ExecuteWithHttpInfo() (DBRPs, *_nethttp.Response, error) {
+	return r.ApiService.GetDBRPsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetDBRPs List database retention policy mappings
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -381,6 +426,15 @@ func (a *DBRPsApiService) GetDBRPs(ctx _context.Context) ApiGetDBRPsRequest {
  * @return DBRPs
  */
 func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
+	returnVal, _, err := a.GetDBRPsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return DBRPs
+ */
+func (a *DBRPsApiService) GetDBRPsExecuteWithHttpInfo(r ApiGetDBRPsRequest) (DBRPs, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -392,7 +446,7 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DBRPsApiService.GetDBRPs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/dbrps"
@@ -444,12 +498,12 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -463,12 +517,12 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -479,32 +533,32 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -512,10 +566,10 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetDBRPsIDRequest struct {
@@ -563,6 +617,10 @@ func (r ApiGetDBRPsIDRequest) Execute() (DBRPGet, error) {
 	return r.ApiService.GetDBRPsIDExecute(r)
 }
 
+func (r ApiGetDBRPsIDRequest) ExecuteWithHttpInfo() (DBRPGet, *_nethttp.Response, error) {
+	return r.ApiService.GetDBRPsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetDBRPsID Retrieve a database retention policy mapping
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -582,6 +640,15 @@ func (a *DBRPsApiService) GetDBRPsID(ctx _context.Context, dbrpID string) ApiGet
  * @return DBRPGet
  */
 func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, error) {
+	returnVal, _, err := a.GetDBRPsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return DBRPGet
+ */
+func (a *DBRPsApiService) GetDBRPsIDExecuteWithHttpInfo(r ApiGetDBRPsIDRequest) (DBRPGet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -593,7 +660,7 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DBRPsApiService.GetDBRPsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/dbrps/{dbrpID}"
@@ -631,12 +698,12 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -650,12 +717,12 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -666,32 +733,32 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -699,10 +766,10 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchDBRPIDRequest struct {
@@ -759,6 +826,10 @@ func (r ApiPatchDBRPIDRequest) Execute() (DBRPGet, error) {
 	return r.ApiService.PatchDBRPIDExecute(r)
 }
 
+func (r ApiPatchDBRPIDRequest) ExecuteWithHttpInfo() (DBRPGet, *_nethttp.Response, error) {
+	return r.ApiService.PatchDBRPIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchDBRPID Update a database retention policy mapping
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -778,6 +849,15 @@ func (a *DBRPsApiService) PatchDBRPID(ctx _context.Context, dbrpID string) ApiPa
  * @return DBRPGet
  */
 func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, error) {
+	returnVal, _, err := a.PatchDBRPIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return DBRPGet
+ */
+func (a *DBRPsApiService) PatchDBRPIDExecuteWithHttpInfo(r ApiPatchDBRPIDRequest) (DBRPGet, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -789,7 +869,7 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DBRPsApiService.PatchDBRPID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/dbrps/{dbrpID}"
@@ -799,7 +879,7 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.dBRPUpdate == nil {
-		return localVarReturnValue, reportError("dBRPUpdate is required and must be specified")
+		return localVarReturnValue, nil, reportError("dBRPUpdate is required and must be specified")
 	}
 
 	if r.orgID != nil {
@@ -832,12 +912,12 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 	localVarPostBody = r.dBRPUpdate
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -851,12 +931,12 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -867,43 +947,43 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -911,10 +991,10 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostDBRPRequest struct {
@@ -944,6 +1024,10 @@ func (r ApiPostDBRPRequest) Execute() (DBRP, error) {
 	return r.ApiService.PostDBRPExecute(r)
 }
 
+func (r ApiPostDBRPRequest) ExecuteWithHttpInfo() (DBRP, *_nethttp.Response, error) {
+	return r.ApiService.PostDBRPExecuteWithHttpInfo(r)
+}
+
 /*
  * PostDBRP Add a database retention policy mapping
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -961,6 +1045,15 @@ func (a *DBRPsApiService) PostDBRP(ctx _context.Context) ApiPostDBRPRequest {
  * @return DBRP
  */
 func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
+	returnVal, _, err := a.PostDBRPExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return DBRP
+ */
+func (a *DBRPsApiService) PostDBRPExecuteWithHttpInfo(r ApiPostDBRPRequest) (DBRP, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -972,7 +1065,7 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DBRPsApiService.PostDBRP")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/dbrps"
@@ -981,7 +1074,7 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.dBRPCreate == nil {
-		return localVarReturnValue, reportError("dBRPCreate is required and must be specified")
+		return localVarReturnValue, nil, reportError("dBRPCreate is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1008,12 +1101,12 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 	localVarPostBody = r.dBRPCreate
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1027,12 +1120,12 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1043,32 +1136,32 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1076,8 +1169,8 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_dbrps.gen.go
+++ b/api/api_dbrps.gen.go
@@ -40,7 +40,9 @@ type DBRPsApi interface {
 	DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error
 
 	/*
-	 * DeleteDBRPIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteDBRPIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteDBRPIDExecuteWithHttpInfo(r ApiDeleteDBRPIDRequest) (*_nethttp.Response, error)
 
@@ -58,9 +60,11 @@ type DBRPsApi interface {
 	GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error)
 
 	/*
-	   * GetDBRPsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return DBRPs
-	*/
+	 * GetDBRPsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return DBRPs
+	 */
 	GetDBRPsExecuteWithHttpInfo(r ApiGetDBRPsRequest) (DBRPs, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type DBRPsApi interface {
 	GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, error)
 
 	/*
-	   * GetDBRPsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return DBRPGet
-	*/
+	 * GetDBRPsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return DBRPGet
+	 */
 	GetDBRPsIDExecuteWithHttpInfo(r ApiGetDBRPsIDRequest) (DBRPGet, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type DBRPsApi interface {
 	PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, error)
 
 	/*
-	   * PatchDBRPIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return DBRPGet
-	*/
+	 * PatchDBRPIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return DBRPGet
+	 */
 	PatchDBRPIDExecuteWithHttpInfo(r ApiPatchDBRPIDRequest) (DBRPGet, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type DBRPsApi interface {
 	PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error)
 
 	/*
-	   * PostDBRPExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return DBRP
-	*/
+	 * PostDBRPExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return DBRP
+	 */
 	PostDBRPExecuteWithHttpInfo(r ApiPostDBRPRequest) (DBRP, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -218,7 +228,9 @@ func (a *DBRPsApiService) DeleteDBRPIDExecute(r ApiDeleteDBRPIDRequest) error {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *DBRPsApiService) DeleteDBRPIDExecuteWithHttpInfo(r ApiDeleteDBRPIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -431,7 +443,9 @@ func (a *DBRPsApiService) GetDBRPsExecute(r ApiGetDBRPsRequest) (DBRPs, error) {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return DBRPs
  */
 func (a *DBRPsApiService) GetDBRPsExecuteWithHttpInfo(r ApiGetDBRPsRequest) (DBRPs, *_nethttp.Response, error) {
@@ -645,7 +659,9 @@ func (a *DBRPsApiService) GetDBRPsIDExecute(r ApiGetDBRPsIDRequest) (DBRPGet, er
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return DBRPGet
  */
 func (a *DBRPsApiService) GetDBRPsIDExecuteWithHttpInfo(r ApiGetDBRPsIDRequest) (DBRPGet, *_nethttp.Response, error) {
@@ -854,7 +870,9 @@ func (a *DBRPsApiService) PatchDBRPIDExecute(r ApiPatchDBRPIDRequest) (DBRPGet, 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return DBRPGet
  */
 func (a *DBRPsApiService) PatchDBRPIDExecuteWithHttpInfo(r ApiPatchDBRPIDRequest) (DBRPGet, *_nethttp.Response, error) {
@@ -1050,7 +1068,9 @@ func (a *DBRPsApiService) PostDBRPExecute(r ApiPostDBRPRequest) (DBRP, error) {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return DBRP
  */
 func (a *DBRPsApiService) PostDBRPExecuteWithHttpInfo(r ApiPostDBRPRequest) (DBRP, *_nethttp.Response, error) {

--- a/api/api_delete.gen.go
+++ b/api/api_delete.gen.go
@@ -38,7 +38,9 @@ type DeleteApi interface {
 	PostDeleteExecute(r ApiPostDeleteRequest) error
 
 	/*
-	 * PostDeleteExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostDeleteExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostDeleteExecuteWithHttpInfo(r ApiPostDeleteRequest) (*_nethttp.Response, error)
 
@@ -154,7 +156,9 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *DeleteApiService) PostDeleteExecuteWithHttpInfo(r ApiPostDeleteRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/api_delete.gen.go
+++ b/api/api_delete.gen.go
@@ -37,6 +37,11 @@ type DeleteApi interface {
 	 */
 	PostDeleteExecute(r ApiPostDeleteRequest) error
 
+	/*
+	 * PostDeleteExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostDeleteExecuteWithHttpInfo(r ApiPostDeleteRequest) (*_nethttp.Response, error)
+
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
 	// servers.
@@ -124,6 +129,10 @@ func (r ApiPostDeleteRequest) Execute() error {
 	return r.ApiService.PostDeleteExecute(r)
 }
 
+func (r ApiPostDeleteRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostDeleteExecuteWithHttpInfo(r)
+}
+
 /*
  * PostDelete Delete data
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -140,6 +149,14 @@ func (a *DeleteApiService) PostDelete(ctx _context.Context) ApiPostDeleteRequest
  * Execute executes the request
  */
 func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
+	_, err := a.PostDeleteExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *DeleteApiService) PostDeleteExecuteWithHttpInfo(r ApiPostDeleteRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -150,7 +167,7 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "DeleteApiService.PostDelete")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/delete"
@@ -159,7 +176,7 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.deletePredicateRequest == nil {
-		return reportError("deletePredicateRequest is required and must be specified")
+		return nil, reportError("deletePredicateRequest is required and must be specified")
 	}
 
 	if r.org != nil {
@@ -198,12 +215,12 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 	localVarPostBody = r.deletePredicateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -217,12 +234,12 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -233,44 +250,44 @@ func (a *DeleteApiService) PostDeleteExecute(r ApiPostDeleteRequest) error {
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 403 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_health.gen.go
+++ b/api/api_health.gen.go
@@ -38,6 +38,12 @@ type HealthApi interface {
 	 */
 	GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, error)
 
+	/*
+	   * GetHealthExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return HealthCheck
+	*/
+	GetHealthExecuteWithHttpInfo(r ApiGetHealthRequest) (HealthCheck, *_nethttp.Response, error)
+
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
 	// servers.
@@ -80,6 +86,10 @@ func (r ApiGetHealthRequest) Execute() (HealthCheck, error) {
 	return r.ApiService.GetHealthExecute(r)
 }
 
+func (r ApiGetHealthRequest) ExecuteWithHttpInfo() (HealthCheck, *_nethttp.Response, error) {
+	return r.ApiService.GetHealthExecuteWithHttpInfo(r)
+}
+
 /*
  * GetHealth Get the health of an instance
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -97,6 +107,15 @@ func (a *HealthApiService) GetHealth(ctx _context.Context) ApiGetHealthRequest {
  * @return HealthCheck
  */
 func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, error) {
+	returnVal, _, err := a.GetHealthExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return HealthCheck
+ */
+func (a *HealthApiService) GetHealthExecuteWithHttpInfo(r ApiGetHealthRequest) (HealthCheck, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -108,7 +127,7 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "HealthApiService.GetHealth")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/health"
@@ -139,12 +158,12 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -158,12 +177,12 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -174,32 +193,32 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -207,8 +226,8 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_health.gen.go
+++ b/api/api_health.gen.go
@@ -39,9 +39,11 @@ type HealthApi interface {
 	GetHealthExecute(r ApiGetHealthRequest) (HealthCheck, error)
 
 	/*
-	   * GetHealthExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return HealthCheck
-	*/
+	 * GetHealthExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return HealthCheck
+	 */
 	GetHealthExecuteWithHttpInfo(r ApiGetHealthRequest) (HealthCheck, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -112,7 +114,9 @@ func (a *HealthApiService) GetHealthExecute(r ApiGetHealthRequest) (HealthCheck,
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return HealthCheck
  */
 func (a *HealthApiService) GetHealthExecuteWithHttpInfo(r ApiGetHealthRequest) (HealthCheck, *_nethttp.Response, error) {

--- a/api/api_legacy_authorizations.gen.go
+++ b/api/api_legacy_authorizations.gen.go
@@ -40,7 +40,9 @@ type LegacyAuthorizationsApi interface {
 	DeleteLegacyAuthorizationsIDExecute(r ApiDeleteLegacyAuthorizationsIDRequest) error
 
 	/*
-	 * DeleteLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteLegacyAuthorizationsIDRequest) (*_nethttp.Response, error)
 
@@ -58,9 +60,11 @@ type LegacyAuthorizationsApi interface {
 	GetLegacyAuthorizationsExecute(r ApiGetLegacyAuthorizationsRequest) (Authorizations, error)
 
 	/*
-	   * GetLegacyAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorizations
-	*/
+	 * GetLegacyAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorizations
+	 */
 	GetLegacyAuthorizationsExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsRequest) (Authorizations, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type LegacyAuthorizationsApi interface {
 	GetLegacyAuthorizationsIDExecute(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, error)
 
 	/*
-	   * GetLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorization
-	*/
+	 * GetLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorization
+	 */
 	GetLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type LegacyAuthorizationsApi interface {
 	PatchLegacyAuthorizationsIDExecute(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, error)
 
 	/*
-	   * PatchLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorization
-	*/
+	 * PatchLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorization
+	 */
 	PatchLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type LegacyAuthorizationsApi interface {
 	PostLegacyAuthorizationsExecute(r ApiPostLegacyAuthorizationsRequest) (Authorization, error)
 
 	/*
-	   * PostLegacyAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Authorization
-	*/
+	 * PostLegacyAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Authorization
+	 */
 	PostLegacyAuthorizationsExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsRequest) (Authorization, *_nethttp.Response, error)
 
 	/*
@@ -136,7 +146,9 @@ type LegacyAuthorizationsApi interface {
 	PostLegacyAuthorizationsIDPasswordExecute(r ApiPostLegacyAuthorizationsIDPasswordRequest) error
 
 	/*
-	 * PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsIDPasswordRequest) (*_nethttp.Response, error)
 
@@ -218,7 +230,9 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r A
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteLegacyAuthorizationsIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -405,7 +419,9 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorizations
  */
 func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsRequest) (Authorizations, *_nethttp.Response, error) {
@@ -587,7 +603,9 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorization
  */
 func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
@@ -761,7 +779,9 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorization
  */
 func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
@@ -929,7 +949,9 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Authorization
  */
 func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsRequest) (Authorization, *_nethttp.Response, error) {
@@ -1117,7 +1139,9 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsIDPasswordRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/api_legacy_authorizations.gen.go
+++ b/api/api_legacy_authorizations.gen.go
@@ -40,6 +40,11 @@ type LegacyAuthorizationsApi interface {
 	DeleteLegacyAuthorizationsIDExecute(r ApiDeleteLegacyAuthorizationsIDRequest) error
 
 	/*
+	 * DeleteLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteLegacyAuthorizationsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetLegacyAuthorizations List all legacy authorizations
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetLegacyAuthorizationsRequest
@@ -51,6 +56,12 @@ type LegacyAuthorizationsApi interface {
 	 * @return Authorizations
 	 */
 	GetLegacyAuthorizationsExecute(r ApiGetLegacyAuthorizationsRequest) (Authorizations, error)
+
+	/*
+	   * GetLegacyAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorizations
+	*/
+	GetLegacyAuthorizationsExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsRequest) (Authorizations, *_nethttp.Response, error)
 
 	/*
 	 * GetLegacyAuthorizationsID Retrieve a legacy authorization
@@ -67,6 +78,12 @@ type LegacyAuthorizationsApi interface {
 	GetLegacyAuthorizationsIDExecute(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, error)
 
 	/*
+	   * GetLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorization
+	*/
+	GetLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
+
+	/*
 	 * PatchLegacyAuthorizationsID Update a legacy authorization to be active or inactive
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param authID The ID of the legacy authorization to update.
@@ -79,6 +96,12 @@ type LegacyAuthorizationsApi interface {
 	 * @return Authorization
 	 */
 	PatchLegacyAuthorizationsIDExecute(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, error)
+
+	/*
+	   * PatchLegacyAuthorizationsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorization
+	*/
+	PatchLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error)
 
 	/*
 	 * PostLegacyAuthorizations Create a legacy authorization
@@ -94,6 +117,12 @@ type LegacyAuthorizationsApi interface {
 	PostLegacyAuthorizationsExecute(r ApiPostLegacyAuthorizationsRequest) (Authorization, error)
 
 	/*
+	   * PostLegacyAuthorizationsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Authorization
+	*/
+	PostLegacyAuthorizationsExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsRequest) (Authorization, *_nethttp.Response, error)
+
+	/*
 	 * PostLegacyAuthorizationsIDPassword Set a legacy authorization password
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param authID The ID of the legacy authorization to update.
@@ -105,6 +134,11 @@ type LegacyAuthorizationsApi interface {
 	 * PostLegacyAuthorizationsIDPasswordExecute executes the request
 	 */
 	PostLegacyAuthorizationsIDPasswordExecute(r ApiPostLegacyAuthorizationsIDPasswordRequest) error
+
+	/*
+	 * PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsIDPasswordRequest) (*_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -157,6 +191,10 @@ func (r ApiDeleteLegacyAuthorizationsIDRequest) Execute() error {
 	return r.ApiService.DeleteLegacyAuthorizationsIDExecute(r)
 }
 
+func (r ApiDeleteLegacyAuthorizationsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteLegacyAuthorizationsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteLegacyAuthorizationsID Delete a legacy authorization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -175,6 +213,14 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsID(ctx _conte
  * Execute executes the request
  */
 func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r ApiDeleteLegacyAuthorizationsIDRequest) error {
+	_, err := a.DeleteLegacyAuthorizationsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiDeleteLegacyAuthorizationsIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -185,7 +231,7 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r A
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyAuthorizationsApiService.DeleteLegacyAuthorizationsID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/legacy/authorizations/{authID}"
@@ -217,12 +263,12 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r A
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -236,12 +282,12 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r A
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -251,14 +297,14 @@ func (a *LegacyAuthorizationsApiService) DeleteLegacyAuthorizationsIDExecute(r A
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetLegacyAuthorizationsRequest struct {
@@ -333,6 +379,10 @@ func (r ApiGetLegacyAuthorizationsRequest) Execute() (Authorizations, error) {
 	return r.ApiService.GetLegacyAuthorizationsExecute(r)
 }
 
+func (r ApiGetLegacyAuthorizationsRequest) ExecuteWithHttpInfo() (Authorizations, *_nethttp.Response, error) {
+	return r.ApiService.GetLegacyAuthorizationsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetLegacyAuthorizations List all legacy authorizations
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -350,6 +400,15 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizations(ctx _context.Co
  * @return Authorizations
  */
 func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGetLegacyAuthorizationsRequest) (Authorizations, error) {
+	returnVal, _, err := a.GetLegacyAuthorizationsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorizations
+ */
+func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsRequest) (Authorizations, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -361,7 +420,7 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyAuthorizationsApiService.GetLegacyAuthorizations")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/legacy/authorizations"
@@ -410,12 +469,12 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -429,12 +488,12 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -444,22 +503,22 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -467,10 +526,10 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsExecute(r ApiGet
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetLegacyAuthorizationsIDRequest struct {
@@ -500,6 +559,10 @@ func (r ApiGetLegacyAuthorizationsIDRequest) Execute() (Authorization, error) {
 	return r.ApiService.GetLegacyAuthorizationsIDExecute(r)
 }
 
+func (r ApiGetLegacyAuthorizationsIDRequest) ExecuteWithHttpInfo() (Authorization, *_nethttp.Response, error) {
+	return r.ApiService.GetLegacyAuthorizationsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetLegacyAuthorizationsID Retrieve a legacy authorization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -519,6 +582,15 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsID(ctx _context.
  * @return Authorization
  */
 func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, error) {
+	returnVal, _, err := a.GetLegacyAuthorizationsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorization
+ */
+func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiGetLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -530,7 +602,7 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyAuthorizationsApiService.GetLegacyAuthorizationsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/legacy/authorizations/{authID}"
@@ -562,12 +634,12 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -581,12 +653,12 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -596,22 +668,22 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -619,10 +691,10 @@ func (a *LegacyAuthorizationsApiService) GetLegacyAuthorizationsIDExecute(r ApiG
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchLegacyAuthorizationsIDRequest struct {
@@ -661,6 +733,10 @@ func (r ApiPatchLegacyAuthorizationsIDRequest) Execute() (Authorization, error) 
 	return r.ApiService.PatchLegacyAuthorizationsIDExecute(r)
 }
 
+func (r ApiPatchLegacyAuthorizationsIDRequest) ExecuteWithHttpInfo() (Authorization, *_nethttp.Response, error) {
+	return r.ApiService.PatchLegacyAuthorizationsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchLegacyAuthorizationsID Update a legacy authorization to be active or inactive
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -680,6 +756,15 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsID(ctx _contex
  * @return Authorization
  */
 func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, error) {
+	returnVal, _, err := a.PatchLegacyAuthorizationsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorization
+ */
+func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecuteWithHttpInfo(r ApiPatchLegacyAuthorizationsIDRequest) (Authorization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -691,7 +776,7 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyAuthorizationsApiService.PatchLegacyAuthorizationsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/legacy/authorizations/{authID}"
@@ -701,7 +786,7 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.authorizationUpdateRequest == nil {
-		return localVarReturnValue, reportError("authorizationUpdateRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("authorizationUpdateRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -728,12 +813,12 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 	localVarPostBody = r.authorizationUpdateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -747,12 +832,12 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -762,22 +847,22 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -785,10 +870,10 @@ func (a *LegacyAuthorizationsApiService) PatchLegacyAuthorizationsIDExecute(r Ap
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostLegacyAuthorizationsRequest struct {
@@ -818,6 +903,10 @@ func (r ApiPostLegacyAuthorizationsRequest) Execute() (Authorization, error) {
 	return r.ApiService.PostLegacyAuthorizationsExecute(r)
 }
 
+func (r ApiPostLegacyAuthorizationsRequest) ExecuteWithHttpInfo() (Authorization, *_nethttp.Response, error) {
+	return r.ApiService.PostLegacyAuthorizationsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostLegacyAuthorizations Create a legacy authorization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -835,6 +924,15 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizations(ctx _context.C
  * @return Authorization
  */
 func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPostLegacyAuthorizationsRequest) (Authorization, error) {
+	returnVal, _, err := a.PostLegacyAuthorizationsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Authorization
+ */
+func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsRequest) (Authorization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -846,7 +944,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyAuthorizationsApiService.PostLegacyAuthorizations")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/legacy/authorizations"
@@ -855,7 +953,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.legacyAuthorizationPostRequest == nil {
-		return localVarReturnValue, reportError("legacyAuthorizationPostRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("legacyAuthorizationPostRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -882,12 +980,12 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 	localVarPostBody = r.legacyAuthorizationPostRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -901,12 +999,12 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -917,32 +1015,32 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -950,10 +1048,10 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsExecute(r ApiPo
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostLegacyAuthorizationsIDPasswordRequest struct {
@@ -992,6 +1090,10 @@ func (r ApiPostLegacyAuthorizationsIDPasswordRequest) Execute() error {
 	return r.ApiService.PostLegacyAuthorizationsIDPasswordExecute(r)
 }
 
+func (r ApiPostLegacyAuthorizationsIDPasswordRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo(r)
+}
+
 /*
  * PostLegacyAuthorizationsIDPassword Set a legacy authorization password
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1010,6 +1112,14 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPassword(ctx 
  * Execute executes the request
  */
 func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecute(r ApiPostLegacyAuthorizationsIDPasswordRequest) error {
+	_, err := a.PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecuteWithHttpInfo(r ApiPostLegacyAuthorizationsIDPasswordRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -1020,7 +1130,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "LegacyAuthorizationsApiService.PostLegacyAuthorizationsIDPassword")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/legacy/authorizations/{authID}/password"
@@ -1030,7 +1140,7 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.passwordResetBody == nil {
-		return reportError("passwordResetBody is required and must be specified")
+		return nil, reportError("passwordResetBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1057,12 +1167,12 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 	localVarPostBody = r.passwordResetBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1076,12 +1186,12 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1091,12 +1201,12 @@ func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizationsIDPasswordExecu
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_organizations.gen.go
+++ b/api/api_organizations.gen.go
@@ -40,7 +40,9 @@ type OrganizationsApi interface {
 	DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) error
 
 	/*
-	 * DeleteOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteOrgsIDExecuteWithHttpInfo(r ApiDeleteOrgsIDRequest) (*_nethttp.Response, error)
 
@@ -59,7 +61,9 @@ type OrganizationsApi interface {
 	DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsIDMembersIDRequest) error
 
 	/*
-	 * DeleteOrgsIDMembersIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteOrgsIDMembersIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteOrgsIDMembersIDExecuteWithHttpInfo(r ApiDeleteOrgsIDMembersIDRequest) (*_nethttp.Response, error)
 
@@ -77,9 +81,11 @@ type OrganizationsApi interface {
 	GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, error)
 
 	/*
-	   * GetOrgsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Organizations
-	*/
+	 * GetOrgsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Organizations
+	 */
 	GetOrgsExecuteWithHttpInfo(r ApiGetOrgsRequest) (Organizations, *_nethttp.Response, error)
 
 	/*
@@ -97,9 +103,11 @@ type OrganizationsApi interface {
 	GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organization, error)
 
 	/*
-	   * GetOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Organization
-	*/
+	 * GetOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Organization
+	 */
 	GetOrgsIDExecuteWithHttpInfo(r ApiGetOrgsIDRequest) (Organization, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type OrganizationsApi interface {
 	GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersRequest) (ResourceMembers, error)
 
 	/*
-	   * GetOrgsIDMembersExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return ResourceMembers
-	*/
+	 * GetOrgsIDMembersExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return ResourceMembers
+	 */
 	GetOrgsIDMembersExecuteWithHttpInfo(r ApiGetOrgsIDMembersRequest) (ResourceMembers, *_nethttp.Response, error)
 
 	/*
@@ -137,9 +147,11 @@ type OrganizationsApi interface {
 	PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (Organization, error)
 
 	/*
-	   * PatchOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Organization
-	*/
+	 * PatchOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Organization
+	 */
 	PatchOrgsIDExecuteWithHttpInfo(r ApiPatchOrgsIDRequest) (Organization, *_nethttp.Response, error)
 
 	/*
@@ -156,9 +168,11 @@ type OrganizationsApi interface {
 	PostOrgsExecute(r ApiPostOrgsRequest) (Organization, error)
 
 	/*
-	   * PostOrgsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Organization
-	*/
+	 * PostOrgsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Organization
+	 */
 	PostOrgsExecuteWithHttpInfo(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error)
 
 	/*
@@ -176,9 +190,11 @@ type OrganizationsApi interface {
 	PostOrgsIDMembersExecute(r ApiPostOrgsIDMembersRequest) (ResourceMember, error)
 
 	/*
-	   * PostOrgsIDMembersExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return ResourceMember
-	*/
+	 * PostOrgsIDMembersExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return ResourceMember
+	 */
 	PostOrgsIDMembersExecuteWithHttpInfo(r ApiPostOrgsIDMembersRequest) (ResourceMember, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -259,7 +275,9 @@ func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *OrganizationsApiService) DeleteOrgsIDExecuteWithHttpInfo(r ApiDeleteOrgsIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -424,7 +442,9 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsID
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecuteWithHttpInfo(r ApiDeleteOrgsIDMembersIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -612,7 +632,9 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Organizations
  */
 func (a *OrganizationsApiService) GetOrgsExecuteWithHttpInfo(r ApiGetOrgsRequest) (Organizations, *_nethttp.Response, error) {
@@ -794,7 +816,9 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Organization
  */
 func (a *OrganizationsApiService) GetOrgsIDExecuteWithHttpInfo(r ApiGetOrgsIDRequest) (Organization, *_nethttp.Response, error) {
@@ -959,7 +983,9 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return ResourceMembers
  */
 func (a *OrganizationsApiService) GetOrgsIDMembersExecuteWithHttpInfo(r ApiGetOrgsIDMembersRequest) (ResourceMembers, *_nethttp.Response, error) {
@@ -1144,7 +1170,9 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Organization
  */
 func (a *OrganizationsApiService) PatchOrgsIDExecuteWithHttpInfo(r ApiPatchOrgsIDRequest) (Organization, *_nethttp.Response, error) {
@@ -1312,7 +1340,9 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Organization
  */
 func (a *OrganizationsApiService) PostOrgsExecuteWithHttpInfo(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error) {
@@ -1490,7 +1520,9 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return ResourceMember
  */
 func (a *OrganizationsApiService) PostOrgsIDMembersExecuteWithHttpInfo(r ApiPostOrgsIDMembersRequest) (ResourceMember, *_nethttp.Response, error) {

--- a/api/api_organizations.gen.go
+++ b/api/api_organizations.gen.go
@@ -40,6 +40,11 @@ type OrganizationsApi interface {
 	DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) error
 
 	/*
+	 * DeleteOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteOrgsIDExecuteWithHttpInfo(r ApiDeleteOrgsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * DeleteOrgsIDMembersID Remove a member from an organization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param userID The ID of the member to remove.
@@ -54,6 +59,11 @@ type OrganizationsApi interface {
 	DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsIDMembersIDRequest) error
 
 	/*
+	 * DeleteOrgsIDMembersIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteOrgsIDMembersIDExecuteWithHttpInfo(r ApiDeleteOrgsIDMembersIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetOrgs List all organizations
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetOrgsRequest
@@ -65,6 +75,12 @@ type OrganizationsApi interface {
 	 * @return Organizations
 	 */
 	GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, error)
+
+	/*
+	   * GetOrgsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Organizations
+	*/
+	GetOrgsExecuteWithHttpInfo(r ApiGetOrgsRequest) (Organizations, *_nethttp.Response, error)
 
 	/*
 	 * GetOrgsID Retrieve an organization
@@ -81,6 +97,12 @@ type OrganizationsApi interface {
 	GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organization, error)
 
 	/*
+	   * GetOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Organization
+	*/
+	GetOrgsIDExecuteWithHttpInfo(r ApiGetOrgsIDRequest) (Organization, *_nethttp.Response, error)
+
+	/*
 	 * GetOrgsIDMembers List all members of an organization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param orgID The organization ID.
@@ -93,6 +115,12 @@ type OrganizationsApi interface {
 	 * @return ResourceMembers
 	 */
 	GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersRequest) (ResourceMembers, error)
+
+	/*
+	   * GetOrgsIDMembersExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return ResourceMembers
+	*/
+	GetOrgsIDMembersExecuteWithHttpInfo(r ApiGetOrgsIDMembersRequest) (ResourceMembers, *_nethttp.Response, error)
 
 	/*
 	 * PatchOrgsID Update an organization
@@ -109,6 +137,12 @@ type OrganizationsApi interface {
 	PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (Organization, error)
 
 	/*
+	   * PatchOrgsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Organization
+	*/
+	PatchOrgsIDExecuteWithHttpInfo(r ApiPatchOrgsIDRequest) (Organization, *_nethttp.Response, error)
+
+	/*
 	 * PostOrgs Create an organization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostOrgsRequest
@@ -120,6 +154,12 @@ type OrganizationsApi interface {
 	 * @return Organization
 	 */
 	PostOrgsExecute(r ApiPostOrgsRequest) (Organization, error)
+
+	/*
+	   * PostOrgsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Organization
+	*/
+	PostOrgsExecuteWithHttpInfo(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error)
 
 	/*
 	 * PostOrgsIDMembers Add a member to an organization
@@ -134,6 +174,12 @@ type OrganizationsApi interface {
 	 * @return ResourceMember
 	 */
 	PostOrgsIDMembersExecute(r ApiPostOrgsIDMembersRequest) (ResourceMember, error)
+
+	/*
+	   * PostOrgsIDMembersExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return ResourceMember
+	*/
+	PostOrgsIDMembersExecuteWithHttpInfo(r ApiPostOrgsIDMembersRequest) (ResourceMember, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -186,6 +232,10 @@ func (r ApiDeleteOrgsIDRequest) Execute() error {
 	return r.ApiService.DeleteOrgsIDExecute(r)
 }
 
+func (r ApiDeleteOrgsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteOrgsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteOrgsID Delete an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -204,6 +254,14 @@ func (a *OrganizationsApiService) DeleteOrgsID(ctx _context.Context, orgID strin
  * Execute executes the request
  */
 func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) error {
+	_, err := a.DeleteOrgsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *OrganizationsApiService) DeleteOrgsIDExecuteWithHttpInfo(r ApiDeleteOrgsIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -214,7 +272,7 @@ func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.DeleteOrgsID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}"
@@ -246,12 +304,12 @@ func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -265,12 +323,12 @@ func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -281,24 +339,24 @@ func (a *OrganizationsApiService) DeleteOrgsIDExecute(r ApiDeleteOrgsIDRequest) 
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeleteOrgsIDMembersIDRequest struct {
@@ -337,6 +395,10 @@ func (r ApiDeleteOrgsIDMembersIDRequest) Execute() error {
 	return r.ApiService.DeleteOrgsIDMembersIDExecute(r)
 }
 
+func (r ApiDeleteOrgsIDMembersIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteOrgsIDMembersIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteOrgsIDMembersID Remove a member from an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -357,6 +419,14 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersID(ctx _context.Context, us
  * Execute executes the request
  */
 func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsIDMembersIDRequest) error {
+	_, err := a.DeleteOrgsIDMembersIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecuteWithHttpInfo(r ApiDeleteOrgsIDMembersIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -367,7 +437,7 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsID
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.DeleteOrgsIDMembersID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}/members/{userID}"
@@ -400,12 +470,12 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsID
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -419,12 +489,12 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsID
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -434,14 +504,14 @@ func (a *OrganizationsApiService) DeleteOrgsIDMembersIDExecute(r ApiDeleteOrgsID
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetOrgsRequest struct {
@@ -516,6 +586,10 @@ func (r ApiGetOrgsRequest) Execute() (Organizations, error) {
 	return r.ApiService.GetOrgsExecute(r)
 }
 
+func (r ApiGetOrgsRequest) ExecuteWithHttpInfo() (Organizations, *_nethttp.Response, error) {
+	return r.ApiService.GetOrgsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetOrgs List all organizations
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -533,6 +607,15 @@ func (a *OrganizationsApiService) GetOrgs(ctx _context.Context) ApiGetOrgsReques
  * @return Organizations
  */
 func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizations, error) {
+	returnVal, _, err := a.GetOrgsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Organizations
+ */
+func (a *OrganizationsApiService) GetOrgsExecuteWithHttpInfo(r ApiGetOrgsRequest) (Organizations, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -544,7 +627,7 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.GetOrgs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs"
@@ -593,12 +676,12 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -612,12 +695,12 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -627,22 +710,22 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -650,10 +733,10 @@ func (a *OrganizationsApiService) GetOrgsExecute(r ApiGetOrgsRequest) (Organizat
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetOrgsIDRequest struct {
@@ -683,6 +766,10 @@ func (r ApiGetOrgsIDRequest) Execute() (Organization, error) {
 	return r.ApiService.GetOrgsIDExecute(r)
 }
 
+func (r ApiGetOrgsIDRequest) ExecuteWithHttpInfo() (Organization, *_nethttp.Response, error) {
+	return r.ApiService.GetOrgsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetOrgsID Retrieve an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -702,6 +789,15 @@ func (a *OrganizationsApiService) GetOrgsID(ctx _context.Context, orgID string) 
  * @return Organization
  */
 func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organization, error) {
+	returnVal, _, err := a.GetOrgsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Organization
+ */
+func (a *OrganizationsApiService) GetOrgsIDExecuteWithHttpInfo(r ApiGetOrgsIDRequest) (Organization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -713,7 +809,7 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.GetOrgsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}"
@@ -745,12 +841,12 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -764,12 +860,12 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -779,22 +875,22 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -802,10 +898,10 @@ func (a *OrganizationsApiService) GetOrgsIDExecute(r ApiGetOrgsIDRequest) (Organ
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetOrgsIDMembersRequest struct {
@@ -835,6 +931,10 @@ func (r ApiGetOrgsIDMembersRequest) Execute() (ResourceMembers, error) {
 	return r.ApiService.GetOrgsIDMembersExecute(r)
 }
 
+func (r ApiGetOrgsIDMembersRequest) ExecuteWithHttpInfo() (ResourceMembers, *_nethttp.Response, error) {
+	return r.ApiService.GetOrgsIDMembersExecuteWithHttpInfo(r)
+}
+
 /*
  * GetOrgsIDMembers List all members of an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -854,6 +954,15 @@ func (a *OrganizationsApiService) GetOrgsIDMembers(ctx _context.Context, orgID s
  * @return ResourceMembers
  */
 func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersRequest) (ResourceMembers, error) {
+	returnVal, _, err := a.GetOrgsIDMembersExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return ResourceMembers
+ */
+func (a *OrganizationsApiService) GetOrgsIDMembersExecuteWithHttpInfo(r ApiGetOrgsIDMembersRequest) (ResourceMembers, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -865,7 +974,7 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.GetOrgsIDMembers")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}/members"
@@ -897,12 +1006,12 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -916,12 +1025,12 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -932,32 +1041,32 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -965,10 +1074,10 @@ func (a *OrganizationsApiService) GetOrgsIDMembersExecute(r ApiGetOrgsIDMembersR
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchOrgsIDRequest struct {
@@ -1007,6 +1116,10 @@ func (r ApiPatchOrgsIDRequest) Execute() (Organization, error) {
 	return r.ApiService.PatchOrgsIDExecute(r)
 }
 
+func (r ApiPatchOrgsIDRequest) ExecuteWithHttpInfo() (Organization, *_nethttp.Response, error) {
+	return r.ApiService.PatchOrgsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchOrgsID Update an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1026,6 +1139,15 @@ func (a *OrganizationsApiService) PatchOrgsID(ctx _context.Context, orgID string
  * @return Organization
  */
 func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (Organization, error) {
+	returnVal, _, err := a.PatchOrgsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Organization
+ */
+func (a *OrganizationsApiService) PatchOrgsIDExecuteWithHttpInfo(r ApiPatchOrgsIDRequest) (Organization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -1037,7 +1159,7 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.PatchOrgsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}"
@@ -1047,7 +1169,7 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.patchOrganizationRequest == nil {
-		return localVarReturnValue, reportError("patchOrganizationRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("patchOrganizationRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1074,12 +1196,12 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 	localVarPostBody = r.patchOrganizationRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1093,12 +1215,12 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1108,22 +1230,22 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1131,10 +1253,10 @@ func (a *OrganizationsApiService) PatchOrgsIDExecute(r ApiPatchOrgsIDRequest) (O
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostOrgsRequest struct {
@@ -1164,6 +1286,10 @@ func (r ApiPostOrgsRequest) Execute() (Organization, error) {
 	return r.ApiService.PostOrgsExecute(r)
 }
 
+func (r ApiPostOrgsRequest) ExecuteWithHttpInfo() (Organization, *_nethttp.Response, error) {
+	return r.ApiService.PostOrgsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostOrgs Create an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1181,6 +1307,15 @@ func (a *OrganizationsApiService) PostOrgs(ctx _context.Context) ApiPostOrgsRequ
  * @return Organization
  */
 func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organization, error) {
+	returnVal, _, err := a.PostOrgsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Organization
+ */
+func (a *OrganizationsApiService) PostOrgsExecuteWithHttpInfo(r ApiPostOrgsRequest) (Organization, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -1192,7 +1327,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.PostOrgs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs"
@@ -1201,7 +1336,7 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.postOrganizationRequest == nil {
-		return localVarReturnValue, reportError("postOrganizationRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("postOrganizationRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1228,12 +1363,12 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 	localVarPostBody = r.postOrganizationRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1247,12 +1382,12 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1262,22 +1397,22 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1285,10 +1420,10 @@ func (a *OrganizationsApiService) PostOrgsExecute(r ApiPostOrgsRequest) (Organiz
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostOrgsIDMembersRequest struct {
@@ -1327,6 +1462,10 @@ func (r ApiPostOrgsIDMembersRequest) Execute() (ResourceMember, error) {
 	return r.ApiService.PostOrgsIDMembersExecute(r)
 }
 
+func (r ApiPostOrgsIDMembersRequest) ExecuteWithHttpInfo() (ResourceMember, *_nethttp.Response, error) {
+	return r.ApiService.PostOrgsIDMembersExecuteWithHttpInfo(r)
+}
+
 /*
  * PostOrgsIDMembers Add a member to an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1346,6 +1485,15 @@ func (a *OrganizationsApiService) PostOrgsIDMembers(ctx _context.Context, orgID 
  * @return ResourceMember
  */
 func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMembersRequest) (ResourceMember, error) {
+	returnVal, _, err := a.PostOrgsIDMembersExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return ResourceMember
+ */
+func (a *OrganizationsApiService) PostOrgsIDMembersExecuteWithHttpInfo(r ApiPostOrgsIDMembersRequest) (ResourceMember, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -1357,7 +1505,7 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "OrganizationsApiService.PostOrgsIDMembers")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}/members"
@@ -1367,7 +1515,7 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.addResourceMemberRequestBody == nil {
-		return localVarReturnValue, reportError("addResourceMemberRequestBody is required and must be specified")
+		return localVarReturnValue, nil, reportError("addResourceMemberRequestBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1394,12 +1542,12 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 	localVarPostBody = r.addResourceMemberRequestBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1413,12 +1561,12 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1428,22 +1576,22 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1451,8 +1599,8 @@ func (a *OrganizationsApiService) PostOrgsIDMembersExecute(r ApiPostOrgsIDMember
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_query.gen.go
+++ b/api/api_query.gen.go
@@ -38,6 +38,12 @@ type QueryApi interface {
 	 */
 	PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Response, error)
 
+	/*
+	   * PostQueryExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return *os.File
+	*/
+	PostQueryExecuteWithHttpInfo(r ApiPostQueryRequest) (*_nethttp.Response, *_nethttp.Response, error)
+
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
 	// servers.
@@ -125,6 +131,10 @@ func (r ApiPostQueryRequest) Execute() (*_nethttp.Response, error) {
 	return r.ApiService.PostQueryExecute(r)
 }
 
+func (r ApiPostQueryRequest) ExecuteWithHttpInfo() (*_nethttp.Response, *_nethttp.Response, error) {
+	return r.ApiService.PostQueryExecuteWithHttpInfo(r)
+}
+
 /*
  * PostQuery Query InfluxDB
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -142,6 +152,15 @@ func (a *QueryApiService) PostQuery(ctx _context.Context) ApiPostQueryRequest {
  * @return *os.File
  */
 func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Response, error) {
+	returnVal, _, err := a.PostQueryExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return *os.File
+ */
+func (a *QueryApiService) PostQueryExecuteWithHttpInfo(r ApiPostQueryRequest) (*_nethttp.Response, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -153,7 +172,7 @@ func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Res
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "QueryApiService.PostQuery")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/query"
@@ -198,12 +217,12 @@ func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Res
 	localVarPostBody = r.query
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -217,12 +236,12 @@ func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Res
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -232,14 +251,14 @@ func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Res
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	localVarReturnValue = localVarHTTPResponse
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_query.gen.go
+++ b/api/api_query.gen.go
@@ -39,9 +39,11 @@ type QueryApi interface {
 	PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Response, error)
 
 	/*
-	   * PostQueryExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return *os.File
-	*/
+	 * PostQueryExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return *os.File
+	 */
 	PostQueryExecuteWithHttpInfo(r ApiPostQueryRequest) (*_nethttp.Response, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -157,7 +159,9 @@ func (a *QueryApiService) PostQueryExecute(r ApiPostQueryRequest) (*_nethttp.Res
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return *os.File
  */
 func (a *QueryApiService) PostQueryExecuteWithHttpInfo(r ApiPostQueryRequest) (*_nethttp.Response, *_nethttp.Response, error) {

--- a/api/api_remote_connections.gen.go
+++ b/api/api_remote_connections.gen.go
@@ -40,6 +40,11 @@ type RemoteConnectionsApi interface {
 	DeleteRemoteConnectionByIDExecute(r ApiDeleteRemoteConnectionByIDRequest) error
 
 	/*
+	 * DeleteRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteRemoteConnectionByIDExecuteWithHttpInfo(r ApiDeleteRemoteConnectionByIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetRemoteConnectionByID Retrieve a remote connection
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param remoteID
@@ -54,6 +59,12 @@ type RemoteConnectionsApi interface {
 	GetRemoteConnectionByIDExecute(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, error)
 
 	/*
+	   * GetRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return RemoteConnection
+	*/
+	GetRemoteConnectionByIDExecuteWithHttpInfo(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error)
+
+	/*
 	 * GetRemoteConnections List all remote connections
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetRemoteConnectionsRequest
@@ -65,6 +76,12 @@ type RemoteConnectionsApi interface {
 	 * @return RemoteConnections
 	 */
 	GetRemoteConnectionsExecute(r ApiGetRemoteConnectionsRequest) (RemoteConnections, error)
+
+	/*
+	   * GetRemoteConnectionsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return RemoteConnections
+	*/
+	GetRemoteConnectionsExecuteWithHttpInfo(r ApiGetRemoteConnectionsRequest) (RemoteConnections, *_nethttp.Response, error)
 
 	/*
 	 * PatchRemoteConnectionByID Update a remote connection
@@ -81,6 +98,12 @@ type RemoteConnectionsApi interface {
 	PatchRemoteConnectionByIDExecute(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, error)
 
 	/*
+	   * PatchRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return RemoteConnection
+	*/
+	PatchRemoteConnectionByIDExecuteWithHttpInfo(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error)
+
+	/*
 	 * PostRemoteConnection Register a new remote connection
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostRemoteConnectionRequest
@@ -92,6 +115,12 @@ type RemoteConnectionsApi interface {
 	 * @return RemoteConnection
 	 */
 	PostRemoteConnectionExecute(r ApiPostRemoteConnectionRequest) (RemoteConnection, error)
+
+	/*
+	   * PostRemoteConnectionExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return RemoteConnection
+	*/
+	PostRemoteConnectionExecuteWithHttpInfo(r ApiPostRemoteConnectionRequest) (RemoteConnection, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -144,6 +173,10 @@ func (r ApiDeleteRemoteConnectionByIDRequest) Execute() error {
 	return r.ApiService.DeleteRemoteConnectionByIDExecute(r)
 }
 
+func (r ApiDeleteRemoteConnectionByIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteRemoteConnectionByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteRemoteConnectionByID Delete a remote connection
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -162,6 +195,14 @@ func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByID(ctx _context.Co
  * Execute executes the request
  */
 func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecute(r ApiDeleteRemoteConnectionByIDRequest) error {
+	_, err := a.DeleteRemoteConnectionByIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecuteWithHttpInfo(r ApiDeleteRemoteConnectionByIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -172,7 +213,7 @@ func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecute(r ApiDel
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RemoteConnectionsApiService.DeleteRemoteConnectionByID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/remotes/{remoteID}"
@@ -204,12 +245,12 @@ func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecute(r ApiDel
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -223,12 +264,12 @@ func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecute(r ApiDel
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -239,24 +280,24 @@ func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecute(r ApiDel
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetRemoteConnectionByIDRequest struct {
@@ -286,6 +327,10 @@ func (r ApiGetRemoteConnectionByIDRequest) Execute() (RemoteConnection, error) {
 	return r.ApiService.GetRemoteConnectionByIDExecute(r)
 }
 
+func (r ApiGetRemoteConnectionByIDRequest) ExecuteWithHttpInfo() (RemoteConnection, *_nethttp.Response, error) {
+	return r.ApiService.GetRemoteConnectionByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetRemoteConnectionByID Retrieve a remote connection
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -305,6 +350,15 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByID(ctx _context.Conte
  * @return RemoteConnection
  */
 func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, error) {
+	returnVal, _, err := a.GetRemoteConnectionByIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return RemoteConnection
+ */
+func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecuteWithHttpInfo(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -316,7 +370,7 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRem
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RemoteConnectionsApiService.GetRemoteConnectionByID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/remotes/{remoteID}"
@@ -348,12 +402,12 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRem
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -367,12 +421,12 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRem
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -383,32 +437,32 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRem
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -416,10 +470,10 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRem
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetRemoteConnectionsRequest struct {
@@ -467,6 +521,10 @@ func (r ApiGetRemoteConnectionsRequest) Execute() (RemoteConnections, error) {
 	return r.ApiService.GetRemoteConnectionsExecute(r)
 }
 
+func (r ApiGetRemoteConnectionsRequest) ExecuteWithHttpInfo() (RemoteConnections, *_nethttp.Response, error) {
+	return r.ApiService.GetRemoteConnectionsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetRemoteConnections List all remote connections
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -484,6 +542,15 @@ func (a *RemoteConnectionsApiService) GetRemoteConnections(ctx _context.Context)
  * @return RemoteConnections
  */
 func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemoteConnectionsRequest) (RemoteConnections, error) {
+	returnVal, _, err := a.GetRemoteConnectionsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return RemoteConnections
+ */
+func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecuteWithHttpInfo(r ApiGetRemoteConnectionsRequest) (RemoteConnections, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -495,7 +562,7 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RemoteConnectionsApiService.GetRemoteConnections")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/remotes"
@@ -504,7 +571,7 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orgID == nil {
-		return localVarReturnValue, reportError("orgID is required and must be specified")
+		return localVarReturnValue, nil, reportError("orgID is required and must be specified")
 	}
 
 	localVarQueryParams.Add("orgID", parameterToString(*r.orgID, ""))
@@ -536,12 +603,12 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -555,12 +622,12 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -571,32 +638,32 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -604,10 +671,10 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchRemoteConnectionByIDRequest struct {
@@ -646,6 +713,10 @@ func (r ApiPatchRemoteConnectionByIDRequest) Execute() (RemoteConnection, error)
 	return r.ApiService.PatchRemoteConnectionByIDExecute(r)
 }
 
+func (r ApiPatchRemoteConnectionByIDRequest) ExecuteWithHttpInfo() (RemoteConnection, *_nethttp.Response, error) {
+	return r.ApiService.PatchRemoteConnectionByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchRemoteConnectionByID Update a remote connection
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -665,6 +736,15 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByID(ctx _context.Con
  * @return RemoteConnection
  */
 func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, error) {
+	returnVal, _, err := a.PatchRemoteConnectionByIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return RemoteConnection
+ */
+func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecuteWithHttpInfo(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -676,7 +756,7 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RemoteConnectionsApiService.PatchRemoteConnectionByID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/remotes/{remoteID}"
@@ -686,7 +766,7 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.remoteConnenctionUpdateRequest == nil {
-		return localVarReturnValue, reportError("remoteConnenctionUpdateRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("remoteConnenctionUpdateRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -713,12 +793,12 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 	localVarPostBody = r.remoteConnenctionUpdateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -732,12 +812,12 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -748,43 +828,43 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -792,10 +872,10 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostRemoteConnectionRequest struct {
@@ -816,6 +896,10 @@ func (r ApiPostRemoteConnectionRequest) Execute() (RemoteConnection, error) {
 	return r.ApiService.PostRemoteConnectionExecute(r)
 }
 
+func (r ApiPostRemoteConnectionRequest) ExecuteWithHttpInfo() (RemoteConnection, *_nethttp.Response, error) {
+	return r.ApiService.PostRemoteConnectionExecuteWithHttpInfo(r)
+}
+
 /*
  * PostRemoteConnection Register a new remote connection
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -833,6 +917,15 @@ func (a *RemoteConnectionsApiService) PostRemoteConnection(ctx _context.Context)
  * @return RemoteConnection
  */
 func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemoteConnectionRequest) (RemoteConnection, error) {
+	returnVal, _, err := a.PostRemoteConnectionExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return RemoteConnection
+ */
+func (a *RemoteConnectionsApiService) PostRemoteConnectionExecuteWithHttpInfo(r ApiPostRemoteConnectionRequest) (RemoteConnection, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -844,7 +937,7 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RemoteConnectionsApiService.PostRemoteConnection")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/remotes"
@@ -853,7 +946,7 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.remoteConnectionCreationRequest == nil {
-		return localVarReturnValue, reportError("remoteConnectionCreationRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("remoteConnectionCreationRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -877,12 +970,12 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 	localVarPostBody = r.remoteConnectionCreationRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -896,12 +989,12 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -912,32 +1005,32 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -945,8 +1038,8 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_remote_connections.gen.go
+++ b/api/api_remote_connections.gen.go
@@ -40,7 +40,9 @@ type RemoteConnectionsApi interface {
 	DeleteRemoteConnectionByIDExecute(r ApiDeleteRemoteConnectionByIDRequest) error
 
 	/*
-	 * DeleteRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteRemoteConnectionByIDExecuteWithHttpInfo(r ApiDeleteRemoteConnectionByIDRequest) (*_nethttp.Response, error)
 
@@ -59,9 +61,11 @@ type RemoteConnectionsApi interface {
 	GetRemoteConnectionByIDExecute(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, error)
 
 	/*
-	   * GetRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return RemoteConnection
-	*/
+	 * GetRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return RemoteConnection
+	 */
 	GetRemoteConnectionByIDExecuteWithHttpInfo(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type RemoteConnectionsApi interface {
 	GetRemoteConnectionsExecute(r ApiGetRemoteConnectionsRequest) (RemoteConnections, error)
 
 	/*
-	   * GetRemoteConnectionsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return RemoteConnections
-	*/
+	 * GetRemoteConnectionsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return RemoteConnections
+	 */
 	GetRemoteConnectionsExecuteWithHttpInfo(r ApiGetRemoteConnectionsRequest) (RemoteConnections, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type RemoteConnectionsApi interface {
 	PatchRemoteConnectionByIDExecute(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, error)
 
 	/*
-	   * PatchRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return RemoteConnection
-	*/
+	 * PatchRemoteConnectionByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return RemoteConnection
+	 */
 	PatchRemoteConnectionByIDExecuteWithHttpInfo(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type RemoteConnectionsApi interface {
 	PostRemoteConnectionExecute(r ApiPostRemoteConnectionRequest) (RemoteConnection, error)
 
 	/*
-	   * PostRemoteConnectionExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return RemoteConnection
-	*/
+	 * PostRemoteConnectionExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return RemoteConnection
+	 */
 	PostRemoteConnectionExecuteWithHttpInfo(r ApiPostRemoteConnectionRequest) (RemoteConnection, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -200,7 +210,9 @@ func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecute(r ApiDel
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *RemoteConnectionsApiService) DeleteRemoteConnectionByIDExecuteWithHttpInfo(r ApiDeleteRemoteConnectionByIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -355,7 +367,9 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecute(r ApiGetRem
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return RemoteConnection
  */
 func (a *RemoteConnectionsApiService) GetRemoteConnectionByIDExecuteWithHttpInfo(r ApiGetRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error) {
@@ -547,7 +561,9 @@ func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecute(r ApiGetRemote
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return RemoteConnections
  */
 func (a *RemoteConnectionsApiService) GetRemoteConnectionsExecuteWithHttpInfo(r ApiGetRemoteConnectionsRequest) (RemoteConnections, *_nethttp.Response, error) {
@@ -741,7 +757,9 @@ func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecute(r ApiPatc
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return RemoteConnection
  */
 func (a *RemoteConnectionsApiService) PatchRemoteConnectionByIDExecuteWithHttpInfo(r ApiPatchRemoteConnectionByIDRequest) (RemoteConnection, *_nethttp.Response, error) {
@@ -922,7 +940,9 @@ func (a *RemoteConnectionsApiService) PostRemoteConnectionExecute(r ApiPostRemot
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return RemoteConnection
  */
 func (a *RemoteConnectionsApiService) PostRemoteConnectionExecuteWithHttpInfo(r ApiPostRemoteConnectionRequest) (RemoteConnection, *_nethttp.Response, error) {

--- a/api/api_replications.gen.go
+++ b/api/api_replications.gen.go
@@ -40,6 +40,11 @@ type ReplicationsApi interface {
 	DeleteReplicationByIDExecute(r ApiDeleteReplicationByIDRequest) error
 
 	/*
+	 * DeleteReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteReplicationByIDExecuteWithHttpInfo(r ApiDeleteReplicationByIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetReplicationByID Retrieve a replication
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param replicationID
@@ -54,6 +59,12 @@ type ReplicationsApi interface {
 	GetReplicationByIDExecute(r ApiGetReplicationByIDRequest) (Replication, error)
 
 	/*
+	   * GetReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Replication
+	*/
+	GetReplicationByIDExecuteWithHttpInfo(r ApiGetReplicationByIDRequest) (Replication, *_nethttp.Response, error)
+
+	/*
 	 * GetReplications List all replications
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetReplicationsRequest
@@ -65,6 +76,12 @@ type ReplicationsApi interface {
 	 * @return Replications
 	 */
 	GetReplicationsExecute(r ApiGetReplicationsRequest) (Replications, error)
+
+	/*
+	   * GetReplicationsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Replications
+	*/
+	GetReplicationsExecuteWithHttpInfo(r ApiGetReplicationsRequest) (Replications, *_nethttp.Response, error)
 
 	/*
 	 * PatchReplicationByID Update a replication
@@ -81,6 +98,12 @@ type ReplicationsApi interface {
 	PatchReplicationByIDExecute(r ApiPatchReplicationByIDRequest) (Replication, error)
 
 	/*
+	   * PatchReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Replication
+	*/
+	PatchReplicationByIDExecuteWithHttpInfo(r ApiPatchReplicationByIDRequest) (Replication, *_nethttp.Response, error)
+
+	/*
 	 * PostReplication Register a new replication
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostReplicationRequest
@@ -94,6 +117,12 @@ type ReplicationsApi interface {
 	PostReplicationExecute(r ApiPostReplicationRequest) (Replication, error)
 
 	/*
+	   * PostReplicationExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Replication
+	*/
+	PostReplicationExecuteWithHttpInfo(r ApiPostReplicationRequest) (Replication, *_nethttp.Response, error)
+
+	/*
 	 * PostValidateReplicationByID Validate a replication
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param replicationID
@@ -105,6 +134,11 @@ type ReplicationsApi interface {
 	 * PostValidateReplicationByIDExecute executes the request
 	 */
 	PostValidateReplicationByIDExecute(r ApiPostValidateReplicationByIDRequest) error
+
+	/*
+	 * PostValidateReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostValidateReplicationByIDExecuteWithHttpInfo(r ApiPostValidateReplicationByIDRequest) (*_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -157,6 +191,10 @@ func (r ApiDeleteReplicationByIDRequest) Execute() error {
 	return r.ApiService.DeleteReplicationByIDExecute(r)
 }
 
+func (r ApiDeleteReplicationByIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteReplicationByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteReplicationByID Delete a replication
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -175,6 +213,14 @@ func (a *ReplicationsApiService) DeleteReplicationByID(ctx _context.Context, rep
  * Execute executes the request
  */
 func (a *ReplicationsApiService) DeleteReplicationByIDExecute(r ApiDeleteReplicationByIDRequest) error {
+	_, err := a.DeleteReplicationByIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *ReplicationsApiService) DeleteReplicationByIDExecuteWithHttpInfo(r ApiDeleteReplicationByIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -185,7 +231,7 @@ func (a *ReplicationsApiService) DeleteReplicationByIDExecute(r ApiDeleteReplica
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ReplicationsApiService.DeleteReplicationByID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/replications/{replicationID}"
@@ -217,12 +263,12 @@ func (a *ReplicationsApiService) DeleteReplicationByIDExecute(r ApiDeleteReplica
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -236,12 +282,12 @@ func (a *ReplicationsApiService) DeleteReplicationByIDExecute(r ApiDeleteReplica
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -252,24 +298,24 @@ func (a *ReplicationsApiService) DeleteReplicationByIDExecute(r ApiDeleteReplica
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetReplicationByIDRequest struct {
@@ -299,6 +345,10 @@ func (r ApiGetReplicationByIDRequest) Execute() (Replication, error) {
 	return r.ApiService.GetReplicationByIDExecute(r)
 }
 
+func (r ApiGetReplicationByIDRequest) ExecuteWithHttpInfo() (Replication, *_nethttp.Response, error) {
+	return r.ApiService.GetReplicationByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetReplicationByID Retrieve a replication
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -318,6 +368,15 @@ func (a *ReplicationsApiService) GetReplicationByID(ctx _context.Context, replic
  * @return Replication
  */
 func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationByIDRequest) (Replication, error) {
+	returnVal, _, err := a.GetReplicationByIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Replication
+ */
+func (a *ReplicationsApiService) GetReplicationByIDExecuteWithHttpInfo(r ApiGetReplicationByIDRequest) (Replication, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -329,7 +388,7 @@ func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationBy
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ReplicationsApiService.GetReplicationByID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/replications/{replicationID}"
@@ -361,12 +420,12 @@ func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationBy
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -380,12 +439,12 @@ func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationBy
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -396,32 +455,32 @@ func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationBy
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -429,10 +488,10 @@ func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationBy
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetReplicationsRequest struct {
@@ -489,6 +548,10 @@ func (r ApiGetReplicationsRequest) Execute() (Replications, error) {
 	return r.ApiService.GetReplicationsExecute(r)
 }
 
+func (r ApiGetReplicationsRequest) ExecuteWithHttpInfo() (Replications, *_nethttp.Response, error) {
+	return r.ApiService.GetReplicationsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetReplications List all replications
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -506,6 +569,15 @@ func (a *ReplicationsApiService) GetReplications(ctx _context.Context) ApiGetRep
  * @return Replications
  */
 func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequest) (Replications, error) {
+	returnVal, _, err := a.GetReplicationsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Replications
+ */
+func (a *ReplicationsApiService) GetReplicationsExecuteWithHttpInfo(r ApiGetReplicationsRequest) (Replications, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -517,7 +589,7 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ReplicationsApiService.GetReplications")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/replications"
@@ -526,7 +598,7 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orgID == nil {
-		return localVarReturnValue, reportError("orgID is required and must be specified")
+		return localVarReturnValue, nil, reportError("orgID is required and must be specified")
 	}
 
 	localVarQueryParams.Add("orgID", parameterToString(*r.orgID, ""))
@@ -561,12 +633,12 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -580,12 +652,12 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -596,32 +668,32 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -629,10 +701,10 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchReplicationByIDRequest struct {
@@ -680,6 +752,10 @@ func (r ApiPatchReplicationByIDRequest) Execute() (Replication, error) {
 	return r.ApiService.PatchReplicationByIDExecute(r)
 }
 
+func (r ApiPatchReplicationByIDRequest) ExecuteWithHttpInfo() (Replication, *_nethttp.Response, error) {
+	return r.ApiService.PatchReplicationByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchReplicationByID Update a replication
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -699,6 +775,15 @@ func (a *ReplicationsApiService) PatchReplicationByID(ctx _context.Context, repl
  * @return Replication
  */
 func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicationByIDRequest) (Replication, error) {
+	returnVal, _, err := a.PatchReplicationByIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Replication
+ */
+func (a *ReplicationsApiService) PatchReplicationByIDExecuteWithHttpInfo(r ApiPatchReplicationByIDRequest) (Replication, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -710,7 +795,7 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ReplicationsApiService.PatchReplicationByID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/replications/{replicationID}"
@@ -720,7 +805,7 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.replicationUpdateRequest == nil {
-		return localVarReturnValue, reportError("replicationUpdateRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("replicationUpdateRequest is required and must be specified")
 	}
 
 	if r.validate != nil {
@@ -750,12 +835,12 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 	localVarPostBody = r.replicationUpdateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -769,12 +854,12 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -785,43 +870,43 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -829,10 +914,10 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostReplicationRequest struct {
@@ -871,6 +956,10 @@ func (r ApiPostReplicationRequest) Execute() (Replication, error) {
 	return r.ApiService.PostReplicationExecute(r)
 }
 
+func (r ApiPostReplicationRequest) ExecuteWithHttpInfo() (Replication, *_nethttp.Response, error) {
+	return r.ApiService.PostReplicationExecuteWithHttpInfo(r)
+}
+
 /*
  * PostReplication Register a new replication
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -888,6 +977,15 @@ func (a *ReplicationsApiService) PostReplication(ctx _context.Context) ApiPostRe
  * @return Replication
  */
 func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequest) (Replication, error) {
+	returnVal, _, err := a.PostReplicationExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Replication
+ */
+func (a *ReplicationsApiService) PostReplicationExecuteWithHttpInfo(r ApiPostReplicationRequest) (Replication, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -899,7 +997,7 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ReplicationsApiService.PostReplication")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/replications"
@@ -908,7 +1006,7 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.replicationCreationRequest == nil {
-		return localVarReturnValue, reportError("replicationCreationRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("replicationCreationRequest is required and must be specified")
 	}
 
 	if r.validate != nil {
@@ -938,12 +1036,12 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 	localVarPostBody = r.replicationCreationRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -957,12 +1055,12 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -973,32 +1071,32 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1006,10 +1104,10 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostValidateReplicationByIDRequest struct {
@@ -1039,6 +1137,10 @@ func (r ApiPostValidateReplicationByIDRequest) Execute() error {
 	return r.ApiService.PostValidateReplicationByIDExecute(r)
 }
 
+func (r ApiPostValidateReplicationByIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostValidateReplicationByIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PostValidateReplicationByID Validate a replication
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1057,6 +1159,14 @@ func (a *ReplicationsApiService) PostValidateReplicationByID(ctx _context.Contex
  * Execute executes the request
  */
 func (a *ReplicationsApiService) PostValidateReplicationByIDExecute(r ApiPostValidateReplicationByIDRequest) error {
+	_, err := a.PostValidateReplicationByIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *ReplicationsApiService) PostValidateReplicationByIDExecuteWithHttpInfo(r ApiPostValidateReplicationByIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -1067,7 +1177,7 @@ func (a *ReplicationsApiService) PostValidateReplicationByIDExecute(r ApiPostVal
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ReplicationsApiService.PostValidateReplicationByID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/replications/{replicationID}/validate"
@@ -1099,12 +1209,12 @@ func (a *ReplicationsApiService) PostValidateReplicationByIDExecute(r ApiPostVal
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1118,12 +1228,12 @@ func (a *ReplicationsApiService) PostValidateReplicationByIDExecute(r ApiPostVal
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1134,22 +1244,22 @@ func (a *ReplicationsApiService) PostValidateReplicationByIDExecute(r ApiPostVal
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_replications.gen.go
+++ b/api/api_replications.gen.go
@@ -40,7 +40,9 @@ type ReplicationsApi interface {
 	DeleteReplicationByIDExecute(r ApiDeleteReplicationByIDRequest) error
 
 	/*
-	 * DeleteReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteReplicationByIDExecuteWithHttpInfo(r ApiDeleteReplicationByIDRequest) (*_nethttp.Response, error)
 
@@ -59,9 +61,11 @@ type ReplicationsApi interface {
 	GetReplicationByIDExecute(r ApiGetReplicationByIDRequest) (Replication, error)
 
 	/*
-	   * GetReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Replication
-	*/
+	 * GetReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Replication
+	 */
 	GetReplicationByIDExecuteWithHttpInfo(r ApiGetReplicationByIDRequest) (Replication, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type ReplicationsApi interface {
 	GetReplicationsExecute(r ApiGetReplicationsRequest) (Replications, error)
 
 	/*
-	   * GetReplicationsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Replications
-	*/
+	 * GetReplicationsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Replications
+	 */
 	GetReplicationsExecuteWithHttpInfo(r ApiGetReplicationsRequest) (Replications, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type ReplicationsApi interface {
 	PatchReplicationByIDExecute(r ApiPatchReplicationByIDRequest) (Replication, error)
 
 	/*
-	   * PatchReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Replication
-	*/
+	 * PatchReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Replication
+	 */
 	PatchReplicationByIDExecuteWithHttpInfo(r ApiPatchReplicationByIDRequest) (Replication, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type ReplicationsApi interface {
 	PostReplicationExecute(r ApiPostReplicationRequest) (Replication, error)
 
 	/*
-	   * PostReplicationExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Replication
-	*/
+	 * PostReplicationExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Replication
+	 */
 	PostReplicationExecuteWithHttpInfo(r ApiPostReplicationRequest) (Replication, *_nethttp.Response, error)
 
 	/*
@@ -136,7 +146,9 @@ type ReplicationsApi interface {
 	PostValidateReplicationByIDExecute(r ApiPostValidateReplicationByIDRequest) error
 
 	/*
-	 * PostValidateReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostValidateReplicationByIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostValidateReplicationByIDExecuteWithHttpInfo(r ApiPostValidateReplicationByIDRequest) (*_nethttp.Response, error)
 
@@ -218,7 +230,9 @@ func (a *ReplicationsApiService) DeleteReplicationByIDExecute(r ApiDeleteReplica
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *ReplicationsApiService) DeleteReplicationByIDExecuteWithHttpInfo(r ApiDeleteReplicationByIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -373,7 +387,9 @@ func (a *ReplicationsApiService) GetReplicationByIDExecute(r ApiGetReplicationBy
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Replication
  */
 func (a *ReplicationsApiService) GetReplicationByIDExecuteWithHttpInfo(r ApiGetReplicationByIDRequest) (Replication, *_nethttp.Response, error) {
@@ -574,7 +590,9 @@ func (a *ReplicationsApiService) GetReplicationsExecute(r ApiGetReplicationsRequ
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Replications
  */
 func (a *ReplicationsApiService) GetReplicationsExecuteWithHttpInfo(r ApiGetReplicationsRequest) (Replications, *_nethttp.Response, error) {
@@ -780,7 +798,9 @@ func (a *ReplicationsApiService) PatchReplicationByIDExecute(r ApiPatchReplicati
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Replication
  */
 func (a *ReplicationsApiService) PatchReplicationByIDExecuteWithHttpInfo(r ApiPatchReplicationByIDRequest) (Replication, *_nethttp.Response, error) {
@@ -982,7 +1002,9 @@ func (a *ReplicationsApiService) PostReplicationExecute(r ApiPostReplicationRequ
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Replication
  */
 func (a *ReplicationsApiService) PostReplicationExecuteWithHttpInfo(r ApiPostReplicationRequest) (Replication, *_nethttp.Response, error) {
@@ -1164,7 +1186,9 @@ func (a *ReplicationsApiService) PostValidateReplicationByIDExecute(r ApiPostVal
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *ReplicationsApiService) PostValidateReplicationByIDExecuteWithHttpInfo(r ApiPostValidateReplicationByIDRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/api_resources.gen.go
+++ b/api/api_resources.gen.go
@@ -38,6 +38,12 @@ type ResourcesApi interface {
 	 */
 	GetResourcesExecute(r ApiGetResourcesRequest) ([]string, error)
 
+	/*
+	   * GetResourcesExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return []string
+	*/
+	GetResourcesExecuteWithHttpInfo(r ApiGetResourcesRequest) ([]string, *_nethttp.Response, error)
+
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
 	// servers.
@@ -80,6 +86,10 @@ func (r ApiGetResourcesRequest) Execute() ([]string, error) {
 	return r.ApiService.GetResourcesExecute(r)
 }
 
+func (r ApiGetResourcesRequest) ExecuteWithHttpInfo() ([]string, *_nethttp.Response, error) {
+	return r.ApiService.GetResourcesExecuteWithHttpInfo(r)
+}
+
 /*
  * GetResources List all known resources
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -97,6 +107,15 @@ func (a *ResourcesApiService) GetResources(ctx _context.Context) ApiGetResources
  * @return []string
  */
 func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]string, error) {
+	returnVal, _, err := a.GetResourcesExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return []string
+ */
+func (a *ResourcesApiService) GetResourcesExecuteWithHttpInfo(r ApiGetResourcesRequest) ([]string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -108,7 +127,7 @@ func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]s
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "ResourcesApiService.GetResources")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/resources"
@@ -139,12 +158,12 @@ func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]s
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -158,12 +177,12 @@ func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]s
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -173,22 +192,22 @@ func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]s
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -196,8 +215,8 @@ func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]s
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_resources.gen.go
+++ b/api/api_resources.gen.go
@@ -39,9 +39,11 @@ type ResourcesApi interface {
 	GetResourcesExecute(r ApiGetResourcesRequest) ([]string, error)
 
 	/*
-	   * GetResourcesExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return []string
-	*/
+	 * GetResourcesExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return []string
+	 */
 	GetResourcesExecuteWithHttpInfo(r ApiGetResourcesRequest) ([]string, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -112,7 +114,9 @@ func (a *ResourcesApiService) GetResourcesExecute(r ApiGetResourcesRequest) ([]s
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return []string
  */
 func (a *ResourcesApiService) GetResourcesExecuteWithHttpInfo(r ApiGetResourcesRequest) ([]string, *_nethttp.Response, error) {

--- a/api/api_restore.gen.go
+++ b/api/api_restore.gen.go
@@ -41,9 +41,11 @@ type RestoreApi interface {
 	PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDRequest) (string, error)
 
 	/*
-	   * PostRestoreBucketIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return string
-	*/
+	 * PostRestoreBucketIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return string
+	 */
 	PostRestoreBucketIDExecuteWithHttpInfo(r ApiPostRestoreBucketIDRequest) (string, *_nethttp.Response, error)
 
 	/*
@@ -60,9 +62,11 @@ type RestoreApi interface {
 	PostRestoreBucketMetadataExecute(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, error)
 
 	/*
-	   * PostRestoreBucketMetadataExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return RestoredBucketMappings
-	*/
+	 * PostRestoreBucketMetadataExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return RestoredBucketMappings
+	 */
 	PostRestoreBucketMetadataExecuteWithHttpInfo(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, *_nethttp.Response, error)
 
 	/*
@@ -79,9 +83,11 @@ type RestoreApi interface {
 	PostRestoreKVExecute(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, error)
 
 	/*
-	   * PostRestoreKVExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return PostRestoreKVResponse
-	*/
+	 * PostRestoreKVExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return PostRestoreKVResponse
+	 */
 	PostRestoreKVExecuteWithHttpInfo(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, *_nethttp.Response, error)
 
 	/*
@@ -97,7 +103,9 @@ type RestoreApi interface {
 	PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) error
 
 	/*
-	 * PostRestoreSQLExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostRestoreSQLExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostRestoreSQLExecuteWithHttpInfo(r ApiPostRestoreSQLRequest) (*_nethttp.Response, error)
 
@@ -115,7 +123,9 @@ type RestoreApi interface {
 	PostRestoreShardIdExecute(r ApiPostRestoreShardIdRequest) error
 
 	/*
-	 * PostRestoreShardIdExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostRestoreShardIdExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostRestoreShardIdExecuteWithHttpInfo(r ApiPostRestoreShardIdRequest) (*_nethttp.Response, error)
 
@@ -216,7 +226,9 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return string
  */
 func (a *RestoreApiService) PostRestoreBucketIDExecuteWithHttpInfo(r ApiPostRestoreBucketIDRequest) (string, *_nethttp.Response, error) {
@@ -387,7 +399,9 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return RestoredBucketMappings
  */
 func (a *RestoreApiService) PostRestoreBucketMetadataExecuteWithHttpInfo(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, *_nethttp.Response, error) {
@@ -572,7 +586,9 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return PostRestoreKVResponse
  */
 func (a *RestoreApiService) PostRestoreKVExecuteWithHttpInfo(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, *_nethttp.Response, error) {
@@ -762,7 +778,9 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *RestoreApiService) PostRestoreSQLExecuteWithHttpInfo(r ApiPostRestoreSQLRequest) (*_nethttp.Response, error) {
 	var (
@@ -942,7 +960,9 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *RestoreApiService) PostRestoreShardIdExecuteWithHttpInfo(r ApiPostRestoreShardIdRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/api_restore.gen.go
+++ b/api/api_restore.gen.go
@@ -41,6 +41,12 @@ type RestoreApi interface {
 	PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDRequest) (string, error)
 
 	/*
+	   * PostRestoreBucketIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return string
+	*/
+	PostRestoreBucketIDExecuteWithHttpInfo(r ApiPostRestoreBucketIDRequest) (string, *_nethttp.Response, error)
+
+	/*
 	 * PostRestoreBucketMetadata Create a new bucket pre-seeded with shard info from a backup.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostRestoreBucketMetadataRequest
@@ -52,6 +58,12 @@ type RestoreApi interface {
 	 * @return RestoredBucketMappings
 	 */
 	PostRestoreBucketMetadataExecute(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, error)
+
+	/*
+	   * PostRestoreBucketMetadataExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return RestoredBucketMappings
+	*/
+	PostRestoreBucketMetadataExecuteWithHttpInfo(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, *_nethttp.Response, error)
 
 	/*
 	 * PostRestoreKV Overwrite the embedded KV store on the server with a backed-up snapshot.
@@ -67,6 +79,12 @@ type RestoreApi interface {
 	PostRestoreKVExecute(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, error)
 
 	/*
+	   * PostRestoreKVExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return PostRestoreKVResponse
+	*/
+	PostRestoreKVExecuteWithHttpInfo(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, *_nethttp.Response, error)
+
+	/*
 	 * PostRestoreSQL Overwrite the embedded SQL store on the server with a backed-up snapshot.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostRestoreSQLRequest
@@ -77,6 +95,11 @@ type RestoreApi interface {
 	 * PostRestoreSQLExecute executes the request
 	 */
 	PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) error
+
+	/*
+	 * PostRestoreSQLExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostRestoreSQLExecuteWithHttpInfo(r ApiPostRestoreSQLRequest) (*_nethttp.Response, error)
 
 	/*
 	 * PostRestoreShardId Restore a TSM snapshot into a shard.
@@ -90,6 +113,11 @@ type RestoreApi interface {
 	 * PostRestoreShardIdExecute executes the request
 	 */
 	PostRestoreShardIdExecute(r ApiPostRestoreShardIdRequest) error
+
+	/*
+	 * PostRestoreShardIdExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostRestoreShardIdExecuteWithHttpInfo(r ApiPostRestoreShardIdRequest) (*_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -160,6 +188,10 @@ func (r ApiPostRestoreBucketIDRequest) Execute() (string, error) {
 	return r.ApiService.PostRestoreBucketIDExecute(r)
 }
 
+func (r ApiPostRestoreBucketIDRequest) ExecuteWithHttpInfo() (string, *_nethttp.Response, error) {
+	return r.ApiService.PostRestoreBucketIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PostRestoreBucketID Overwrite storage metadata for a bucket with shard info from a backup.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -179,6 +211,15 @@ func (a *RestoreApiService) PostRestoreBucketID(ctx _context.Context, bucketID s
  * @return string
  */
 func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDRequest) (string, error) {
+	returnVal, _, err := a.PostRestoreBucketIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return string
+ */
+func (a *RestoreApiService) PostRestoreBucketIDExecuteWithHttpInfo(r ApiPostRestoreBucketIDRequest) (string, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -190,7 +231,7 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RestoreApiService.PostRestoreBucketID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/restore/buckets/{bucketID}"
@@ -200,7 +241,7 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		return localVarReturnValue, reportError("body is required and must be specified")
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -230,12 +271,12 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -249,12 +290,12 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -264,22 +305,22 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -287,10 +328,10 @@ func (a *RestoreApiService) PostRestoreBucketIDExecute(r ApiPostRestoreBucketIDR
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostRestoreBucketMetadataRequest struct {
@@ -320,6 +361,10 @@ func (r ApiPostRestoreBucketMetadataRequest) Execute() (RestoredBucketMappings, 
 	return r.ApiService.PostRestoreBucketMetadataExecute(r)
 }
 
+func (r ApiPostRestoreBucketMetadataRequest) ExecuteWithHttpInfo() (RestoredBucketMappings, *_nethttp.Response, error) {
+	return r.ApiService.PostRestoreBucketMetadataExecuteWithHttpInfo(r)
+}
+
 /*
  * PostRestoreBucketMetadata Create a new bucket pre-seeded with shard info from a backup.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -337,6 +382,15 @@ func (a *RestoreApiService) PostRestoreBucketMetadata(ctx _context.Context) ApiP
  * @return RestoredBucketMappings
  */
 func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, error) {
+	returnVal, _, err := a.PostRestoreBucketMetadataExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return RestoredBucketMappings
+ */
+func (a *RestoreApiService) PostRestoreBucketMetadataExecuteWithHttpInfo(r ApiPostRestoreBucketMetadataRequest) (RestoredBucketMappings, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -348,7 +402,7 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RestoreApiService.PostRestoreBucketMetadata")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/restore/bucketMetadata"
@@ -357,7 +411,7 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.bucketMetadataManifest == nil {
-		return localVarReturnValue, reportError("bucketMetadataManifest is required and must be specified")
+		return localVarReturnValue, nil, reportError("bucketMetadataManifest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -384,12 +438,12 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 	localVarPostBody = r.bucketMetadataManifest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -403,12 +457,12 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -418,22 +472,22 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -441,10 +495,10 @@ func (a *RestoreApiService) PostRestoreBucketMetadataExecute(r ApiPostRestoreBuc
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostRestoreKVRequest struct {
@@ -492,6 +546,10 @@ func (r ApiPostRestoreKVRequest) Execute() (PostRestoreKVResponse, error) {
 	return r.ApiService.PostRestoreKVExecute(r)
 }
 
+func (r ApiPostRestoreKVRequest) ExecuteWithHttpInfo() (PostRestoreKVResponse, *_nethttp.Response, error) {
+	return r.ApiService.PostRestoreKVExecuteWithHttpInfo(r)
+}
+
 /*
  * PostRestoreKV Overwrite the embedded KV store on the server with a backed-up snapshot.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -509,6 +567,15 @@ func (a *RestoreApiService) PostRestoreKV(ctx _context.Context) ApiPostRestoreKV
  * @return PostRestoreKVResponse
  */
 func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, error) {
+	returnVal, _, err := a.PostRestoreKVExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return PostRestoreKVResponse
+ */
+func (a *RestoreApiService) PostRestoreKVExecuteWithHttpInfo(r ApiPostRestoreKVRequest) (PostRestoreKVResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -520,7 +587,7 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RestoreApiService.PostRestoreKV")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/restore/kv"
@@ -529,7 +596,7 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		return localVarReturnValue, reportError("body is required and must be specified")
+		return localVarReturnValue, nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -562,12 +629,12 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -581,12 +648,12 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -596,22 +663,22 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -619,10 +686,10 @@ func (a *RestoreApiService) PostRestoreKVExecute(r ApiPostRestoreKVRequest) (Pos
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostRestoreSQLRequest struct {
@@ -670,6 +737,10 @@ func (r ApiPostRestoreSQLRequest) Execute() error {
 	return r.ApiService.PostRestoreSQLExecute(r)
 }
 
+func (r ApiPostRestoreSQLRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostRestoreSQLExecuteWithHttpInfo(r)
+}
+
 /*
  * PostRestoreSQL Overwrite the embedded SQL store on the server with a backed-up snapshot.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -686,6 +757,14 @@ func (a *RestoreApiService) PostRestoreSQL(ctx _context.Context) ApiPostRestoreS
  * Execute executes the request
  */
 func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) error {
+	_, err := a.PostRestoreSQLExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *RestoreApiService) PostRestoreSQLExecuteWithHttpInfo(r ApiPostRestoreSQLRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -696,7 +775,7 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RestoreApiService.PostRestoreSQL")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/restore/sql"
@@ -705,7 +784,7 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		return reportError("body is required and must be specified")
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -738,12 +817,12 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -757,12 +836,12 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -772,14 +851,14 @@ func (a *RestoreApiService) PostRestoreSQLExecute(r ApiPostRestoreSQLRequest) er
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiPostRestoreShardIdRequest struct {
@@ -836,6 +915,10 @@ func (r ApiPostRestoreShardIdRequest) Execute() error {
 	return r.ApiService.PostRestoreShardIdExecute(r)
 }
 
+func (r ApiPostRestoreShardIdRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostRestoreShardIdExecuteWithHttpInfo(r)
+}
+
 /*
  * PostRestoreShardId Restore a TSM snapshot into a shard.
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -854,6 +937,14 @@ func (a *RestoreApiService) PostRestoreShardId(ctx _context.Context, shardID str
  * Execute executes the request
  */
 func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdRequest) error {
+	_, err := a.PostRestoreShardIdExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *RestoreApiService) PostRestoreShardIdExecuteWithHttpInfo(r ApiPostRestoreShardIdRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -864,7 +955,7 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "RestoreApiService.PostRestoreShardId")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/restore/shards/{shardID}"
@@ -874,7 +965,7 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.body == nil {
-		return reportError("body is required and must be specified")
+		return nil, reportError("body is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -907,12 +998,12 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -926,12 +1017,12 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -941,12 +1032,12 @@ func (a *RestoreApiService) PostRestoreShardIdExecute(r ApiPostRestoreShardIdReq
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_secrets.gen.go
+++ b/api/api_secrets.gen.go
@@ -41,9 +41,11 @@ type SecretsApi interface {
 	GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, error)
 
 	/*
-	   * GetOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return SecretKeysResponse
-	*/
+	 * GetOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return SecretKeysResponse
+	 */
 	GetOrgsIDSecretsExecuteWithHttpInfo(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, *_nethttp.Response, error)
 
 	/*
@@ -60,7 +62,9 @@ type SecretsApi interface {
 	PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsRequest) error
 
 	/*
-	 * PatchOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PatchOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PatchOrgsIDSecretsExecuteWithHttpInfo(r ApiPatchOrgsIDSecretsRequest) (*_nethttp.Response, error)
 
@@ -78,7 +82,9 @@ type SecretsApi interface {
 	PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsRequest) error
 
 	/*
-	 * PostOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostOrgsIDSecretsExecuteWithHttpInfo(r ApiPostOrgsIDSecretsRequest) (*_nethttp.Response, error)
 
@@ -161,7 +167,9 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return SecretKeysResponse
  */
 func (a *SecretsApiService) GetOrgsIDSecretsExecuteWithHttpInfo(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, *_nethttp.Response, error) {
@@ -334,7 +342,9 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *SecretsApiService) PatchOrgsIDSecretsExecuteWithHttpInfo(r ApiPatchOrgsIDSecretsRequest) (*_nethttp.Response, error) {
 	var (
@@ -491,7 +501,9 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *SecretsApiService) PostOrgsIDSecretsExecuteWithHttpInfo(r ApiPostOrgsIDSecretsRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/api_secrets.gen.go
+++ b/api/api_secrets.gen.go
@@ -41,6 +41,12 @@ type SecretsApi interface {
 	GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, error)
 
 	/*
+	   * GetOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return SecretKeysResponse
+	*/
+	GetOrgsIDSecretsExecuteWithHttpInfo(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, *_nethttp.Response, error)
+
+	/*
 	 * PatchOrgsIDSecrets Update secrets in an organization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param orgID The organization ID.
@@ -54,6 +60,11 @@ type SecretsApi interface {
 	PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsRequest) error
 
 	/*
+	 * PatchOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PatchOrgsIDSecretsExecuteWithHttpInfo(r ApiPatchOrgsIDSecretsRequest) (*_nethttp.Response, error)
+
+	/*
 	 * PostOrgsIDSecrets Delete secrets from an organization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param orgID The organization ID.
@@ -65,6 +76,11 @@ type SecretsApi interface {
 	 * PostOrgsIDSecretsExecute executes the request
 	 */
 	PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsRequest) error
+
+	/*
+	 * PostOrgsIDSecretsExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostOrgsIDSecretsExecuteWithHttpInfo(r ApiPostOrgsIDSecretsRequest) (*_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -117,6 +133,10 @@ func (r ApiGetOrgsIDSecretsRequest) Execute() (SecretKeysResponse, error) {
 	return r.ApiService.GetOrgsIDSecretsExecute(r)
 }
 
+func (r ApiGetOrgsIDSecretsRequest) ExecuteWithHttpInfo() (SecretKeysResponse, *_nethttp.Response, error) {
+	return r.ApiService.GetOrgsIDSecretsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetOrgsIDSecrets List all secret keys for an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -136,6 +156,15 @@ func (a *SecretsApiService) GetOrgsIDSecrets(ctx _context.Context, orgID string)
  * @return SecretKeysResponse
  */
 func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, error) {
+	returnVal, _, err := a.GetOrgsIDSecretsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return SecretKeysResponse
+ */
+func (a *SecretsApiService) GetOrgsIDSecretsExecuteWithHttpInfo(r ApiGetOrgsIDSecretsRequest) (SecretKeysResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -147,7 +176,7 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SecretsApiService.GetOrgsIDSecrets")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}/secrets"
@@ -179,12 +208,12 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -198,12 +227,12 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -213,22 +242,22 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -236,10 +265,10 @@ func (a *SecretsApiService) GetOrgsIDSecretsExecute(r ApiGetOrgsIDSecretsRequest
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchOrgsIDSecretsRequest struct {
@@ -278,6 +307,10 @@ func (r ApiPatchOrgsIDSecretsRequest) Execute() error {
 	return r.ApiService.PatchOrgsIDSecretsExecute(r)
 }
 
+func (r ApiPatchOrgsIDSecretsRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PatchOrgsIDSecretsExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchOrgsIDSecrets Update secrets in an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -296,6 +329,14 @@ func (a *SecretsApiService) PatchOrgsIDSecrets(ctx _context.Context, orgID strin
  * Execute executes the request
  */
 func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsRequest) error {
+	_, err := a.PatchOrgsIDSecretsExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *SecretsApiService) PatchOrgsIDSecretsExecuteWithHttpInfo(r ApiPatchOrgsIDSecretsRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -306,7 +347,7 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SecretsApiService.PatchOrgsIDSecrets")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}/secrets"
@@ -316,7 +357,7 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.requestBody == nil {
-		return reportError("requestBody is required and must be specified")
+		return nil, reportError("requestBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -343,12 +384,12 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 	localVarPostBody = r.requestBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -362,12 +403,12 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -377,14 +418,14 @@ func (a *SecretsApiService) PatchOrgsIDSecretsExecute(r ApiPatchOrgsIDSecretsReq
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiPostOrgsIDSecretsRequest struct {
@@ -423,6 +464,10 @@ func (r ApiPostOrgsIDSecretsRequest) Execute() error {
 	return r.ApiService.PostOrgsIDSecretsExecute(r)
 }
 
+func (r ApiPostOrgsIDSecretsRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostOrgsIDSecretsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostOrgsIDSecrets Delete secrets from an organization
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -441,6 +486,14 @@ func (a *SecretsApiService) PostOrgsIDSecrets(ctx _context.Context, orgID string
  * Execute executes the request
  */
 func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsRequest) error {
+	_, err := a.PostOrgsIDSecretsExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *SecretsApiService) PostOrgsIDSecretsExecuteWithHttpInfo(r ApiPostOrgsIDSecretsRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -451,7 +504,7 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SecretsApiService.PostOrgsIDSecrets")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/orgs/{orgID}/secrets/{delete}"
@@ -461,7 +514,7 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.secretKeys == nil {
-		return reportError("secretKeys is required and must be specified")
+		return nil, reportError("secretKeys is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -488,12 +541,12 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 	localVarPostBody = r.secretKeys
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -507,12 +560,12 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -522,12 +575,12 @@ func (a *SecretsApiService) PostOrgsIDSecretsExecute(r ApiPostOrgsIDSecretsReque
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_setup.gen.go
+++ b/api/api_setup.gen.go
@@ -40,9 +40,11 @@ type SetupApi interface {
 	GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, error)
 
 	/*
-	   * GetSetupExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return InlineResponse200
-	*/
+	 * GetSetupExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return InlineResponse200
+	 */
 	GetSetupExecuteWithHttpInfo(r ApiGetSetupRequest) (InlineResponse200, *_nethttp.Response, error)
 
 	/*
@@ -60,9 +62,11 @@ type SetupApi interface {
 	PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, error)
 
 	/*
-	   * PostSetupExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return OnboardingResponse
-	*/
+	 * PostSetupExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return OnboardingResponse
+	 */
 	PostSetupExecuteWithHttpInfo(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -134,7 +138,9 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return InlineResponse200
  */
 func (a *SetupApiService) GetSetupExecuteWithHttpInfo(r ApiGetSetupRequest) (InlineResponse200, *_nethttp.Response, error) {
@@ -289,7 +295,9 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return OnboardingResponse
  */
 func (a *SetupApiService) PostSetupExecuteWithHttpInfo(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error) {

--- a/api/api_setup.gen.go
+++ b/api/api_setup.gen.go
@@ -40,6 +40,12 @@ type SetupApi interface {
 	GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, error)
 
 	/*
+	   * GetSetupExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return InlineResponse200
+	*/
+	GetSetupExecuteWithHttpInfo(r ApiGetSetupRequest) (InlineResponse200, *_nethttp.Response, error)
+
+	/*
 	 * PostSetup Set up initial user, org and bucket
 	 * Post an onboarding request to set up initial user, org and bucket.
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -52,6 +58,12 @@ type SetupApi interface {
 	 * @return OnboardingResponse
 	 */
 	PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, error)
+
+	/*
+	   * PostSetupExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return OnboardingResponse
+	*/
+	PostSetupExecuteWithHttpInfo(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -95,6 +107,10 @@ func (r ApiGetSetupRequest) Execute() (InlineResponse200, error) {
 	return r.ApiService.GetSetupExecute(r)
 }
 
+func (r ApiGetSetupRequest) ExecuteWithHttpInfo() (InlineResponse200, *_nethttp.Response, error) {
+	return r.ApiService.GetSetupExecuteWithHttpInfo(r)
+}
+
 /*
  * GetSetup Check if database has default user, org, bucket
  * Returns `true` if no default user, organization, or bucket has been created.
@@ -113,6 +129,15 @@ func (a *SetupApiService) GetSetup(ctx _context.Context) ApiGetSetupRequest {
  * @return InlineResponse200
  */
 func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse200, error) {
+	returnVal, _, err := a.GetSetupExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return InlineResponse200
+ */
+func (a *SetupApiService) GetSetupExecuteWithHttpInfo(r ApiGetSetupRequest) (InlineResponse200, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -124,7 +149,7 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SetupApiService.GetSetup")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/setup"
@@ -155,12 +180,12 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -174,29 +199,29 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, localVarHTTPResponse.Status),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -204,10 +229,10 @@ func (a *SetupApiService) GetSetupExecute(r ApiGetSetupRequest) (InlineResponse2
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostSetupRequest struct {
@@ -237,6 +262,10 @@ func (r ApiPostSetupRequest) Execute() (OnboardingResponse, error) {
 	return r.ApiService.PostSetupExecute(r)
 }
 
+func (r ApiPostSetupRequest) ExecuteWithHttpInfo() (OnboardingResponse, *_nethttp.Response, error) {
+	return r.ApiService.PostSetupExecuteWithHttpInfo(r)
+}
+
 /*
  * PostSetup Set up initial user, org and bucket
  * Post an onboarding request to set up initial user, org and bucket.
@@ -255,6 +284,15 @@ func (a *SetupApiService) PostSetup(ctx _context.Context) ApiPostSetupRequest {
  * @return OnboardingResponse
  */
 func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingResponse, error) {
+	returnVal, _, err := a.PostSetupExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return OnboardingResponse
+ */
+func (a *SetupApiService) PostSetupExecuteWithHttpInfo(r ApiPostSetupRequest) (OnboardingResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -266,7 +304,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SetupApiService.PostSetup")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/setup"
@@ -275,7 +313,7 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.onboardingRequest == nil {
-		return localVarReturnValue, reportError("onboardingRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("onboardingRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -302,12 +340,12 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 	localVarPostBody = r.onboardingRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -321,12 +359,12 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -336,22 +374,22 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -359,8 +397,8 @@ func (a *SetupApiService) PostSetupExecute(r ApiPostSetupRequest) (OnboardingRes
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_stacks.gen.go
+++ b/api/api_stacks.gen.go
@@ -41,6 +41,12 @@ type StacksApi interface {
 	CreateStackExecute(r ApiCreateStackRequest) (Stack, error)
 
 	/*
+	   * CreateStackExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Stack
+	*/
+	CreateStackExecuteWithHttpInfo(r ApiCreateStackRequest) (Stack, *_nethttp.Response, error)
+
+	/*
 	 * DeleteStack Delete a stack and associated resources
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param stackId The identifier of the stack.
@@ -54,6 +60,11 @@ type StacksApi interface {
 	DeleteStackExecute(r ApiDeleteStackRequest) error
 
 	/*
+	 * DeleteStackExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteStackExecuteWithHttpInfo(r ApiDeleteStackRequest) (*_nethttp.Response, error)
+
+	/*
 	 * ListStacks List all installed InfluxDB templates
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiListStacksRequest
@@ -65,6 +76,12 @@ type StacksApi interface {
 	 * @return Stacks
 	 */
 	ListStacksExecute(r ApiListStacksRequest) (Stacks, error)
+
+	/*
+	   * ListStacksExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Stacks
+	*/
+	ListStacksExecuteWithHttpInfo(r ApiListStacksRequest) (Stacks, *_nethttp.Response, error)
 
 	/*
 	 * ReadStack Retrieve a stack
@@ -81,6 +98,12 @@ type StacksApi interface {
 	ReadStackExecute(r ApiReadStackRequest) (Stack, error)
 
 	/*
+	   * ReadStackExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Stack
+	*/
+	ReadStackExecuteWithHttpInfo(r ApiReadStackRequest) (Stack, *_nethttp.Response, error)
+
+	/*
 	 * UpdateStack Update an InfluxDB Stack
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param stackId The identifier of the stack.
@@ -93,6 +116,12 @@ type StacksApi interface {
 	 * @return Stack
 	 */
 	UpdateStackExecute(r ApiUpdateStackRequest) (Stack, error)
+
+	/*
+	   * UpdateStackExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Stack
+	*/
+	UpdateStackExecuteWithHttpInfo(r ApiUpdateStackRequest) (Stack, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -136,6 +165,10 @@ func (r ApiCreateStackRequest) Execute() (Stack, error) {
 	return r.ApiService.CreateStackExecute(r)
 }
 
+func (r ApiCreateStackRequest) ExecuteWithHttpInfo() (Stack, *_nethttp.Response, error) {
+	return r.ApiService.CreateStackExecuteWithHttpInfo(r)
+}
+
 /*
  * CreateStack Create a new stack
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -153,6 +186,15 @@ func (a *StacksApiService) CreateStack(ctx _context.Context) ApiCreateStackReque
  * @return Stack
  */
 func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, error) {
+	returnVal, _, err := a.CreateStackExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Stack
+ */
+func (a *StacksApiService) CreateStackExecuteWithHttpInfo(r ApiCreateStackRequest) (Stack, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -164,7 +206,7 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StacksApiService.CreateStack")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/stacks"
@@ -173,7 +215,7 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.stackPostRequest == nil {
-		return localVarReturnValue, reportError("stackPostRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("stackPostRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -197,12 +239,12 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 	localVarPostBody = r.stackPostRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -216,12 +258,12 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -231,22 +273,22 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -254,10 +296,10 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiDeleteStackRequest struct {
@@ -287,6 +329,10 @@ func (r ApiDeleteStackRequest) Execute() error {
 	return r.ApiService.DeleteStackExecute(r)
 }
 
+func (r ApiDeleteStackRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteStackExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteStack Delete a stack and associated resources
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -305,6 +351,14 @@ func (a *StacksApiService) DeleteStack(ctx _context.Context, stackId string) Api
  * Execute executes the request
  */
 func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
+	_, err := a.DeleteStackExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *StacksApiService) DeleteStackExecuteWithHttpInfo(r ApiDeleteStackRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -315,7 +369,7 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StacksApiService.DeleteStack")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/stacks/{stack_id}"
@@ -325,7 +379,7 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orgID == nil {
-		return reportError("orgID is required and must be specified")
+		return nil, reportError("orgID is required and must be specified")
 	}
 
 	localVarQueryParams.Add("orgID", parameterToString(*r.orgID, ""))
@@ -348,12 +402,12 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -367,12 +421,12 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -382,14 +436,14 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiListStacksRequest struct {
@@ -428,6 +482,10 @@ func (r ApiListStacksRequest) Execute() (Stacks, error) {
 	return r.ApiService.ListStacksExecute(r)
 }
 
+func (r ApiListStacksRequest) ExecuteWithHttpInfo() (Stacks, *_nethttp.Response, error) {
+	return r.ApiService.ListStacksExecuteWithHttpInfo(r)
+}
+
 /*
  * ListStacks List all installed InfluxDB templates
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -445,6 +503,15 @@ func (a *StacksApiService) ListStacks(ctx _context.Context) ApiListStacksRequest
  * @return Stacks
  */
 func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, error) {
+	returnVal, _, err := a.ListStacksExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Stacks
+ */
+func (a *StacksApiService) ListStacksExecuteWithHttpInfo(r ApiListStacksRequest) (Stacks, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -456,7 +523,7 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StacksApiService.ListStacks")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/stacks"
@@ -465,7 +532,7 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.orgID == nil {
-		return localVarReturnValue, reportError("orgID is required and must be specified")
+		return localVarReturnValue, nil, reportError("orgID is required and must be specified")
 	}
 
 	localVarQueryParams.Add("orgID", parameterToString(*r.orgID, ""))
@@ -510,12 +577,12 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -529,12 +596,12 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -544,22 +611,22 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -567,10 +634,10 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiReadStackRequest struct {
@@ -589,6 +656,10 @@ func (r ApiReadStackRequest) GetStackId() string {
 
 func (r ApiReadStackRequest) Execute() (Stack, error) {
 	return r.ApiService.ReadStackExecute(r)
+}
+
+func (r ApiReadStackRequest) ExecuteWithHttpInfo() (Stack, *_nethttp.Response, error) {
+	return r.ApiService.ReadStackExecuteWithHttpInfo(r)
 }
 
 /*
@@ -610,6 +681,15 @@ func (a *StacksApiService) ReadStack(ctx _context.Context, stackId string) ApiRe
  * @return Stack
  */
 func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error) {
+	returnVal, _, err := a.ReadStackExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Stack
+ */
+func (a *StacksApiService) ReadStackExecuteWithHttpInfo(r ApiReadStackRequest) (Stack, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -621,7 +701,7 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StacksApiService.ReadStack")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/stacks/{stack_id}"
@@ -650,12 +730,12 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -669,12 +749,12 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -684,22 +764,22 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -707,10 +787,10 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiUpdateStackRequest struct {
@@ -740,6 +820,10 @@ func (r ApiUpdateStackRequest) Execute() (Stack, error) {
 	return r.ApiService.UpdateStackExecute(r)
 }
 
+func (r ApiUpdateStackRequest) ExecuteWithHttpInfo() (Stack, *_nethttp.Response, error) {
+	return r.ApiService.UpdateStackExecuteWithHttpInfo(r)
+}
+
 /*
  * UpdateStack Update an InfluxDB Stack
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -759,6 +843,15 @@ func (a *StacksApiService) UpdateStack(ctx _context.Context, stackId string) Api
  * @return Stack
  */
 func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, error) {
+	returnVal, _, err := a.UpdateStackExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Stack
+ */
+func (a *StacksApiService) UpdateStackExecuteWithHttpInfo(r ApiUpdateStackRequest) (Stack, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -770,7 +863,7 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "StacksApiService.UpdateStack")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/stacks/{stack_id}"
@@ -780,7 +873,7 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.stackPatchRequest == nil {
-		return localVarReturnValue, reportError("stackPatchRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("stackPatchRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -804,12 +897,12 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 	localVarPostBody = r.stackPatchRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -823,12 +916,12 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -838,22 +931,22 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -861,8 +954,8 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_stacks.gen.go
+++ b/api/api_stacks.gen.go
@@ -41,9 +41,11 @@ type StacksApi interface {
 	CreateStackExecute(r ApiCreateStackRequest) (Stack, error)
 
 	/*
-	   * CreateStackExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Stack
-	*/
+	 * CreateStackExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Stack
+	 */
 	CreateStackExecuteWithHttpInfo(r ApiCreateStackRequest) (Stack, *_nethttp.Response, error)
 
 	/*
@@ -60,7 +62,9 @@ type StacksApi interface {
 	DeleteStackExecute(r ApiDeleteStackRequest) error
 
 	/*
-	 * DeleteStackExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteStackExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteStackExecuteWithHttpInfo(r ApiDeleteStackRequest) (*_nethttp.Response, error)
 
@@ -78,9 +82,11 @@ type StacksApi interface {
 	ListStacksExecute(r ApiListStacksRequest) (Stacks, error)
 
 	/*
-	   * ListStacksExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Stacks
-	*/
+	 * ListStacksExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Stacks
+	 */
 	ListStacksExecuteWithHttpInfo(r ApiListStacksRequest) (Stacks, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type StacksApi interface {
 	ReadStackExecute(r ApiReadStackRequest) (Stack, error)
 
 	/*
-	   * ReadStackExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Stack
-	*/
+	 * ReadStackExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Stack
+	 */
 	ReadStackExecuteWithHttpInfo(r ApiReadStackRequest) (Stack, *_nethttp.Response, error)
 
 	/*
@@ -118,9 +126,11 @@ type StacksApi interface {
 	UpdateStackExecute(r ApiUpdateStackRequest) (Stack, error)
 
 	/*
-	   * UpdateStackExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Stack
-	*/
+	 * UpdateStackExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Stack
+	 */
 	UpdateStackExecuteWithHttpInfo(r ApiUpdateStackRequest) (Stack, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -191,7 +201,9 @@ func (a *StacksApiService) CreateStackExecute(r ApiCreateStackRequest) (Stack, e
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Stack
  */
 func (a *StacksApiService) CreateStackExecuteWithHttpInfo(r ApiCreateStackRequest) (Stack, *_nethttp.Response, error) {
@@ -356,7 +368,9 @@ func (a *StacksApiService) DeleteStackExecute(r ApiDeleteStackRequest) error {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *StacksApiService) DeleteStackExecuteWithHttpInfo(r ApiDeleteStackRequest) (*_nethttp.Response, error) {
 	var (
@@ -508,7 +522,9 @@ func (a *StacksApiService) ListStacksExecute(r ApiListStacksRequest) (Stacks, er
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Stacks
  */
 func (a *StacksApiService) ListStacksExecuteWithHttpInfo(r ApiListStacksRequest) (Stacks, *_nethttp.Response, error) {
@@ -686,7 +702,9 @@ func (a *StacksApiService) ReadStackExecute(r ApiReadStackRequest) (Stack, error
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Stack
  */
 func (a *StacksApiService) ReadStackExecuteWithHttpInfo(r ApiReadStackRequest) (Stack, *_nethttp.Response, error) {
@@ -848,7 +866,9 @@ func (a *StacksApiService) UpdateStackExecute(r ApiUpdateStackRequest) (Stack, e
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Stack
  */
 func (a *StacksApiService) UpdateStackExecuteWithHttpInfo(r ApiUpdateStackRequest) (Stack, *_nethttp.Response, error) {

--- a/api/api_tasks.gen.go
+++ b/api/api_tasks.gen.go
@@ -42,6 +42,11 @@ type TasksApi interface {
 	DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error
 
 	/*
+	 * DeleteTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteTasksIDExecuteWithHttpInfo(r ApiDeleteTasksIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * DeleteTasksIDRunsID Cancel a running task
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param taskID The task ID.
@@ -56,6 +61,11 @@ type TasksApi interface {
 	DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDRequest) error
 
 	/*
+	 * DeleteTasksIDRunsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteTasksIDRunsIDExecuteWithHttpInfo(r ApiDeleteTasksIDRunsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetTasks List all tasks
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetTasksRequest
@@ -67,6 +77,12 @@ type TasksApi interface {
 	 * @return Tasks
 	 */
 	GetTasksExecute(r ApiGetTasksRequest) (Tasks, error)
+
+	/*
+	   * GetTasksExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Tasks
+	*/
+	GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tasks, *_nethttp.Response, error)
 
 	/*
 	 * GetTasksID Retrieve a task
@@ -83,6 +99,12 @@ type TasksApi interface {
 	GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error)
 
 	/*
+	   * GetTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Task
+	*/
+	GetTasksIDExecuteWithHttpInfo(r ApiGetTasksIDRequest) (Task, *_nethttp.Response, error)
+
+	/*
 	 * GetTasksIDLogs Retrieve all logs for a task
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param taskID The task ID.
@@ -97,6 +119,12 @@ type TasksApi interface {
 	GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Logs, error)
 
 	/*
+	   * GetTasksIDLogsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Logs
+	*/
+	GetTasksIDLogsExecuteWithHttpInfo(r ApiGetTasksIDLogsRequest) (Logs, *_nethttp.Response, error)
+
+	/*
 	 * GetTasksIDRuns List runs for a task
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param taskID The ID of the task to get runs for.
@@ -109,6 +137,12 @@ type TasksApi interface {
 	 * @return Runs
 	 */
 	GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Runs, error)
+
+	/*
+	   * GetTasksIDRunsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Runs
+	*/
+	GetTasksIDRunsExecuteWithHttpInfo(r ApiGetTasksIDRunsRequest) (Runs, *_nethttp.Response, error)
 
 	/*
 	 * GetTasksIDRunsID Retrieve a single run for a task
@@ -126,6 +160,12 @@ type TasksApi interface {
 	GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) (Run, error)
 
 	/*
+	   * GetTasksIDRunsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Run
+	*/
+	GetTasksIDRunsIDExecuteWithHttpInfo(r ApiGetTasksIDRunsIDRequest) (Run, *_nethttp.Response, error)
+
+	/*
 	 * GetTasksIDRunsIDLogs Retrieve all logs for a run
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param taskID ID of task to get logs for.
@@ -139,6 +179,12 @@ type TasksApi interface {
 	 * @return Logs
 	 */
 	GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsRequest) (Logs, error)
+
+	/*
+	   * GetTasksIDRunsIDLogsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Logs
+	*/
+	GetTasksIDRunsIDLogsExecuteWithHttpInfo(r ApiGetTasksIDRunsIDLogsRequest) (Logs, *_nethttp.Response, error)
 
 	/*
 	 * PatchTasksID Update a task
@@ -156,6 +202,12 @@ type TasksApi interface {
 	PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, error)
 
 	/*
+	   * PatchTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Task
+	*/
+	PatchTasksIDExecuteWithHttpInfo(r ApiPatchTasksIDRequest) (Task, *_nethttp.Response, error)
+
+	/*
 	 * PostTasks Create a new task
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostTasksRequest
@@ -167,6 +219,12 @@ type TasksApi interface {
 	 * @return Task
 	 */
 	PostTasksExecute(r ApiPostTasksRequest) (Task, error)
+
+	/*
+	   * PostTasksExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Task
+	*/
+	PostTasksExecuteWithHttpInfo(r ApiPostTasksRequest) (Task, *_nethttp.Response, error)
 
 	/*
 	 * PostTasksIDRuns Manually start a task run, overriding the current schedule
@@ -183,6 +241,12 @@ type TasksApi interface {
 	PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (Run, error)
 
 	/*
+	   * PostTasksIDRunsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Run
+	*/
+	PostTasksIDRunsExecuteWithHttpInfo(r ApiPostTasksIDRunsRequest) (Run, *_nethttp.Response, error)
+
+	/*
 	 * PostTasksIDRunsIDRetry Retry a task run
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param taskID The task ID.
@@ -196,6 +260,12 @@ type TasksApi interface {
 	 * @return Run
 	 */
 	PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRetryRequest) (Run, error)
+
+	/*
+	   * PostTasksIDRunsIDRetryExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Run
+	*/
+	PostTasksIDRunsIDRetryExecuteWithHttpInfo(r ApiPostTasksIDRunsIDRetryRequest) (Run, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -248,6 +318,10 @@ func (r ApiDeleteTasksIDRequest) Execute() error {
 	return r.ApiService.DeleteTasksIDExecute(r)
 }
 
+func (r ApiDeleteTasksIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteTasksIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteTasksID Delete a task
  * Deletes a task and all associated records
@@ -267,6 +341,14 @@ func (a *TasksApiService) DeleteTasksID(ctx _context.Context, taskID string) Api
  * Execute executes the request
  */
 func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error {
+	_, err := a.DeleteTasksIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *TasksApiService) DeleteTasksIDExecuteWithHttpInfo(r ApiDeleteTasksIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -277,7 +359,7 @@ func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.DeleteTasksID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}"
@@ -309,12 +391,12 @@ func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -328,12 +410,12 @@ func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -343,14 +425,14 @@ func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiDeleteTasksIDRunsIDRequest struct {
@@ -389,6 +471,10 @@ func (r ApiDeleteTasksIDRunsIDRequest) Execute() error {
 	return r.ApiService.DeleteTasksIDRunsIDExecute(r)
 }
 
+func (r ApiDeleteTasksIDRunsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteTasksIDRunsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteTasksIDRunsID Cancel a running task
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -409,6 +495,14 @@ func (a *TasksApiService) DeleteTasksIDRunsID(ctx _context.Context, taskID strin
  * Execute executes the request
  */
 func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDRequest) error {
+	_, err := a.DeleteTasksIDRunsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *TasksApiService) DeleteTasksIDRunsIDExecuteWithHttpInfo(r ApiDeleteTasksIDRunsIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -419,7 +513,7 @@ func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDReq
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.DeleteTasksIDRunsID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/runs/{runID}"
@@ -452,12 +546,12 @@ func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDReq
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -471,12 +565,12 @@ func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDReq
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -486,14 +580,14 @@ func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDReq
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetTasksRequest struct {
@@ -586,6 +680,10 @@ func (r ApiGetTasksRequest) Execute() (Tasks, error) {
 	return r.ApiService.GetTasksExecute(r)
 }
 
+func (r ApiGetTasksRequest) ExecuteWithHttpInfo() (Tasks, *_nethttp.Response, error) {
+	return r.ApiService.GetTasksExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTasks List all tasks
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -603,6 +701,15 @@ func (a *TasksApiService) GetTasks(ctx _context.Context) ApiGetTasksRequest {
  * @return Tasks
  */
 func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
+	returnVal, _, err := a.GetTasksExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Tasks
+ */
+func (a *TasksApiService) GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tasks, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -614,7 +721,7 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.GetTasks")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks"
@@ -669,12 +776,12 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -688,12 +795,12 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -703,22 +810,22 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -726,10 +833,10 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetTasksIDRequest struct {
@@ -759,6 +866,10 @@ func (r ApiGetTasksIDRequest) Execute() (Task, error) {
 	return r.ApiService.GetTasksIDExecute(r)
 }
 
+func (r ApiGetTasksIDRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, error) {
+	return r.ApiService.GetTasksIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTasksID Retrieve a task
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -778,6 +889,15 @@ func (a *TasksApiService) GetTasksID(ctx _context.Context, taskID string) ApiGet
  * @return Task
  */
 func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error) {
+	returnVal, _, err := a.GetTasksIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Task
+ */
+func (a *TasksApiService) GetTasksIDExecuteWithHttpInfo(r ApiGetTasksIDRequest) (Task, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -789,7 +909,7 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.GetTasksID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}"
@@ -821,12 +941,12 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -840,12 +960,12 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -855,22 +975,22 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -878,10 +998,10 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetTasksIDLogsRequest struct {
@@ -911,6 +1031,10 @@ func (r ApiGetTasksIDLogsRequest) Execute() (Logs, error) {
 	return r.ApiService.GetTasksIDLogsExecute(r)
 }
 
+func (r ApiGetTasksIDLogsRequest) ExecuteWithHttpInfo() (Logs, *_nethttp.Response, error) {
+	return r.ApiService.GetTasksIDLogsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTasksIDLogs Retrieve all logs for a task
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -930,6 +1054,15 @@ func (a *TasksApiService) GetTasksIDLogs(ctx _context.Context, taskID string) Ap
  * @return Logs
  */
 func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Logs, error) {
+	returnVal, _, err := a.GetTasksIDLogsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Logs
+ */
+func (a *TasksApiService) GetTasksIDLogsExecuteWithHttpInfo(r ApiGetTasksIDLogsRequest) (Logs, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -941,7 +1074,7 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.GetTasksIDLogs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/logs"
@@ -973,12 +1106,12 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -992,12 +1125,12 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1007,22 +1140,22 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1030,10 +1163,10 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetTasksIDRunsRequest struct {
@@ -1099,6 +1232,10 @@ func (r ApiGetTasksIDRunsRequest) Execute() (Runs, error) {
 	return r.ApiService.GetTasksIDRunsExecute(r)
 }
 
+func (r ApiGetTasksIDRunsRequest) ExecuteWithHttpInfo() (Runs, *_nethttp.Response, error) {
+	return r.ApiService.GetTasksIDRunsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTasksIDRuns List runs for a task
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1118,6 +1255,15 @@ func (a *TasksApiService) GetTasksIDRuns(ctx _context.Context, taskID string) Ap
  * @return Runs
  */
 func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Runs, error) {
+	returnVal, _, err := a.GetTasksIDRunsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Runs
+ */
+func (a *TasksApiService) GetTasksIDRunsExecuteWithHttpInfo(r ApiGetTasksIDRunsRequest) (Runs, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -1129,7 +1275,7 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.GetTasksIDRuns")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/runs"
@@ -1173,12 +1319,12 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1192,12 +1338,12 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1207,22 +1353,22 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1230,10 +1376,10 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetTasksIDRunsIDRequest struct {
@@ -1272,6 +1418,10 @@ func (r ApiGetTasksIDRunsIDRequest) Execute() (Run, error) {
 	return r.ApiService.GetTasksIDRunsIDExecute(r)
 }
 
+func (r ApiGetTasksIDRunsIDRequest) ExecuteWithHttpInfo() (Run, *_nethttp.Response, error) {
+	return r.ApiService.GetTasksIDRunsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTasksIDRunsID Retrieve a single run for a task
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1293,6 +1443,15 @@ func (a *TasksApiService) GetTasksIDRunsID(ctx _context.Context, taskID string, 
  * @return Run
  */
 func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) (Run, error) {
+	returnVal, _, err := a.GetTasksIDRunsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Run
+ */
+func (a *TasksApiService) GetTasksIDRunsIDExecuteWithHttpInfo(r ApiGetTasksIDRunsIDRequest) (Run, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -1304,7 +1463,7 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.GetTasksIDRunsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/runs/{runID}"
@@ -1337,12 +1496,12 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1356,12 +1515,12 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1371,22 +1530,22 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1394,10 +1553,10 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetTasksIDRunsIDLogsRequest struct {
@@ -1436,6 +1595,10 @@ func (r ApiGetTasksIDRunsIDLogsRequest) Execute() (Logs, error) {
 	return r.ApiService.GetTasksIDRunsIDLogsExecute(r)
 }
 
+func (r ApiGetTasksIDRunsIDLogsRequest) ExecuteWithHttpInfo() (Logs, *_nethttp.Response, error) {
+	return r.ApiService.GetTasksIDRunsIDLogsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTasksIDRunsIDLogs Retrieve all logs for a run
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1457,6 +1620,15 @@ func (a *TasksApiService) GetTasksIDRunsIDLogs(ctx _context.Context, taskID stri
  * @return Logs
  */
 func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsRequest) (Logs, error) {
+	returnVal, _, err := a.GetTasksIDRunsIDLogsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Logs
+ */
+func (a *TasksApiService) GetTasksIDRunsIDLogsExecuteWithHttpInfo(r ApiGetTasksIDRunsIDLogsRequest) (Logs, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -1468,7 +1640,7 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.GetTasksIDRunsIDLogs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/runs/{runID}/logs"
@@ -1501,12 +1673,12 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1520,12 +1692,12 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1535,22 +1707,22 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1558,10 +1730,10 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchTasksIDRequest struct {
@@ -1600,6 +1772,10 @@ func (r ApiPatchTasksIDRequest) Execute() (Task, error) {
 	return r.ApiService.PatchTasksIDExecute(r)
 }
 
+func (r ApiPatchTasksIDRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, error) {
+	return r.ApiService.PatchTasksIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchTasksID Update a task
  * Update a task. This will cancel all queued runs.
@@ -1620,6 +1796,15 @@ func (a *TasksApiService) PatchTasksID(ctx _context.Context, taskID string) ApiP
  * @return Task
  */
 func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, error) {
+	returnVal, _, err := a.PatchTasksIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Task
+ */
+func (a *TasksApiService) PatchTasksIDExecuteWithHttpInfo(r ApiPatchTasksIDRequest) (Task, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -1631,7 +1816,7 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.PatchTasksID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}"
@@ -1641,7 +1826,7 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.taskUpdateRequest == nil {
-		return localVarReturnValue, reportError("taskUpdateRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("taskUpdateRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1668,12 +1853,12 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 	localVarPostBody = r.taskUpdateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1687,12 +1872,12 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1702,22 +1887,22 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1725,10 +1910,10 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostTasksRequest struct {
@@ -1758,6 +1943,10 @@ func (r ApiPostTasksRequest) Execute() (Task, error) {
 	return r.ApiService.PostTasksExecute(r)
 }
 
+func (r ApiPostTasksRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, error) {
+	return r.ApiService.PostTasksExecuteWithHttpInfo(r)
+}
+
 /*
  * PostTasks Create a new task
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1775,6 +1964,15 @@ func (a *TasksApiService) PostTasks(ctx _context.Context) ApiPostTasksRequest {
  * @return Task
  */
 func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) {
+	returnVal, _, err := a.PostTasksExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Task
+ */
+func (a *TasksApiService) PostTasksExecuteWithHttpInfo(r ApiPostTasksRequest) (Task, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -1786,7 +1984,7 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.PostTasks")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks"
@@ -1795,7 +1993,7 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.taskCreateRequest == nil {
-		return localVarReturnValue, reportError("taskCreateRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("taskCreateRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1822,12 +2020,12 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 	localVarPostBody = r.taskCreateRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1841,12 +2039,12 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1856,22 +2054,22 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -1879,10 +2077,10 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostTasksIDRunsRequest struct {
@@ -1921,6 +2119,10 @@ func (r ApiPostTasksIDRunsRequest) Execute() (Run, error) {
 	return r.ApiService.PostTasksIDRunsExecute(r)
 }
 
+func (r ApiPostTasksIDRunsRequest) ExecuteWithHttpInfo() (Run, *_nethttp.Response, error) {
+	return r.ApiService.PostTasksIDRunsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostTasksIDRuns Manually start a task run, overriding the current schedule
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -1940,6 +2142,15 @@ func (a *TasksApiService) PostTasksIDRuns(ctx _context.Context, taskID string) A
  * @return Run
  */
 func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (Run, error) {
+	returnVal, _, err := a.PostTasksIDRunsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Run
+ */
+func (a *TasksApiService) PostTasksIDRunsExecuteWithHttpInfo(r ApiPostTasksIDRunsRequest) (Run, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -1951,7 +2162,7 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.PostTasksIDRuns")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/runs"
@@ -1985,12 +2196,12 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 	localVarPostBody = r.runManually
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -2004,12 +2215,12 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -2019,22 +2230,22 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -2042,10 +2253,10 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostTasksIDRunsIDRetryRequest struct {
@@ -2093,6 +2304,10 @@ func (r ApiPostTasksIDRunsIDRetryRequest) Execute() (Run, error) {
 	return r.ApiService.PostTasksIDRunsIDRetryExecute(r)
 }
 
+func (r ApiPostTasksIDRunsIDRetryRequest) ExecuteWithHttpInfo() (Run, *_nethttp.Response, error) {
+	return r.ApiService.PostTasksIDRunsIDRetryExecuteWithHttpInfo(r)
+}
+
 /*
  * PostTasksIDRunsIDRetry Retry a task run
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -2114,6 +2329,15 @@ func (a *TasksApiService) PostTasksIDRunsIDRetry(ctx _context.Context, taskID st
  * @return Run
  */
 func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRetryRequest) (Run, error) {
+	returnVal, _, err := a.PostTasksIDRunsIDRetryExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Run
+ */
+func (a *TasksApiService) PostTasksIDRunsIDRetryExecuteWithHttpInfo(r ApiPostTasksIDRunsIDRetryRequest) (Run, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -2125,7 +2349,7 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TasksApiService.PostTasksIDRunsIDRetry")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/tasks/{taskID}/runs/{runID}/retry"
@@ -2160,12 +2384,12 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -2179,12 +2403,12 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -2194,22 +2418,22 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -2217,8 +2441,8 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_tasks.gen.go
+++ b/api/api_tasks.gen.go
@@ -42,7 +42,9 @@ type TasksApi interface {
 	DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error
 
 	/*
-	 * DeleteTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteTasksIDExecuteWithHttpInfo(r ApiDeleteTasksIDRequest) (*_nethttp.Response, error)
 
@@ -61,7 +63,9 @@ type TasksApi interface {
 	DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDRequest) error
 
 	/*
-	 * DeleteTasksIDRunsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteTasksIDRunsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteTasksIDRunsIDExecuteWithHttpInfo(r ApiDeleteTasksIDRunsIDRequest) (*_nethttp.Response, error)
 
@@ -79,9 +83,11 @@ type TasksApi interface {
 	GetTasksExecute(r ApiGetTasksRequest) (Tasks, error)
 
 	/*
-	   * GetTasksExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Tasks
-	*/
+	 * GetTasksExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Tasks
+	 */
 	GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tasks, *_nethttp.Response, error)
 
 	/*
@@ -99,9 +105,11 @@ type TasksApi interface {
 	GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error)
 
 	/*
-	   * GetTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Task
-	*/
+	 * GetTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Task
+	 */
 	GetTasksIDExecuteWithHttpInfo(r ApiGetTasksIDRequest) (Task, *_nethttp.Response, error)
 
 	/*
@@ -119,9 +127,11 @@ type TasksApi interface {
 	GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Logs, error)
 
 	/*
-	   * GetTasksIDLogsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Logs
-	*/
+	 * GetTasksIDLogsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Logs
+	 */
 	GetTasksIDLogsExecuteWithHttpInfo(r ApiGetTasksIDLogsRequest) (Logs, *_nethttp.Response, error)
 
 	/*
@@ -139,9 +149,11 @@ type TasksApi interface {
 	GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Runs, error)
 
 	/*
-	   * GetTasksIDRunsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Runs
-	*/
+	 * GetTasksIDRunsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Runs
+	 */
 	GetTasksIDRunsExecuteWithHttpInfo(r ApiGetTasksIDRunsRequest) (Runs, *_nethttp.Response, error)
 
 	/*
@@ -160,9 +172,11 @@ type TasksApi interface {
 	GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) (Run, error)
 
 	/*
-	   * GetTasksIDRunsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Run
-	*/
+	 * GetTasksIDRunsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Run
+	 */
 	GetTasksIDRunsIDExecuteWithHttpInfo(r ApiGetTasksIDRunsIDRequest) (Run, *_nethttp.Response, error)
 
 	/*
@@ -181,9 +195,11 @@ type TasksApi interface {
 	GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsRequest) (Logs, error)
 
 	/*
-	   * GetTasksIDRunsIDLogsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Logs
-	*/
+	 * GetTasksIDRunsIDLogsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Logs
+	 */
 	GetTasksIDRunsIDLogsExecuteWithHttpInfo(r ApiGetTasksIDRunsIDLogsRequest) (Logs, *_nethttp.Response, error)
 
 	/*
@@ -202,9 +218,11 @@ type TasksApi interface {
 	PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, error)
 
 	/*
-	   * PatchTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Task
-	*/
+	 * PatchTasksIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Task
+	 */
 	PatchTasksIDExecuteWithHttpInfo(r ApiPatchTasksIDRequest) (Task, *_nethttp.Response, error)
 
 	/*
@@ -221,9 +239,11 @@ type TasksApi interface {
 	PostTasksExecute(r ApiPostTasksRequest) (Task, error)
 
 	/*
-	   * PostTasksExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Task
-	*/
+	 * PostTasksExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Task
+	 */
 	PostTasksExecuteWithHttpInfo(r ApiPostTasksRequest) (Task, *_nethttp.Response, error)
 
 	/*
@@ -241,9 +261,11 @@ type TasksApi interface {
 	PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (Run, error)
 
 	/*
-	   * PostTasksIDRunsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Run
-	*/
+	 * PostTasksIDRunsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Run
+	 */
 	PostTasksIDRunsExecuteWithHttpInfo(r ApiPostTasksIDRunsRequest) (Run, *_nethttp.Response, error)
 
 	/*
@@ -262,9 +284,11 @@ type TasksApi interface {
 	PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRetryRequest) (Run, error)
 
 	/*
-	   * PostTasksIDRunsIDRetryExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Run
-	*/
+	 * PostTasksIDRunsIDRetryExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Run
+	 */
 	PostTasksIDRunsIDRetryExecuteWithHttpInfo(r ApiPostTasksIDRunsIDRetryRequest) (Run, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -346,7 +370,9 @@ func (a *TasksApiService) DeleteTasksIDExecute(r ApiDeleteTasksIDRequest) error 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *TasksApiService) DeleteTasksIDExecuteWithHttpInfo(r ApiDeleteTasksIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -500,7 +526,9 @@ func (a *TasksApiService) DeleteTasksIDRunsIDExecute(r ApiDeleteTasksIDRunsIDReq
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *TasksApiService) DeleteTasksIDRunsIDExecuteWithHttpInfo(r ApiDeleteTasksIDRunsIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -706,7 +734,9 @@ func (a *TasksApiService) GetTasksExecute(r ApiGetTasksRequest) (Tasks, error) {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Tasks
  */
 func (a *TasksApiService) GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tasks, *_nethttp.Response, error) {
@@ -894,7 +924,9 @@ func (a *TasksApiService) GetTasksIDExecute(r ApiGetTasksIDRequest) (Task, error
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Task
  */
 func (a *TasksApiService) GetTasksIDExecuteWithHttpInfo(r ApiGetTasksIDRequest) (Task, *_nethttp.Response, error) {
@@ -1059,7 +1091,9 @@ func (a *TasksApiService) GetTasksIDLogsExecute(r ApiGetTasksIDLogsRequest) (Log
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Logs
  */
 func (a *TasksApiService) GetTasksIDLogsExecuteWithHttpInfo(r ApiGetTasksIDLogsRequest) (Logs, *_nethttp.Response, error) {
@@ -1260,7 +1294,9 @@ func (a *TasksApiService) GetTasksIDRunsExecute(r ApiGetTasksIDRunsRequest) (Run
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Runs
  */
 func (a *TasksApiService) GetTasksIDRunsExecuteWithHttpInfo(r ApiGetTasksIDRunsRequest) (Runs, *_nethttp.Response, error) {
@@ -1448,7 +1484,9 @@ func (a *TasksApiService) GetTasksIDRunsIDExecute(r ApiGetTasksIDRunsIDRequest) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Run
  */
 func (a *TasksApiService) GetTasksIDRunsIDExecuteWithHttpInfo(r ApiGetTasksIDRunsIDRequest) (Run, *_nethttp.Response, error) {
@@ -1625,7 +1663,9 @@ func (a *TasksApiService) GetTasksIDRunsIDLogsExecute(r ApiGetTasksIDRunsIDLogsR
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Logs
  */
 func (a *TasksApiService) GetTasksIDRunsIDLogsExecuteWithHttpInfo(r ApiGetTasksIDRunsIDLogsRequest) (Logs, *_nethttp.Response, error) {
@@ -1801,7 +1841,9 @@ func (a *TasksApiService) PatchTasksIDExecute(r ApiPatchTasksIDRequest) (Task, e
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Task
  */
 func (a *TasksApiService) PatchTasksIDExecuteWithHttpInfo(r ApiPatchTasksIDRequest) (Task, *_nethttp.Response, error) {
@@ -1969,7 +2011,9 @@ func (a *TasksApiService) PostTasksExecute(r ApiPostTasksRequest) (Task, error) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Task
  */
 func (a *TasksApiService) PostTasksExecuteWithHttpInfo(r ApiPostTasksRequest) (Task, *_nethttp.Response, error) {
@@ -2147,7 +2191,9 @@ func (a *TasksApiService) PostTasksIDRunsExecute(r ApiPostTasksIDRunsRequest) (R
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Run
  */
 func (a *TasksApiService) PostTasksIDRunsExecuteWithHttpInfo(r ApiPostTasksIDRunsRequest) (Run, *_nethttp.Response, error) {
@@ -2334,7 +2380,9 @@ func (a *TasksApiService) PostTasksIDRunsIDRetryExecute(r ApiPostTasksIDRunsIDRe
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Run
  */
 func (a *TasksApiService) PostTasksIDRunsIDRetryExecuteWithHttpInfo(r ApiPostTasksIDRunsIDRetryRequest) (Run, *_nethttp.Response, error) {

--- a/api/api_telegrafs.gen.go
+++ b/api/api_telegrafs.gen.go
@@ -40,6 +40,11 @@ type TelegrafsApi interface {
 	DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDRequest) error
 
 	/*
+	 * DeleteTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteTelegrafsIDExecuteWithHttpInfo(r ApiDeleteTelegrafsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetTelegrafs List all Telegraf configurations
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetTelegrafsRequest
@@ -51,6 +56,12 @@ type TelegrafsApi interface {
 	 * @return Telegrafs
 	 */
 	GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Telegrafs, error)
+
+	/*
+	   * GetTelegrafsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Telegrafs
+	*/
+	GetTelegrafsExecuteWithHttpInfo(r ApiGetTelegrafsRequest) (Telegrafs, *_nethttp.Response, error)
 
 	/*
 	 * GetTelegrafsID Retrieve a Telegraf configuration
@@ -67,6 +78,12 @@ type TelegrafsApi interface {
 	GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) (Telegraf, error)
 
 	/*
+	   * GetTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Telegraf
+	*/
+	GetTelegrafsIDExecuteWithHttpInfo(r ApiGetTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error)
+
+	/*
 	 * PostTelegrafs Create a Telegraf configuration
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiPostTelegrafsRequest
@@ -78,6 +95,12 @@ type TelegrafsApi interface {
 	 * @return Telegraf
 	 */
 	PostTelegrafsExecute(r ApiPostTelegrafsRequest) (Telegraf, error)
+
+	/*
+	   * PostTelegrafsExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Telegraf
+	*/
+	PostTelegrafsExecuteWithHttpInfo(r ApiPostTelegrafsRequest) (Telegraf, *_nethttp.Response, error)
 
 	/*
 	 * PutTelegrafsID Update a Telegraf configuration
@@ -92,6 +115,12 @@ type TelegrafsApi interface {
 	 * @return Telegraf
 	 */
 	PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) (Telegraf, error)
+
+	/*
+	   * PutTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Telegraf
+	*/
+	PutTelegrafsIDExecuteWithHttpInfo(r ApiPutTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -144,6 +173,10 @@ func (r ApiDeleteTelegrafsIDRequest) Execute() error {
 	return r.ApiService.DeleteTelegrafsIDExecute(r)
 }
 
+func (r ApiDeleteTelegrafsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteTelegrafsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteTelegrafsID Delete a Telegraf configuration
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -162,6 +195,14 @@ func (a *TelegrafsApiService) DeleteTelegrafsID(ctx _context.Context, telegrafID
  * Execute executes the request
  */
 func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDRequest) error {
+	_, err := a.DeleteTelegrafsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *TelegrafsApiService) DeleteTelegrafsIDExecuteWithHttpInfo(r ApiDeleteTelegrafsIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -172,7 +213,7 @@ func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDReq
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TelegrafsApiService.DeleteTelegrafsID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/telegrafs/{telegrafID}"
@@ -204,12 +245,12 @@ func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDReq
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -223,12 +264,12 @@ func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDReq
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -238,14 +279,14 @@ func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDReq
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetTelegrafsRequest struct {
@@ -275,6 +316,10 @@ func (r ApiGetTelegrafsRequest) Execute() (Telegrafs, error) {
 	return r.ApiService.GetTelegrafsExecute(r)
 }
 
+func (r ApiGetTelegrafsRequest) ExecuteWithHttpInfo() (Telegrafs, *_nethttp.Response, error) {
+	return r.ApiService.GetTelegrafsExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTelegrafs List all Telegraf configurations
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -292,6 +337,15 @@ func (a *TelegrafsApiService) GetTelegrafs(ctx _context.Context) ApiGetTelegrafs
  * @return Telegrafs
  */
 func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Telegrafs, error) {
+	returnVal, _, err := a.GetTelegrafsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Telegrafs
+ */
+func (a *TelegrafsApiService) GetTelegrafsExecuteWithHttpInfo(r ApiGetTelegrafsRequest) (Telegrafs, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -303,7 +357,7 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TelegrafsApiService.GetTelegrafs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/telegrafs"
@@ -337,12 +391,12 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -356,12 +410,12 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -371,22 +425,22 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -394,10 +448,10 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetTelegrafsIDRequest struct {
@@ -436,6 +490,10 @@ func (r ApiGetTelegrafsIDRequest) Execute() (Telegraf, error) {
 	return r.ApiService.GetTelegrafsIDExecute(r)
 }
 
+func (r ApiGetTelegrafsIDRequest) ExecuteWithHttpInfo() (Telegraf, *_nethttp.Response, error) {
+	return r.ApiService.GetTelegrafsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetTelegrafsID Retrieve a Telegraf configuration
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -455,6 +513,15 @@ func (a *TelegrafsApiService) GetTelegrafsID(ctx _context.Context, telegrafID st
  * @return Telegraf
  */
 func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) (Telegraf, error) {
+	returnVal, _, err := a.GetTelegrafsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Telegraf
+ */
+func (a *TelegrafsApiService) GetTelegrafsIDExecuteWithHttpInfo(r ApiGetTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -466,7 +533,7 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TelegrafsApiService.GetTelegrafsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/telegrafs/{telegrafID}"
@@ -501,12 +568,12 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -520,12 +587,12 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -535,22 +602,22 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -558,10 +625,10 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostTelegrafsRequest struct {
@@ -591,6 +658,10 @@ func (r ApiPostTelegrafsRequest) Execute() (Telegraf, error) {
 	return r.ApiService.PostTelegrafsExecute(r)
 }
 
+func (r ApiPostTelegrafsRequest) ExecuteWithHttpInfo() (Telegraf, *_nethttp.Response, error) {
+	return r.ApiService.PostTelegrafsExecuteWithHttpInfo(r)
+}
+
 /*
  * PostTelegrafs Create a Telegraf configuration
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -608,6 +679,15 @@ func (a *TelegrafsApiService) PostTelegrafs(ctx _context.Context) ApiPostTelegra
  * @return Telegraf
  */
 func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (Telegraf, error) {
+	returnVal, _, err := a.PostTelegrafsExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Telegraf
+ */
+func (a *TelegrafsApiService) PostTelegrafsExecuteWithHttpInfo(r ApiPostTelegrafsRequest) (Telegraf, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -619,7 +699,7 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TelegrafsApiService.PostTelegrafs")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/telegrafs"
@@ -628,7 +708,7 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.telegrafRequest == nil {
-		return localVarReturnValue, reportError("telegrafRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("telegrafRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -655,12 +735,12 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 	localVarPostBody = r.telegrafRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -674,12 +754,12 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -689,22 +769,22 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -712,10 +792,10 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPutTelegrafsIDRequest struct {
@@ -754,6 +834,10 @@ func (r ApiPutTelegrafsIDRequest) Execute() (Telegraf, error) {
 	return r.ApiService.PutTelegrafsIDExecute(r)
 }
 
+func (r ApiPutTelegrafsIDRequest) ExecuteWithHttpInfo() (Telegraf, *_nethttp.Response, error) {
+	return r.ApiService.PutTelegrafsIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PutTelegrafsID Update a Telegraf configuration
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -773,6 +857,15 @@ func (a *TelegrafsApiService) PutTelegrafsID(ctx _context.Context, telegrafID st
  * @return Telegraf
  */
 func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) (Telegraf, error) {
+	returnVal, _, err := a.PutTelegrafsIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Telegraf
+ */
+func (a *TelegrafsApiService) PutTelegrafsIDExecuteWithHttpInfo(r ApiPutTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPut
 		localVarPostBody     interface{}
@@ -784,7 +877,7 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TelegrafsApiService.PutTelegrafsID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/telegrafs/{telegrafID}"
@@ -794,7 +887,7 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.telegrafRequest == nil {
-		return localVarReturnValue, reportError("telegrafRequest is required and must be specified")
+		return localVarReturnValue, nil, reportError("telegrafRequest is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -821,12 +914,12 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 	localVarPostBody = r.telegrafRequest
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -840,12 +933,12 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -855,22 +948,22 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -878,8 +971,8 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_telegrafs.gen.go
+++ b/api/api_telegrafs.gen.go
@@ -40,7 +40,9 @@ type TelegrafsApi interface {
 	DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDRequest) error
 
 	/*
-	 * DeleteTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteTelegrafsIDExecuteWithHttpInfo(r ApiDeleteTelegrafsIDRequest) (*_nethttp.Response, error)
 
@@ -58,9 +60,11 @@ type TelegrafsApi interface {
 	GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Telegrafs, error)
 
 	/*
-	   * GetTelegrafsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Telegrafs
-	*/
+	 * GetTelegrafsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Telegrafs
+	 */
 	GetTelegrafsExecuteWithHttpInfo(r ApiGetTelegrafsRequest) (Telegrafs, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type TelegrafsApi interface {
 	GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) (Telegraf, error)
 
 	/*
-	   * GetTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Telegraf
-	*/
+	 * GetTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Telegraf
+	 */
 	GetTelegrafsIDExecuteWithHttpInfo(r ApiGetTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error)
 
 	/*
@@ -97,9 +103,11 @@ type TelegrafsApi interface {
 	PostTelegrafsExecute(r ApiPostTelegrafsRequest) (Telegraf, error)
 
 	/*
-	   * PostTelegrafsExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Telegraf
-	*/
+	 * PostTelegrafsExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Telegraf
+	 */
 	PostTelegrafsExecuteWithHttpInfo(r ApiPostTelegrafsRequest) (Telegraf, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type TelegrafsApi interface {
 	PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) (Telegraf, error)
 
 	/*
-	   * PutTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Telegraf
-	*/
+	 * PutTelegrafsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Telegraf
+	 */
 	PutTelegrafsIDExecuteWithHttpInfo(r ApiPutTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -200,7 +210,9 @@ func (a *TelegrafsApiService) DeleteTelegrafsIDExecute(r ApiDeleteTelegrafsIDReq
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *TelegrafsApiService) DeleteTelegrafsIDExecuteWithHttpInfo(r ApiDeleteTelegrafsIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -342,7 +354,9 @@ func (a *TelegrafsApiService) GetTelegrafsExecute(r ApiGetTelegrafsRequest) (Tel
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Telegrafs
  */
 func (a *TelegrafsApiService) GetTelegrafsExecuteWithHttpInfo(r ApiGetTelegrafsRequest) (Telegrafs, *_nethttp.Response, error) {
@@ -518,7 +532,9 @@ func (a *TelegrafsApiService) GetTelegrafsIDExecute(r ApiGetTelegrafsIDRequest) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Telegraf
  */
 func (a *TelegrafsApiService) GetTelegrafsIDExecuteWithHttpInfo(r ApiGetTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error) {
@@ -684,7 +700,9 @@ func (a *TelegrafsApiService) PostTelegrafsExecute(r ApiPostTelegrafsRequest) (T
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Telegraf
  */
 func (a *TelegrafsApiService) PostTelegrafsExecuteWithHttpInfo(r ApiPostTelegrafsRequest) (Telegraf, *_nethttp.Response, error) {
@@ -862,7 +880,9 @@ func (a *TelegrafsApiService) PutTelegrafsIDExecute(r ApiPutTelegrafsIDRequest) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Telegraf
  */
 func (a *TelegrafsApiService) PutTelegrafsIDExecuteWithHttpInfo(r ApiPutTelegrafsIDRequest) (Telegraf, *_nethttp.Response, error) {

--- a/api/api_templates.gen.go
+++ b/api/api_templates.gen.go
@@ -39,9 +39,11 @@ type TemplatesApi interface {
 	ApplyTemplateExecute(r ApiApplyTemplateRequest) (TemplateSummary, error)
 
 	/*
-	   * ApplyTemplateExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return TemplateSummary
-	*/
+	 * ApplyTemplateExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return TemplateSummary
+	 */
 	ApplyTemplateExecuteWithHttpInfo(r ApiApplyTemplateRequest) (TemplateSummary, *_nethttp.Response, error)
 
 	/*
@@ -58,9 +60,11 @@ type TemplatesApi interface {
 	ExportTemplateExecute(r ApiExportTemplateRequest) ([]TemplateEntry, error)
 
 	/*
-	   * ExportTemplateExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return []TemplateEntry
-	*/
+	 * ExportTemplateExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return []TemplateEntry
+	 */
 	ExportTemplateExecuteWithHttpInfo(r ApiExportTemplateRequest) ([]TemplateEntry, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
@@ -131,7 +135,9 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return TemplateSummary
  */
 func (a *TemplatesApiService) ApplyTemplateExecuteWithHttpInfo(r ApiApplyTemplateRequest) (TemplateSummary, *_nethttp.Response, error) {
@@ -297,7 +303,9 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return []TemplateEntry
  */
 func (a *TemplatesApiService) ExportTemplateExecuteWithHttpInfo(r ApiExportTemplateRequest) ([]TemplateEntry, *_nethttp.Response, error) {

--- a/api/api_templates.gen.go
+++ b/api/api_templates.gen.go
@@ -39,6 +39,12 @@ type TemplatesApi interface {
 	ApplyTemplateExecute(r ApiApplyTemplateRequest) (TemplateSummary, error)
 
 	/*
+	   * ApplyTemplateExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return TemplateSummary
+	*/
+	ApplyTemplateExecuteWithHttpInfo(r ApiApplyTemplateRequest) (TemplateSummary, *_nethttp.Response, error)
+
+	/*
 	 * ExportTemplate Export a new Influx Template
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiExportTemplateRequest
@@ -50,6 +56,12 @@ type TemplatesApi interface {
 	 * @return []TemplateEntry
 	 */
 	ExportTemplateExecute(r ApiExportTemplateRequest) ([]TemplateEntry, error)
+
+	/*
+	   * ExportTemplateExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return []TemplateEntry
+	*/
+	ExportTemplateExecuteWithHttpInfo(r ApiExportTemplateRequest) ([]TemplateEntry, *_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -93,6 +105,10 @@ func (r ApiApplyTemplateRequest) Execute() (TemplateSummary, error) {
 	return r.ApiService.ApplyTemplateExecute(r)
 }
 
+func (r ApiApplyTemplateRequest) ExecuteWithHttpInfo() (TemplateSummary, *_nethttp.Response, error) {
+	return r.ApiService.ApplyTemplateExecuteWithHttpInfo(r)
+}
+
 /*
  * ApplyTemplate Apply or dry-run an InfluxDB Template
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -110,6 +126,15 @@ func (a *TemplatesApiService) ApplyTemplate(ctx _context.Context) ApiApplyTempla
  * @return TemplateSummary
  */
 func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (TemplateSummary, error) {
+	returnVal, _, err := a.ApplyTemplateExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return TemplateSummary
+ */
+func (a *TemplatesApiService) ApplyTemplateExecuteWithHttpInfo(r ApiApplyTemplateRequest) (TemplateSummary, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -121,7 +146,7 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TemplatesApiService.ApplyTemplate")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/templates/apply"
@@ -130,7 +155,7 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.templateApply == nil {
-		return localVarReturnValue, reportError("templateApply is required and must be specified")
+		return localVarReturnValue, nil, reportError("templateApply is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -154,12 +179,12 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 	localVarPostBody = r.templateApply
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -173,12 +198,12 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -189,32 +214,32 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarReturnValue, newErr
+				return localVarReturnValue, localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -222,10 +247,10 @@ func (a *TemplatesApiService) ApplyTemplateExecute(r ApiApplyTemplateRequest) (T
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiExportTemplateRequest struct {
@@ -246,6 +271,10 @@ func (r ApiExportTemplateRequest) Execute() ([]TemplateEntry, error) {
 	return r.ApiService.ExportTemplateExecute(r)
 }
 
+func (r ApiExportTemplateRequest) ExecuteWithHttpInfo() ([]TemplateEntry, *_nethttp.Response, error) {
+	return r.ApiService.ExportTemplateExecuteWithHttpInfo(r)
+}
+
 /*
  * ExportTemplate Export a new Influx Template
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -263,6 +292,15 @@ func (a *TemplatesApiService) ExportTemplate(ctx _context.Context) ApiExportTemp
  * @return []TemplateEntry
  */
 func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) ([]TemplateEntry, error) {
+	returnVal, _, err := a.ExportTemplateExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return []TemplateEntry
+ */
+func (a *TemplatesApiService) ExportTemplateExecuteWithHttpInfo(r ApiExportTemplateRequest) ([]TemplateEntry, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -274,7 +312,7 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "TemplatesApiService.ExportTemplate")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/templates/export"
@@ -304,12 +342,12 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 	localVarPostBody = r.templateExport
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -323,12 +361,12 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -338,22 +376,22 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -361,8 +399,8 @@ func (a *TemplatesApiService) ExportTemplateExecute(r ApiExportTemplateRequest) 
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }

--- a/api/api_users.gen.go
+++ b/api/api_users.gen.go
@@ -40,6 +40,11 @@ type UsersApi interface {
 	DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error
 
 	/*
+	 * DeleteUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	DeleteUsersIDExecuteWithHttpInfo(r ApiDeleteUsersIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetUsers List all users
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @return ApiGetUsersRequest
@@ -51,6 +56,12 @@ type UsersApi interface {
 	 * @return Users
 	 */
 	GetUsersExecute(r ApiGetUsersRequest) (Users, error)
+
+	/*
+	   * GetUsersExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return Users
+	*/
+	GetUsersExecuteWithHttpInfo(r ApiGetUsersRequest) (Users, *_nethttp.Response, error)
 
 	/*
 	 * GetUsersID Retrieve a user
@@ -67,6 +78,12 @@ type UsersApi interface {
 	GetUsersIDExecute(r ApiGetUsersIDRequest) (UserResponse, error)
 
 	/*
+	   * GetUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return UserResponse
+	*/
+	GetUsersIDExecuteWithHttpInfo(r ApiGetUsersIDRequest) (UserResponse, *_nethttp.Response, error)
+
+	/*
 	 * PatchUsersID Update a user
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param userID The ID of the user to update.
@@ -79,6 +96,12 @@ type UsersApi interface {
 	 * @return UserResponse
 	 */
 	PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserResponse, error)
+
+	/*
+	   * PatchUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return UserResponse
+	*/
+	PatchUsersIDExecuteWithHttpInfo(r ApiPatchUsersIDRequest) (UserResponse, *_nethttp.Response, error)
 
 	/*
 	 * PostUsers Create a user
@@ -94,6 +117,12 @@ type UsersApi interface {
 	PostUsersExecute(r ApiPostUsersRequest) (UserResponse, error)
 
 	/*
+	   * PostUsersExecuteWithHttpInfo executes the request with HTTP response info returned
+	       * @return UserResponse
+	*/
+	PostUsersExecuteWithHttpInfo(r ApiPostUsersRequest) (UserResponse, *_nethttp.Response, error)
+
+	/*
 	 * PostUsersIDPassword Update a password
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param userID The user ID.
@@ -105,6 +134,11 @@ type UsersApi interface {
 	 * PostUsersIDPasswordExecute executes the request
 	 */
 	PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordRequest) error
+
+	/*
+	 * PostUsersIDPasswordExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostUsersIDPasswordExecuteWithHttpInfo(r ApiPostUsersIDPasswordRequest) (*_nethttp.Response, error)
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -157,6 +191,10 @@ func (r ApiDeleteUsersIDRequest) Execute() error {
 	return r.ApiService.DeleteUsersIDExecute(r)
 }
 
+func (r ApiDeleteUsersIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteUsersIDExecuteWithHttpInfo(r)
+}
+
 /*
  * DeleteUsersID Delete a user
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -175,6 +213,14 @@ func (a *UsersApiService) DeleteUsersID(ctx _context.Context, userID string) Api
  * Execute executes the request
  */
 func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error {
+	_, err := a.DeleteUsersIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *UsersApiService) DeleteUsersIDExecuteWithHttpInfo(r ApiDeleteUsersIDRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodDelete
 		localVarPostBody     interface{}
@@ -185,7 +231,7 @@ func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error 
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsersApiService.DeleteUsersID")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/users/{userID}"
@@ -217,12 +263,12 @@ func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error 
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -236,12 +282,12 @@ func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error 
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -251,14 +297,14 @@ func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error 
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }
 
 type ApiGetUsersRequest struct {
@@ -324,6 +370,10 @@ func (r ApiGetUsersRequest) Execute() (Users, error) {
 	return r.ApiService.GetUsersExecute(r)
 }
 
+func (r ApiGetUsersRequest) ExecuteWithHttpInfo() (Users, *_nethttp.Response, error) {
+	return r.ApiService.GetUsersExecuteWithHttpInfo(r)
+}
+
 /*
  * GetUsers List all users
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -341,6 +391,15 @@ func (a *UsersApiService) GetUsers(ctx _context.Context) ApiGetUsersRequest {
  * @return Users
  */
 func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
+	returnVal, _, err := a.GetUsersExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return Users
+ */
+func (a *UsersApiService) GetUsersExecuteWithHttpInfo(r ApiGetUsersRequest) (Users, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -352,7 +411,7 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsersApiService.GetUsers")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/users"
@@ -398,12 +457,12 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -417,12 +476,12 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -432,22 +491,22 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -455,10 +514,10 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiGetUsersIDRequest struct {
@@ -488,6 +547,10 @@ func (r ApiGetUsersIDRequest) Execute() (UserResponse, error) {
 	return r.ApiService.GetUsersIDExecute(r)
 }
 
+func (r ApiGetUsersIDRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.Response, error) {
+	return r.ApiService.GetUsersIDExecuteWithHttpInfo(r)
+}
+
 /*
  * GetUsersID Retrieve a user
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -507,6 +570,15 @@ func (a *UsersApiService) GetUsersID(ctx _context.Context, userID string) ApiGet
  * @return UserResponse
  */
 func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserResponse, error) {
+	returnVal, _, err := a.GetUsersIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return UserResponse
+ */
+func (a *UsersApiService) GetUsersIDExecuteWithHttpInfo(r ApiGetUsersIDRequest) (UserResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodGet
 		localVarPostBody     interface{}
@@ -518,7 +590,7 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsersApiService.GetUsersID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/users/{userID}"
@@ -550,12 +622,12 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 	}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -569,12 +641,12 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -584,22 +656,22 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -607,10 +679,10 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPatchUsersIDRequest struct {
@@ -649,6 +721,10 @@ func (r ApiPatchUsersIDRequest) Execute() (UserResponse, error) {
 	return r.ApiService.PatchUsersIDExecute(r)
 }
 
+func (r ApiPatchUsersIDRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.Response, error) {
+	return r.ApiService.PatchUsersIDExecuteWithHttpInfo(r)
+}
+
 /*
  * PatchUsersID Update a user
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -668,6 +744,15 @@ func (a *UsersApiService) PatchUsersID(ctx _context.Context, userID string) ApiP
  * @return UserResponse
  */
 func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserResponse, error) {
+	returnVal, _, err := a.PatchUsersIDExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return UserResponse
+ */
+func (a *UsersApiService) PatchUsersIDExecuteWithHttpInfo(r ApiPatchUsersIDRequest) (UserResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPatch
 		localVarPostBody     interface{}
@@ -679,7 +764,7 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsersApiService.PatchUsersID")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/users/{userID}"
@@ -689,7 +774,7 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		return localVarReturnValue, reportError("user is required and must be specified")
+		return localVarReturnValue, nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -716,12 +801,12 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -735,12 +820,12 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -750,22 +835,22 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -773,10 +858,10 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostUsersRequest struct {
@@ -806,6 +891,10 @@ func (r ApiPostUsersRequest) Execute() (UserResponse, error) {
 	return r.ApiService.PostUsersExecute(r)
 }
 
+func (r ApiPostUsersRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.Response, error) {
+	return r.ApiService.PostUsersExecuteWithHttpInfo(r)
+}
+
 /*
  * PostUsers Create a user
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -823,6 +912,15 @@ func (a *UsersApiService) PostUsers(ctx _context.Context) ApiPostUsersRequest {
  * @return UserResponse
  */
 func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse, error) {
+	returnVal, _, err := a.PostUsersExecuteWithHttpInfo(r)
+	return returnVal, err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * @return UserResponse
+ */
+func (a *UsersApiService) PostUsersExecuteWithHttpInfo(r ApiPostUsersRequest) (UserResponse, *_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -834,7 +932,7 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsersApiService.PostUsers")
 	if err != nil {
-		return localVarReturnValue, GenericOpenAPIError{error: err.Error()}
+		return localVarReturnValue, nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/users"
@@ -843,7 +941,7 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.user == nil {
-		return localVarReturnValue, reportError("user is required and must be specified")
+		return localVarReturnValue, nil, reportError("user is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -870,12 +968,12 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 	localVarPostBody = r.user
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return localVarReturnValue, err
+		return localVarReturnValue, localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -889,12 +987,12 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -904,22 +1002,22 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return localVarReturnValue, newErr
+			return localVarReturnValue, localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return localVarReturnValue, _fmt.Errorf("%s%w", errorPrefix, err)
+		return localVarReturnValue, localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -927,10 +1025,10 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return localVarReturnValue, newErr
+		return localVarReturnValue, localVarHTTPResponse, newErr
 	}
 
-	return localVarReturnValue, nil
+	return localVarReturnValue, localVarHTTPResponse, nil
 }
 
 type ApiPostUsersIDPasswordRequest struct {
@@ -969,6 +1067,10 @@ func (r ApiPostUsersIDPasswordRequest) Execute() error {
 	return r.ApiService.PostUsersIDPasswordExecute(r)
 }
 
+func (r ApiPostUsersIDPasswordRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostUsersIDPasswordExecuteWithHttpInfo(r)
+}
+
 /*
  * PostUsersIDPassword Update a password
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
@@ -987,6 +1089,14 @@ func (a *UsersApiService) PostUsersIDPassword(ctx _context.Context, userID strin
  * Execute executes the request
  */
 func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordRequest) error {
+	_, err := a.PostUsersIDPasswordExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *UsersApiService) PostUsersIDPasswordExecuteWithHttpInfo(r ApiPostUsersIDPasswordRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -997,7 +1107,7 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "UsersApiService.PostUsersIDPassword")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/users/{userID}/password"
@@ -1007,7 +1117,7 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.passwordResetBody == nil {
-		return reportError("passwordResetBody is required and must be specified")
+		return nil, reportError("passwordResetBody is required and must be specified")
 	}
 
 	// to determine the Content-Type header
@@ -1034,12 +1144,12 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 	localVarPostBody = r.passwordResetBody
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -1053,12 +1163,12 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -1068,12 +1178,12 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_users.gen.go
+++ b/api/api_users.gen.go
@@ -40,7 +40,9 @@ type UsersApi interface {
 	DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error
 
 	/*
-	 * DeleteUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * DeleteUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	DeleteUsersIDExecuteWithHttpInfo(r ApiDeleteUsersIDRequest) (*_nethttp.Response, error)
 
@@ -58,9 +60,11 @@ type UsersApi interface {
 	GetUsersExecute(r ApiGetUsersRequest) (Users, error)
 
 	/*
-	   * GetUsersExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return Users
-	*/
+	 * GetUsersExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return Users
+	 */
 	GetUsersExecuteWithHttpInfo(r ApiGetUsersRequest) (Users, *_nethttp.Response, error)
 
 	/*
@@ -78,9 +82,11 @@ type UsersApi interface {
 	GetUsersIDExecute(r ApiGetUsersIDRequest) (UserResponse, error)
 
 	/*
-	   * GetUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return UserResponse
-	*/
+	 * GetUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return UserResponse
+	 */
 	GetUsersIDExecuteWithHttpInfo(r ApiGetUsersIDRequest) (UserResponse, *_nethttp.Response, error)
 
 	/*
@@ -98,9 +104,11 @@ type UsersApi interface {
 	PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserResponse, error)
 
 	/*
-	   * PatchUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return UserResponse
-	*/
+	 * PatchUsersIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return UserResponse
+	 */
 	PatchUsersIDExecuteWithHttpInfo(r ApiPatchUsersIDRequest) (UserResponse, *_nethttp.Response, error)
 
 	/*
@@ -117,9 +125,11 @@ type UsersApi interface {
 	PostUsersExecute(r ApiPostUsersRequest) (UserResponse, error)
 
 	/*
-	   * PostUsersExecuteWithHttpInfo executes the request with HTTP response info returned
-	       * @return UserResponse
-	*/
+	 * PostUsersExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 * @return UserResponse
+	 */
 	PostUsersExecuteWithHttpInfo(r ApiPostUsersRequest) (UserResponse, *_nethttp.Response, error)
 
 	/*
@@ -136,7 +146,9 @@ type UsersApi interface {
 	PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordRequest) error
 
 	/*
-	 * PostUsersIDPasswordExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostUsersIDPasswordExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostUsersIDPasswordExecuteWithHttpInfo(r ApiPostUsersIDPasswordRequest) (*_nethttp.Response, error)
 
@@ -218,7 +230,9 @@ func (a *UsersApiService) DeleteUsersIDExecute(r ApiDeleteUsersIDRequest) error 
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *UsersApiService) DeleteUsersIDExecuteWithHttpInfo(r ApiDeleteUsersIDRequest) (*_nethttp.Response, error) {
 	var (
@@ -396,7 +410,9 @@ func (a *UsersApiService) GetUsersExecute(r ApiGetUsersRequest) (Users, error) {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return Users
  */
 func (a *UsersApiService) GetUsersExecuteWithHttpInfo(r ApiGetUsersRequest) (Users, *_nethttp.Response, error) {
@@ -575,7 +591,9 @@ func (a *UsersApiService) GetUsersIDExecute(r ApiGetUsersIDRequest) (UserRespons
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return UserResponse
  */
 func (a *UsersApiService) GetUsersIDExecuteWithHttpInfo(r ApiGetUsersIDRequest) (UserResponse, *_nethttp.Response, error) {
@@ -749,7 +767,9 @@ func (a *UsersApiService) PatchUsersIDExecute(r ApiPatchUsersIDRequest) (UserRes
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return UserResponse
  */
 func (a *UsersApiService) PatchUsersIDExecuteWithHttpInfo(r ApiPatchUsersIDRequest) (UserResponse, *_nethttp.Response, error) {
@@ -917,7 +937,9 @@ func (a *UsersApiService) PostUsersExecute(r ApiPostUsersRequest) (UserResponse,
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  * @return UserResponse
  */
 func (a *UsersApiService) PostUsersExecuteWithHttpInfo(r ApiPostUsersRequest) (UserResponse, *_nethttp.Response, error) {
@@ -1094,7 +1116,9 @@ func (a *UsersApiService) PostUsersIDPasswordExecute(r ApiPostUsersIDPasswordReq
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *UsersApiService) PostUsersIDPasswordExecuteWithHttpInfo(r ApiPostUsersIDPasswordRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -52,6 +52,11 @@ type WriteApi interface {
 	 */
 	PostWriteExecute(r ApiPostWriteRequest) error
 
+	/*
+	 * PostWriteExecuteWithHttpInfo executes the request with HTTP response info returned
+	 */
+	PostWriteExecuteWithHttpInfo(r ApiPostWriteRequest) (*_nethttp.Response, error)
+
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
 	// servers.
@@ -175,6 +180,10 @@ func (r ApiPostWriteRequest) Execute() error {
 	return r.ApiService.PostWriteExecute(r)
 }
 
+func (r ApiPostWriteRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.PostWriteExecuteWithHttpInfo(r)
+}
+
 /*
  * PostWrite Write data
  * Writes data to a bucket.
@@ -206,6 +215,14 @@ func (a *WriteApiService) PostWrite(ctx _context.Context) ApiPostWriteRequest {
  * Execute executes the request
  */
 func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
+	_, err := a.PostWriteExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ */
+func (a *WriteApiService) PostWriteExecuteWithHttpInfo(r ApiPostWriteRequest) (*_nethttp.Response, error) {
 	var (
 		localVarHTTPMethod   = _nethttp.MethodPost
 		localVarPostBody     interface{}
@@ -216,7 +233,7 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "WriteApiService.PostWrite")
 	if err != nil {
-		return GenericOpenAPIError{error: err.Error()}
+		return nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "/write"
@@ -225,13 +242,13 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 	localVarQueryParams := _neturl.Values{}
 	localVarFormParams := _neturl.Values{}
 	if r.org == nil {
-		return reportError("org is required and must be specified")
+		return nil, reportError("org is required and must be specified")
 	}
 	if r.bucket == nil {
-		return reportError("bucket is required and must be specified")
+		return nil, reportError("bucket is required and must be specified")
 	}
 	if r.body == nil {
-		return reportError("body is required and must be specified")
+		return nil, reportError("body is required and must be specified")
 	}
 
 	localVarQueryParams.Add("org", parameterToString(*r.org, ""))
@@ -278,12 +295,12 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 	localVarPostBody = r.body
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return err
+		return localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -297,12 +314,12 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return _fmt.Errorf("%s%w", errorPrefix, err)
+			return localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -313,66 +330,66 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 401 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 413 {
 			var v LineProtocolLengthError
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		if localVarHTTPResponse.StatusCode == 500 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return newErr
+				return localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
 			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-			return newErr
+			return localVarHTTPResponse, newErr
 		}
 		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 		newErr.model = &v
-		return newErr
+		return localVarHTTPResponse, newErr
 	}
 
-	return nil
+	return localVarHTTPResponse, nil
 }

--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -53,7 +53,9 @@ type WriteApi interface {
 	PostWriteExecute(r ApiPostWriteRequest) error
 
 	/*
-	 * PostWriteExecuteWithHttpInfo executes the request with HTTP response info returned
+	 * PostWriteExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
 	 */
 	PostWriteExecuteWithHttpInfo(r ApiPostWriteRequest) (*_nethttp.Response, error)
 
@@ -220,7 +222,9 @@ func (a *WriteApiService) PostWriteExecute(r ApiPostWriteRequest) error {
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
  */
 func (a *WriteApiService) PostWriteExecuteWithHttpInfo(r ApiPostWriteRequest) (*_nethttp.Response, error) {
 	var (

--- a/api/templates/README.md
+++ b/api/templates/README.md
@@ -19,7 +19,11 @@ multiple locations.
 * Add checks for `isResponseBinary` to directly return the raw `*http.Response`, instead of
   pulling the entire body into memory and transforming it into an `*os.File`
 * GUnzip non-binary response bodies before unmarshalling when `Content-Encoding: gzip` is set
-* Remove `*http.Response`s from the return values of generated `Execute` operations & provide a separate method `ExecuteWithHttpInfo` for returning the `*http.Response` if needed
+* Remove `*http.Response`s from the return values of generated `Execute` operations & provide a separate method
+  `ExecuteWithHttpInfo` for returning the `*http.Response` if needed. The standard `Execute` operation should normally be
+  used unless specific header values or response codes need to be examined with the `ExecuteWithHttpInfo`. The response
+  body cannot be read from the `*http.Reponse` returned from ExecuteWithHttpInfo` as it will have already have been read
+  and closed; access to the response body content should be achieved through the returned response model if applicable
 
 `client.mustache`
 * Removed use of `golang.org/x/oauth2` to avoid its heavy dependencies

--- a/api/templates/README.md
+++ b/api/templates/README.md
@@ -22,7 +22,7 @@ multiple locations.
 * Remove `*http.Response`s from the return values of generated `Execute` operations & provide a separate method
   `ExecuteWithHttpInfo` for returning the `*http.Response` if needed. The standard `Execute` operation should normally be
   used unless specific header values or response codes need to be examined with the `ExecuteWithHttpInfo`. The response
-  body cannot be read from the `*http.Reponse` returned from ExecuteWithHttpInfo` as it will have already have been read
+  body cannot be read from the `*http.Reponse` returned from `ExecuteWithHttpInfo` as it will have already have been read
   and closed; access to the response body content should be achieved through the returned response model if applicable
 
 `client.mustache`

--- a/api/templates/README.md
+++ b/api/templates/README.md
@@ -19,7 +19,7 @@ multiple locations.
 * Add checks for `isResponseBinary` to directly return the raw `*http.Response`, instead of
   pulling the entire body into memory and transforming it into an `*os.File`
 * GUnzip non-binary response bodies before unmarshalling when `Content-Encoding: gzip` is set
-* Remove `*http.Response`s from the return values of generated operations
+* Remove `*http.Response`s from the return values of generated `Execute` operations & provide a separate method `ExecuteWithHttpInfo` for returning the `*http.Response` if needed
 
 `client.mustache`
 * Removed use of `golang.org/x/oauth2` to avoid its heavy dependencies

--- a/api/templates/api.mustache
+++ b/api/templates/api.mustache
@@ -40,8 +40,10 @@ type {{classname}} interface {
 	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error)
 
     /*
-    * {{nickname}}ExecuteWithHttpInfo executes the request with HTTP response info returned{{#returnType}}
-        * @return {{{.}}}{{/returnType}}
+    * {{nickname}}ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+    * available on the returned HTTP response as it will have already been read and closed; access to the response body
+    * content should be achieved through the returned response model if applicable.{{#returnType}}
+    * @return {{{.}}}{{/returnType}}
     */
     {{nickname}}ExecuteWithHttpInfo(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error)
     {{/operation}}
@@ -131,7 +133,9 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 }
 
 /*
- * ExecuteWithHttpInfo executes the request with HTTP response info returned{{#returnType}}
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.{{#returnType}}
  * @return {{{.}}}{{/returnType}}
  */
 func (a *{{{classname}}}Service) {{nickname}}ExecuteWithHttpInfo(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {

--- a/api/templates/api.mustache
+++ b/api/templates/api.mustache
@@ -38,7 +38,13 @@ type {{classname}} interface {
 	 * @return {{{.}}}{{/returnType}}
 	 */
 	{{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}error)
-	{{/operation}}
+
+    /*
+    * {{nickname}}ExecuteWithHttpInfo executes the request with HTTP response info returned{{#returnType}}
+        * @return {{{.}}}{{/returnType}}
+    */
+    {{nickname}}ExecuteWithHttpInfo(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error)
+    {{/operation}}
 
 	// Sets additional descriptive text in the error message if any request in
 	// this API fails, indicating that it is intended to be used only on OSS
@@ -92,6 +98,10 @@ func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Reques
 	return r.ApiService.{{nickname}}Execute(r)
 }
 
+func (r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ExecuteWithHttpInfo() ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{returnType}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {
+    return r.ApiService.{{nickname}}ExecuteWithHttpInfo(r)
+}
+
 /*
  * {{operationId}}{{#summary}} {{{.}}}{{/summary}}{{^summary}} Method for {{operationId}}{{/summary}}
 {{#notes}}
@@ -116,7 +126,16 @@ func (a *{{{classname}}}Service) {{{nickname}}}(ctx _context.Context{{#pathParam
  * @return {{{.}}}{{/returnType}}
  */
 func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}error) {
-	var (
+    {{#returnType}}returnVal, {{/returnType}}_, err := a.{{nickname}}ExecuteWithHttpInfo(r)
+    return {{#returnType}}returnVal, {{/returnType}}err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned{{#returnType}}
+ * @return {{{.}}}{{/returnType}}
+ */
+func (a *{{{classname}}}Service) {{nickname}}ExecuteWithHttpInfo(r {{#structPrefix}}{{&classname}}{{/structPrefix}}Api{{operationId}}Request) ({{#returnType}}{{#isResponseBinary}}*_nethttp.Response{{/isResponseBinary}}{{^isResponseBinary}}{{{.}}}{{/isResponseBinary}}, {{/returnType}}*_nethttp.Response, error) {
+    var (
 		localVarHTTPMethod   = _nethttp.Method{{httpMethod}}
 		localVarPostBody     interface{}
 		localVarFormFileName string
@@ -134,7 +153,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 
 	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "{{{classname}}}Service.{{{nickname}}}")
 	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}GenericOpenAPIError{error: err.Error()}
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, GenericOpenAPIError{error: err.Error()}
 	}
 
 	localVarPath := localBasePath + "{{{path}}}"{{#pathParams}}
@@ -147,27 +166,27 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{#required}}
 	{{^isPathParam}}
 	if r.{{paramName}} == nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} is required and must be specified")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} is required and must be specified")
 	}
 	{{/isPathParam}}
 	{{#minItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minItems}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have at least {{minItems}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minItems}} elements")
 	}
 	{{/minItems}}
 	{{#maxItems}}
 	if len({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxItems}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have less than {{maxItems}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxItems}} elements")
 	}
 	{{/maxItems}}
 	{{#minLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) < {{minLength}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have at least {{minLength}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have at least {{minLength}} elements")
 	}
 	{{/minLength}}
 	{{#maxLength}}
 	if strlen({{^isPathParam}}*{{/isPathParam}}r.{{paramName}}) > {{maxLength}} {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must have less than {{maxLength}} elements")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must have less than {{maxLength}} elements")
 	}
 	{{/maxLength}}
 	{{#minimum}}
@@ -178,7 +197,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} < {{minimum}} {
 	{{/isString}}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must be greater than {{minimum}}")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be greater than {{minimum}}")
 	}
 	{{/minimum}}
 	{{#maximum}}
@@ -189,7 +208,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	{{^isString}}
 	if {{^isPathParam}}*{{/isPathParam}}r.{{paramName}} > {{maximum}} {
 	{{/isString}}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}reportError("{{paramName}} must be less than {{maximum}}")
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, reportError("{{paramName}} must be less than {{maximum}}")
 	}
 	{{/maximum}}
 	{{/required}}
@@ -292,7 +311,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	if r.{{paramName}} != nil {
 		paramJson, err := parameterToJson(*r.{{paramName}})
 		if err != nil {
-			return {{#returnType}}localVarReturnValue, {{/returnType}}err
+			return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 		}
 		localVarFormParams.Add("{{baseName}}", paramJson)
 	}
@@ -347,12 +366,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 {{/authMethods}}
 	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
 	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}err
+		return {{#returnType}}localVarReturnValue, {{/returnType}}nil, err
 	}
 
 	localVarHTTPResponse, err := a.client.callAPI(req)
 	if err != nil || localVarHTTPResponse == nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}err
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, err
 	}
 
 	var errorPrefix string
@@ -366,12 +385,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		body, err := GunzipIfNeeded(localVarHTTPResponse)
 		if err != nil {
 			body.Close()
-			return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
+			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		localVarBody, err := _io.ReadAll(body)
 		body.Close()
 		if err != nil {
-			return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
+			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 		}
 		newErr := GenericOpenAPIError{
 			body:  localVarBody,
@@ -388,12 +407,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
+				return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 			}
 			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
 			newErr.model = &v
 			{{^-last}}
-			return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
+			return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 			{{/-last}}
 		{{^wildcard}}
 		}
@@ -402,7 +421,7 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 		{{/is1xx}}
 		{{/dataType}}
 		{{/responses}}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 	}
 
 	{{#returnType}}
@@ -413,12 +432,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 	body, err := GunzipIfNeeded(localVarHTTPResponse)
 	if err != nil {
 		body.Close()
-		return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	localVarBody, err := _io.ReadAll(body)
 	body.Close()
 	if err != nil {
-		return {{#returnType}}localVarReturnValue, {{/returnType}}_fmt.Errorf("%s%w", errorPrefix, err)
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, _fmt.Errorf("%s%w", errorPrefix, err)
 	}
 	err = a.client.decode(&localVarReturnValue, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 	if err != nil {
@@ -426,12 +445,12 @@ func (a *{{{classname}}}Service) {{nickname}}Execute(r {{#structPrefix}}{{&class
 			body:  localVarBody,
 			error: _fmt.Sprintf("%s%s", errorPrefix, err.Error()),
 		}
-		return {{#returnType}}localVarReturnValue, {{/returnType}}newErr
+		return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, newErr
 	}
 	{{/isResponseBinary}}
 
 	{{/returnType}}
-	return {{#returnType}}localVarReturnValue, {{/returnType}}nil
+	return {{#returnType}}localVarReturnValue, {{/returnType}}localVarHTTPResponse, nil
 }
 {{/operation}}
 {{/operations}}

--- a/internal/mock/api_backup.gen.go
+++ b/internal/mock/api_backup.gen.go
@@ -65,6 +65,22 @@ func (mr *MockBackupApiMockRecorder) GetBackupKVExecute(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupKVExecute", reflect.TypeOf((*MockBackupApi)(nil).GetBackupKVExecute), arg0)
 }
 
+// GetBackupKVExecuteWithHttpInfo mocks base method.
+func (m *MockBackupApi) GetBackupKVExecuteWithHttpInfo(arg0 api.ApiGetBackupKVRequest) (*http.Response, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupKVExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBackupKVExecuteWithHttpInfo indicates an expected call of GetBackupKVExecuteWithHttpInfo.
+func (mr *MockBackupApiMockRecorder) GetBackupKVExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupKVExecuteWithHttpInfo", reflect.TypeOf((*MockBackupApi)(nil).GetBackupKVExecuteWithHttpInfo), arg0)
+}
+
 // GetBackupMetadata mocks base method.
 func (m *MockBackupApi) GetBackupMetadata(arg0 context.Context) api.ApiGetBackupMetadataRequest {
 	m.ctrl.T.Helper()
@@ -94,6 +110,22 @@ func (mr *MockBackupApiMockRecorder) GetBackupMetadataExecute(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupMetadataExecute", reflect.TypeOf((*MockBackupApi)(nil).GetBackupMetadataExecute), arg0)
 }
 
+// GetBackupMetadataExecuteWithHttpInfo mocks base method.
+func (m *MockBackupApi) GetBackupMetadataExecuteWithHttpInfo(arg0 api.ApiGetBackupMetadataRequest) (*http.Response, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupMetadataExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBackupMetadataExecuteWithHttpInfo indicates an expected call of GetBackupMetadataExecuteWithHttpInfo.
+func (mr *MockBackupApiMockRecorder) GetBackupMetadataExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupMetadataExecuteWithHttpInfo", reflect.TypeOf((*MockBackupApi)(nil).GetBackupMetadataExecuteWithHttpInfo), arg0)
+}
+
 // GetBackupShardId mocks base method.
 func (m *MockBackupApi) GetBackupShardId(arg0 context.Context, arg1 int64) api.ApiGetBackupShardIdRequest {
 	m.ctrl.T.Helper()
@@ -121,6 +153,22 @@ func (m *MockBackupApi) GetBackupShardIdExecute(arg0 api.ApiGetBackupShardIdRequ
 func (mr *MockBackupApiMockRecorder) GetBackupShardIdExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupShardIdExecute", reflect.TypeOf((*MockBackupApi)(nil).GetBackupShardIdExecute), arg0)
+}
+
+// GetBackupShardIdExecuteWithHttpInfo mocks base method.
+func (m *MockBackupApi) GetBackupShardIdExecuteWithHttpInfo(arg0 api.ApiGetBackupShardIdRequest) (*http.Response, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBackupShardIdExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBackupShardIdExecuteWithHttpInfo indicates an expected call of GetBackupShardIdExecuteWithHttpInfo.
+func (mr *MockBackupApiMockRecorder) GetBackupShardIdExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBackupShardIdExecuteWithHttpInfo", reflect.TypeOf((*MockBackupApi)(nil).GetBackupShardIdExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.

--- a/internal/mock/api_bucket_schemas.gen.go
+++ b/internal/mock/api_bucket_schemas.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -64,6 +65,22 @@ func (mr *MockBucketSchemasApiMockRecorder) CreateMeasurementSchemaExecute(arg0 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMeasurementSchemaExecute", reflect.TypeOf((*MockBucketSchemasApi)(nil).CreateMeasurementSchemaExecute), arg0)
 }
 
+// CreateMeasurementSchemaExecuteWithHttpInfo mocks base method.
+func (m *MockBucketSchemasApi) CreateMeasurementSchemaExecuteWithHttpInfo(arg0 api.ApiCreateMeasurementSchemaRequest) (api.MeasurementSchema, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateMeasurementSchemaExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.MeasurementSchema)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateMeasurementSchemaExecuteWithHttpInfo indicates an expected call of CreateMeasurementSchemaExecuteWithHttpInfo.
+func (mr *MockBucketSchemasApiMockRecorder) CreateMeasurementSchemaExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateMeasurementSchemaExecuteWithHttpInfo", reflect.TypeOf((*MockBucketSchemasApi)(nil).CreateMeasurementSchemaExecuteWithHttpInfo), arg0)
+}
+
 // GetMeasurementSchema mocks base method.
 func (m *MockBucketSchemasApi) GetMeasurementSchema(arg0 context.Context, arg1, arg2 string) api.ApiGetMeasurementSchemaRequest {
 	m.ctrl.T.Helper()
@@ -93,6 +110,22 @@ func (mr *MockBucketSchemasApiMockRecorder) GetMeasurementSchemaExecute(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeasurementSchemaExecute", reflect.TypeOf((*MockBucketSchemasApi)(nil).GetMeasurementSchemaExecute), arg0)
 }
 
+// GetMeasurementSchemaExecuteWithHttpInfo mocks base method.
+func (m *MockBucketSchemasApi) GetMeasurementSchemaExecuteWithHttpInfo(arg0 api.ApiGetMeasurementSchemaRequest) (api.MeasurementSchema, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeasurementSchemaExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.MeasurementSchema)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetMeasurementSchemaExecuteWithHttpInfo indicates an expected call of GetMeasurementSchemaExecuteWithHttpInfo.
+func (mr *MockBucketSchemasApiMockRecorder) GetMeasurementSchemaExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeasurementSchemaExecuteWithHttpInfo", reflect.TypeOf((*MockBucketSchemasApi)(nil).GetMeasurementSchemaExecuteWithHttpInfo), arg0)
+}
+
 // GetMeasurementSchemas mocks base method.
 func (m *MockBucketSchemasApi) GetMeasurementSchemas(arg0 context.Context, arg1 string) api.ApiGetMeasurementSchemasRequest {
 	m.ctrl.T.Helper()
@@ -120,6 +153,22 @@ func (m *MockBucketSchemasApi) GetMeasurementSchemasExecute(arg0 api.ApiGetMeasu
 func (mr *MockBucketSchemasApiMockRecorder) GetMeasurementSchemasExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeasurementSchemasExecute", reflect.TypeOf((*MockBucketSchemasApi)(nil).GetMeasurementSchemasExecute), arg0)
+}
+
+// GetMeasurementSchemasExecuteWithHttpInfo mocks base method.
+func (m *MockBucketSchemasApi) GetMeasurementSchemasExecuteWithHttpInfo(arg0 api.ApiGetMeasurementSchemasRequest) (api.MeasurementSchemaList, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMeasurementSchemasExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.MeasurementSchemaList)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetMeasurementSchemasExecuteWithHttpInfo indicates an expected call of GetMeasurementSchemasExecuteWithHttpInfo.
+func (mr *MockBucketSchemasApiMockRecorder) GetMeasurementSchemasExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMeasurementSchemasExecuteWithHttpInfo", reflect.TypeOf((*MockBucketSchemasApi)(nil).GetMeasurementSchemasExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.
@@ -177,4 +226,20 @@ func (m *MockBucketSchemasApi) UpdateMeasurementSchemaExecute(arg0 api.ApiUpdate
 func (mr *MockBucketSchemasApiMockRecorder) UpdateMeasurementSchemaExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeasurementSchemaExecute", reflect.TypeOf((*MockBucketSchemasApi)(nil).UpdateMeasurementSchemaExecute), arg0)
+}
+
+// UpdateMeasurementSchemaExecuteWithHttpInfo mocks base method.
+func (m *MockBucketSchemasApi) UpdateMeasurementSchemaExecuteWithHttpInfo(arg0 api.ApiUpdateMeasurementSchemaRequest) (api.MeasurementSchema, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMeasurementSchemaExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.MeasurementSchema)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UpdateMeasurementSchemaExecuteWithHttpInfo indicates an expected call of UpdateMeasurementSchemaExecuteWithHttpInfo.
+func (mr *MockBucketSchemasApiMockRecorder) UpdateMeasurementSchemaExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMeasurementSchemaExecuteWithHttpInfo", reflect.TypeOf((*MockBucketSchemasApi)(nil).UpdateMeasurementSchemaExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_buckets.gen.go
+++ b/internal/mock/api_buckets.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -63,6 +64,21 @@ func (mr *MockBucketsApiMockRecorder) DeleteBucketsIDExecute(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucketsIDExecute", reflect.TypeOf((*MockBucketsApi)(nil).DeleteBucketsIDExecute), arg0)
 }
 
+// DeleteBucketsIDExecuteWithHttpInfo mocks base method.
+func (m *MockBucketsApi) DeleteBucketsIDExecuteWithHttpInfo(arg0 api.ApiDeleteBucketsIDRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBucketsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteBucketsIDExecuteWithHttpInfo indicates an expected call of DeleteBucketsIDExecuteWithHttpInfo.
+func (mr *MockBucketsApiMockRecorder) DeleteBucketsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucketsIDExecuteWithHttpInfo", reflect.TypeOf((*MockBucketsApi)(nil).DeleteBucketsIDExecuteWithHttpInfo), arg0)
+}
+
 // GetBuckets mocks base method.
 func (m *MockBucketsApi) GetBuckets(arg0 context.Context) api.ApiGetBucketsRequest {
 	m.ctrl.T.Helper()
@@ -92,6 +108,22 @@ func (mr *MockBucketsApiMockRecorder) GetBucketsExecute(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketsExecute", reflect.TypeOf((*MockBucketsApi)(nil).GetBucketsExecute), arg0)
 }
 
+// GetBucketsExecuteWithHttpInfo mocks base method.
+func (m *MockBucketsApi) GetBucketsExecuteWithHttpInfo(arg0 api.ApiGetBucketsRequest) (api.Buckets, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBucketsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Buckets)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBucketsExecuteWithHttpInfo indicates an expected call of GetBucketsExecuteWithHttpInfo.
+func (mr *MockBucketsApiMockRecorder) GetBucketsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketsExecuteWithHttpInfo", reflect.TypeOf((*MockBucketsApi)(nil).GetBucketsExecuteWithHttpInfo), arg0)
+}
+
 // GetBucketsID mocks base method.
 func (m *MockBucketsApi) GetBucketsID(arg0 context.Context, arg1 string) api.ApiGetBucketsIDRequest {
 	m.ctrl.T.Helper()
@@ -119,6 +151,22 @@ func (m *MockBucketsApi) GetBucketsIDExecute(arg0 api.ApiGetBucketsIDRequest) (a
 func (mr *MockBucketsApiMockRecorder) GetBucketsIDExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketsIDExecute", reflect.TypeOf((*MockBucketsApi)(nil).GetBucketsIDExecute), arg0)
+}
+
+// GetBucketsIDExecuteWithHttpInfo mocks base method.
+func (m *MockBucketsApi) GetBucketsIDExecuteWithHttpInfo(arg0 api.ApiGetBucketsIDRequest) (api.Bucket, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBucketsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Bucket)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetBucketsIDExecuteWithHttpInfo indicates an expected call of GetBucketsIDExecuteWithHttpInfo.
+func (mr *MockBucketsApiMockRecorder) GetBucketsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketsIDExecuteWithHttpInfo", reflect.TypeOf((*MockBucketsApi)(nil).GetBucketsIDExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.
@@ -178,6 +226,22 @@ func (mr *MockBucketsApiMockRecorder) PatchBucketsIDExecute(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBucketsIDExecute", reflect.TypeOf((*MockBucketsApi)(nil).PatchBucketsIDExecute), arg0)
 }
 
+// PatchBucketsIDExecuteWithHttpInfo mocks base method.
+func (m *MockBucketsApi) PatchBucketsIDExecuteWithHttpInfo(arg0 api.ApiPatchBucketsIDRequest) (api.Bucket, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchBucketsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Bucket)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PatchBucketsIDExecuteWithHttpInfo indicates an expected call of PatchBucketsIDExecuteWithHttpInfo.
+func (mr *MockBucketsApiMockRecorder) PatchBucketsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchBucketsIDExecuteWithHttpInfo", reflect.TypeOf((*MockBucketsApi)(nil).PatchBucketsIDExecuteWithHttpInfo), arg0)
+}
+
 // PostBuckets mocks base method.
 func (m *MockBucketsApi) PostBuckets(arg0 context.Context) api.ApiPostBucketsRequest {
 	m.ctrl.T.Helper()
@@ -205,4 +269,20 @@ func (m *MockBucketsApi) PostBucketsExecute(arg0 api.ApiPostBucketsRequest) (api
 func (mr *MockBucketsApiMockRecorder) PostBucketsExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBucketsExecute", reflect.TypeOf((*MockBucketsApi)(nil).PostBucketsExecute), arg0)
+}
+
+// PostBucketsExecuteWithHttpInfo mocks base method.
+func (m *MockBucketsApi) PostBucketsExecuteWithHttpInfo(arg0 api.ApiPostBucketsRequest) (api.Bucket, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostBucketsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Bucket)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostBucketsExecuteWithHttpInfo indicates an expected call of PostBucketsExecuteWithHttpInfo.
+func (mr *MockBucketsApiMockRecorder) PostBucketsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostBucketsExecuteWithHttpInfo", reflect.TypeOf((*MockBucketsApi)(nil).PostBucketsExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_delete.gen.go
+++ b/internal/mock/api_delete.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -89,4 +90,19 @@ func (m *MockDeleteApi) PostDeleteExecute(arg0 api.ApiPostDeleteRequest) error {
 func (mr *MockDeleteApiMockRecorder) PostDeleteExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeleteExecute", reflect.TypeOf((*MockDeleteApi)(nil).PostDeleteExecute), arg0)
+}
+
+// PostDeleteExecuteWithHttpInfo mocks base method.
+func (m *MockDeleteApi) PostDeleteExecuteWithHttpInfo(arg0 api.ApiPostDeleteRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostDeleteExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostDeleteExecuteWithHttpInfo indicates an expected call of PostDeleteExecuteWithHttpInfo.
+func (mr *MockDeleteApiMockRecorder) PostDeleteExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDeleteExecuteWithHttpInfo", reflect.TypeOf((*MockDeleteApi)(nil).PostDeleteExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_health.gen.go
+++ b/internal/mock/api_health.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -62,6 +63,22 @@ func (m *MockHealthApi) GetHealthExecute(arg0 api.ApiGetHealthRequest) (api.Heal
 func (mr *MockHealthApiMockRecorder) GetHealthExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHealthExecute", reflect.TypeOf((*MockHealthApi)(nil).GetHealthExecute), arg0)
+}
+
+// GetHealthExecuteWithHttpInfo mocks base method.
+func (m *MockHealthApi) GetHealthExecuteWithHttpInfo(arg0 api.ApiGetHealthRequest) (api.HealthCheck, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHealthExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.HealthCheck)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetHealthExecuteWithHttpInfo indicates an expected call of GetHealthExecuteWithHttpInfo.
+func (mr *MockHealthApiMockRecorder) GetHealthExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHealthExecuteWithHttpInfo", reflect.TypeOf((*MockHealthApi)(nil).GetHealthExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.

--- a/internal/mock/api_organizations.gen.go
+++ b/internal/mock/api_organizations.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -63,6 +64,21 @@ func (mr *MockOrganizationsApiMockRecorder) DeleteOrgsIDExecute(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).DeleteOrgsIDExecute), arg0)
 }
 
+// DeleteOrgsIDExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) DeleteOrgsIDExecuteWithHttpInfo(arg0 api.ApiDeleteOrgsIDRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrgsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOrgsIDExecuteWithHttpInfo indicates an expected call of DeleteOrgsIDExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) DeleteOrgsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).DeleteOrgsIDExecuteWithHttpInfo), arg0)
+}
+
 // DeleteOrgsIDMembersID mocks base method.
 func (m *MockOrganizationsApi) DeleteOrgsIDMembersID(arg0 context.Context, arg1, arg2 string) api.ApiDeleteOrgsIDMembersIDRequest {
 	m.ctrl.T.Helper()
@@ -89,6 +105,21 @@ func (m *MockOrganizationsApi) DeleteOrgsIDMembersIDExecute(arg0 api.ApiDeleteOr
 func (mr *MockOrganizationsApiMockRecorder) DeleteOrgsIDMembersIDExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDMembersIDExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).DeleteOrgsIDMembersIDExecute), arg0)
+}
+
+// DeleteOrgsIDMembersIDExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) DeleteOrgsIDMembersIDExecuteWithHttpInfo(arg0 api.ApiDeleteOrgsIDMembersIDRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrgsIDMembersIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOrgsIDMembersIDExecuteWithHttpInfo indicates an expected call of DeleteOrgsIDMembersIDExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) DeleteOrgsIDMembersIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDMembersIDExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).DeleteOrgsIDMembersIDExecuteWithHttpInfo), arg0)
 }
 
 // GetOrgs mocks base method.
@@ -120,6 +151,22 @@ func (mr *MockOrganizationsApiMockRecorder) GetOrgsExecute(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).GetOrgsExecute), arg0)
 }
 
+// GetOrgsExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) GetOrgsExecuteWithHttpInfo(arg0 api.ApiGetOrgsRequest) (api.Organizations, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Organizations)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrgsExecuteWithHttpInfo indicates an expected call of GetOrgsExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) GetOrgsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).GetOrgsExecuteWithHttpInfo), arg0)
+}
+
 // GetOrgsID mocks base method.
 func (m *MockOrganizationsApi) GetOrgsID(arg0 context.Context, arg1 string) api.ApiGetOrgsIDRequest {
 	m.ctrl.T.Helper()
@@ -149,6 +196,22 @@ func (mr *MockOrganizationsApiMockRecorder) GetOrgsIDExecute(arg0 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsIDExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).GetOrgsIDExecute), arg0)
 }
 
+// GetOrgsIDExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) GetOrgsIDExecuteWithHttpInfo(arg0 api.ApiGetOrgsIDRequest) (api.Organization, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Organization)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrgsIDExecuteWithHttpInfo indicates an expected call of GetOrgsIDExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) GetOrgsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsIDExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).GetOrgsIDExecuteWithHttpInfo), arg0)
+}
+
 // GetOrgsIDMembers mocks base method.
 func (m *MockOrganizationsApi) GetOrgsIDMembers(arg0 context.Context, arg1 string) api.ApiGetOrgsIDMembersRequest {
 	m.ctrl.T.Helper()
@@ -176,6 +239,22 @@ func (m *MockOrganizationsApi) GetOrgsIDMembersExecute(arg0 api.ApiGetOrgsIDMemb
 func (mr *MockOrganizationsApiMockRecorder) GetOrgsIDMembersExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsIDMembersExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).GetOrgsIDMembersExecute), arg0)
+}
+
+// GetOrgsIDMembersExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) GetOrgsIDMembersExecuteWithHttpInfo(arg0 api.ApiGetOrgsIDMembersRequest) (api.ResourceMembers, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgsIDMembersExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.ResourceMembers)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrgsIDMembersExecuteWithHttpInfo indicates an expected call of GetOrgsIDMembersExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) GetOrgsIDMembersExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsIDMembersExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).GetOrgsIDMembersExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.
@@ -235,6 +314,22 @@ func (mr *MockOrganizationsApiMockRecorder) PatchOrgsIDExecute(arg0 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchOrgsIDExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).PatchOrgsIDExecute), arg0)
 }
 
+// PatchOrgsIDExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) PatchOrgsIDExecuteWithHttpInfo(arg0 api.ApiPatchOrgsIDRequest) (api.Organization, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchOrgsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Organization)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PatchOrgsIDExecuteWithHttpInfo indicates an expected call of PatchOrgsIDExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) PatchOrgsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchOrgsIDExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).PatchOrgsIDExecuteWithHttpInfo), arg0)
+}
+
 // PostOrgs mocks base method.
 func (m *MockOrganizationsApi) PostOrgs(arg0 context.Context) api.ApiPostOrgsRequest {
 	m.ctrl.T.Helper()
@@ -264,6 +359,22 @@ func (mr *MockOrganizationsApiMockRecorder) PostOrgsExecute(arg0 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostOrgsExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).PostOrgsExecute), arg0)
 }
 
+// PostOrgsExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) PostOrgsExecuteWithHttpInfo(arg0 api.ApiPostOrgsRequest) (api.Organization, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostOrgsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Organization)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostOrgsExecuteWithHttpInfo indicates an expected call of PostOrgsExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) PostOrgsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostOrgsExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).PostOrgsExecuteWithHttpInfo), arg0)
+}
+
 // PostOrgsIDMembers mocks base method.
 func (m *MockOrganizationsApi) PostOrgsIDMembers(arg0 context.Context, arg1 string) api.ApiPostOrgsIDMembersRequest {
 	m.ctrl.T.Helper()
@@ -291,4 +402,20 @@ func (m *MockOrganizationsApi) PostOrgsIDMembersExecute(arg0 api.ApiPostOrgsIDMe
 func (mr *MockOrganizationsApiMockRecorder) PostOrgsIDMembersExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostOrgsIDMembersExecute", reflect.TypeOf((*MockOrganizationsApi)(nil).PostOrgsIDMembersExecute), arg0)
+}
+
+// PostOrgsIDMembersExecuteWithHttpInfo mocks base method.
+func (m *MockOrganizationsApi) PostOrgsIDMembersExecuteWithHttpInfo(arg0 api.ApiPostOrgsIDMembersRequest) (api.ResourceMember, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostOrgsIDMembersExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.ResourceMember)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostOrgsIDMembersExecuteWithHttpInfo indicates an expected call of PostOrgsIDMembersExecuteWithHttpInfo.
+func (mr *MockOrganizationsApiMockRecorder) PostOrgsIDMembersExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostOrgsIDMembersExecuteWithHttpInfo", reflect.TypeOf((*MockOrganizationsApi)(nil).PostOrgsIDMembersExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_query.gen.go
+++ b/internal/mock/api_query.gen.go
@@ -92,3 +92,19 @@ func (mr *MockQueryApiMockRecorder) PostQueryExecute(arg0 interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostQueryExecute", reflect.TypeOf((*MockQueryApi)(nil).PostQueryExecute), arg0)
 }
+
+// PostQueryExecuteWithHttpInfo mocks base method.
+func (m *MockQueryApi) PostQueryExecuteWithHttpInfo(arg0 api.ApiPostQueryRequest) (*http.Response, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostQueryExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostQueryExecuteWithHttpInfo indicates an expected call of PostQueryExecuteWithHttpInfo.
+func (mr *MockQueryApiMockRecorder) PostQueryExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostQueryExecuteWithHttpInfo", reflect.TypeOf((*MockQueryApi)(nil).PostQueryExecuteWithHttpInfo), arg0)
+}

--- a/internal/mock/api_secret.gen.go
+++ b/internal/mock/api_secret.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -64,6 +65,22 @@ func (mr *MockSecretsApiMockRecorder) GetOrgsIDSecretsExecute(arg0 interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsIDSecretsExecute", reflect.TypeOf((*MockSecretsApi)(nil).GetOrgsIDSecretsExecute), arg0)
 }
 
+// GetOrgsIDSecretsExecuteWithHttpInfo mocks base method.
+func (m *MockSecretsApi) GetOrgsIDSecretsExecuteWithHttpInfo(arg0 api.ApiGetOrgsIDSecretsRequest) (api.SecretKeysResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgsIDSecretsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.SecretKeysResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrgsIDSecretsExecuteWithHttpInfo indicates an expected call of GetOrgsIDSecretsExecuteWithHttpInfo.
+func (mr *MockSecretsApiMockRecorder) GetOrgsIDSecretsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgsIDSecretsExecuteWithHttpInfo", reflect.TypeOf((*MockSecretsApi)(nil).GetOrgsIDSecretsExecuteWithHttpInfo), arg0)
+}
+
 // OnlyCloud mocks base method.
 func (m *MockSecretsApi) OnlyCloud() api.SecretsApi {
 	m.ctrl.T.Helper()
@@ -120,6 +137,21 @@ func (mr *MockSecretsApiMockRecorder) PatchOrgsIDSecretsExecute(arg0 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchOrgsIDSecretsExecute", reflect.TypeOf((*MockSecretsApi)(nil).PatchOrgsIDSecretsExecute), arg0)
 }
 
+// PatchOrgsIDSecretsExecuteWithHttpInfo mocks base method.
+func (m *MockSecretsApi) PatchOrgsIDSecretsExecuteWithHttpInfo(arg0 api.ApiPatchOrgsIDSecretsRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchOrgsIDSecretsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PatchOrgsIDSecretsExecuteWithHttpInfo indicates an expected call of PatchOrgsIDSecretsExecuteWithHttpInfo.
+func (mr *MockSecretsApiMockRecorder) PatchOrgsIDSecretsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchOrgsIDSecretsExecuteWithHttpInfo", reflect.TypeOf((*MockSecretsApi)(nil).PatchOrgsIDSecretsExecuteWithHttpInfo), arg0)
+}
+
 // PostOrgsIDSecrets mocks base method.
 func (m *MockSecretsApi) PostOrgsIDSecrets(arg0 context.Context, arg1 string) api.ApiPostOrgsIDSecretsRequest {
 	m.ctrl.T.Helper()
@@ -146,4 +178,19 @@ func (m *MockSecretsApi) PostOrgsIDSecretsExecute(arg0 api.ApiPostOrgsIDSecretsR
 func (mr *MockSecretsApiMockRecorder) PostOrgsIDSecretsExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostOrgsIDSecretsExecute", reflect.TypeOf((*MockSecretsApi)(nil).PostOrgsIDSecretsExecute), arg0)
+}
+
+// PostOrgsIDSecretsExecuteWithHttpInfo mocks base method.
+func (m *MockSecretsApi) PostOrgsIDSecretsExecuteWithHttpInfo(arg0 api.ApiPostOrgsIDSecretsRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostOrgsIDSecretsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostOrgsIDSecretsExecuteWithHttpInfo indicates an expected call of PostOrgsIDSecretsExecuteWithHttpInfo.
+func (mr *MockSecretsApiMockRecorder) PostOrgsIDSecretsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostOrgsIDSecretsExecuteWithHttpInfo", reflect.TypeOf((*MockSecretsApi)(nil).PostOrgsIDSecretsExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_setup.gen.go
+++ b/internal/mock/api_setup.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -64,6 +65,22 @@ func (mr *MockSetupApiMockRecorder) GetSetupExecute(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSetupExecute", reflect.TypeOf((*MockSetupApi)(nil).GetSetupExecute), arg0)
 }
 
+// GetSetupExecuteWithHttpInfo mocks base method.
+func (m *MockSetupApi) GetSetupExecuteWithHttpInfo(arg0 api.ApiGetSetupRequest) (api.InlineResponse200, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSetupExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.InlineResponse200)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetSetupExecuteWithHttpInfo indicates an expected call of GetSetupExecuteWithHttpInfo.
+func (mr *MockSetupApiMockRecorder) GetSetupExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSetupExecuteWithHttpInfo", reflect.TypeOf((*MockSetupApi)(nil).GetSetupExecuteWithHttpInfo), arg0)
+}
+
 // OnlyCloud mocks base method.
 func (m *MockSetupApi) OnlyCloud() api.SetupApi {
 	m.ctrl.T.Helper()
@@ -119,4 +136,20 @@ func (m *MockSetupApi) PostSetupExecute(arg0 api.ApiPostSetupRequest) (api.Onboa
 func (mr *MockSetupApiMockRecorder) PostSetupExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostSetupExecute", reflect.TypeOf((*MockSetupApi)(nil).PostSetupExecute), arg0)
+}
+
+// PostSetupExecuteWithHttpInfo mocks base method.
+func (m *MockSetupApi) PostSetupExecuteWithHttpInfo(arg0 api.ApiPostSetupRequest) (api.OnboardingResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostSetupExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.OnboardingResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostSetupExecuteWithHttpInfo indicates an expected call of PostSetupExecuteWithHttpInfo.
+func (mr *MockSetupApiMockRecorder) PostSetupExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostSetupExecuteWithHttpInfo", reflect.TypeOf((*MockSetupApi)(nil).PostSetupExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_users.gen.go
+++ b/internal/mock/api_users.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -63,6 +64,21 @@ func (mr *MockUsersApiMockRecorder) DeleteUsersIDExecute(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUsersIDExecute", reflect.TypeOf((*MockUsersApi)(nil).DeleteUsersIDExecute), arg0)
 }
 
+// DeleteUsersIDExecuteWithHttpInfo mocks base method.
+func (m *MockUsersApi) DeleteUsersIDExecuteWithHttpInfo(arg0 api.ApiDeleteUsersIDRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteUsersIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteUsersIDExecuteWithHttpInfo indicates an expected call of DeleteUsersIDExecuteWithHttpInfo.
+func (mr *MockUsersApiMockRecorder) DeleteUsersIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUsersIDExecuteWithHttpInfo", reflect.TypeOf((*MockUsersApi)(nil).DeleteUsersIDExecuteWithHttpInfo), arg0)
+}
+
 // GetUsers mocks base method.
 func (m *MockUsersApi) GetUsers(arg0 context.Context) api.ApiGetUsersRequest {
 	m.ctrl.T.Helper()
@@ -92,6 +108,22 @@ func (mr *MockUsersApiMockRecorder) GetUsersExecute(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersExecute", reflect.TypeOf((*MockUsersApi)(nil).GetUsersExecute), arg0)
 }
 
+// GetUsersExecuteWithHttpInfo mocks base method.
+func (m *MockUsersApi) GetUsersExecuteWithHttpInfo(arg0 api.ApiGetUsersRequest) (api.Users, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsersExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.Users)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsersExecuteWithHttpInfo indicates an expected call of GetUsersExecuteWithHttpInfo.
+func (mr *MockUsersApiMockRecorder) GetUsersExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersExecuteWithHttpInfo", reflect.TypeOf((*MockUsersApi)(nil).GetUsersExecuteWithHttpInfo), arg0)
+}
+
 // GetUsersID mocks base method.
 func (m *MockUsersApi) GetUsersID(arg0 context.Context, arg1 string) api.ApiGetUsersIDRequest {
 	m.ctrl.T.Helper()
@@ -119,6 +151,22 @@ func (m *MockUsersApi) GetUsersIDExecute(arg0 api.ApiGetUsersIDRequest) (api.Use
 func (mr *MockUsersApiMockRecorder) GetUsersIDExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersIDExecute", reflect.TypeOf((*MockUsersApi)(nil).GetUsersIDExecute), arg0)
+}
+
+// GetUsersIDExecuteWithHttpInfo mocks base method.
+func (m *MockUsersApi) GetUsersIDExecuteWithHttpInfo(arg0 api.ApiGetUsersIDRequest) (api.UserResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUsersIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.UserResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetUsersIDExecuteWithHttpInfo indicates an expected call of GetUsersIDExecuteWithHttpInfo.
+func (mr *MockUsersApiMockRecorder) GetUsersIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsersIDExecuteWithHttpInfo", reflect.TypeOf((*MockUsersApi)(nil).GetUsersIDExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.
@@ -178,6 +226,22 @@ func (mr *MockUsersApiMockRecorder) PatchUsersIDExecute(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchUsersIDExecute", reflect.TypeOf((*MockUsersApi)(nil).PatchUsersIDExecute), arg0)
 }
 
+// PatchUsersIDExecuteWithHttpInfo mocks base method.
+func (m *MockUsersApi) PatchUsersIDExecuteWithHttpInfo(arg0 api.ApiPatchUsersIDRequest) (api.UserResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchUsersIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.UserResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PatchUsersIDExecuteWithHttpInfo indicates an expected call of PatchUsersIDExecuteWithHttpInfo.
+func (mr *MockUsersApiMockRecorder) PatchUsersIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchUsersIDExecuteWithHttpInfo", reflect.TypeOf((*MockUsersApi)(nil).PatchUsersIDExecuteWithHttpInfo), arg0)
+}
+
 // PostUsers mocks base method.
 func (m *MockUsersApi) PostUsers(arg0 context.Context) api.ApiPostUsersRequest {
 	m.ctrl.T.Helper()
@@ -207,6 +271,22 @@ func (mr *MockUsersApiMockRecorder) PostUsersExecute(arg0 interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostUsersExecute", reflect.TypeOf((*MockUsersApi)(nil).PostUsersExecute), arg0)
 }
 
+// PostUsersExecuteWithHttpInfo mocks base method.
+func (m *MockUsersApi) PostUsersExecuteWithHttpInfo(arg0 api.ApiPostUsersRequest) (api.UserResponse, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostUsersExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.UserResponse)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostUsersExecuteWithHttpInfo indicates an expected call of PostUsersExecuteWithHttpInfo.
+func (mr *MockUsersApiMockRecorder) PostUsersExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostUsersExecuteWithHttpInfo", reflect.TypeOf((*MockUsersApi)(nil).PostUsersExecuteWithHttpInfo), arg0)
+}
+
 // PostUsersIDPassword mocks base method.
 func (m *MockUsersApi) PostUsersIDPassword(arg0 context.Context, arg1 string) api.ApiPostUsersIDPasswordRequest {
 	m.ctrl.T.Helper()
@@ -233,4 +313,19 @@ func (m *MockUsersApi) PostUsersIDPasswordExecute(arg0 api.ApiPostUsersIDPasswor
 func (mr *MockUsersApiMockRecorder) PostUsersIDPasswordExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostUsersIDPasswordExecute", reflect.TypeOf((*MockUsersApi)(nil).PostUsersIDPasswordExecute), arg0)
+}
+
+// PostUsersIDPasswordExecuteWithHttpInfo mocks base method.
+func (m *MockUsersApi) PostUsersIDPasswordExecuteWithHttpInfo(arg0 api.ApiPostUsersIDPasswordRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostUsersIDPasswordExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostUsersIDPasswordExecuteWithHttpInfo indicates an expected call of PostUsersIDPasswordExecuteWithHttpInfo.
+func (mr *MockUsersApiMockRecorder) PostUsersIDPasswordExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostUsersIDPasswordExecuteWithHttpInfo", reflect.TypeOf((*MockUsersApi)(nil).PostUsersIDPasswordExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_v1dbrps.gen.go
+++ b/internal/mock/api_v1dbrps.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -63,6 +64,21 @@ func (mr *MockDBRPsApiMockRecorder) DeleteDBRPIDExecute(arg0 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDBRPIDExecute", reflect.TypeOf((*MockDBRPsApi)(nil).DeleteDBRPIDExecute), arg0)
 }
 
+// DeleteDBRPIDExecuteWithHttpInfo mocks base method.
+func (m *MockDBRPsApi) DeleteDBRPIDExecuteWithHttpInfo(arg0 api.ApiDeleteDBRPIDRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDBRPIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteDBRPIDExecuteWithHttpInfo indicates an expected call of DeleteDBRPIDExecuteWithHttpInfo.
+func (mr *MockDBRPsApiMockRecorder) DeleteDBRPIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDBRPIDExecuteWithHttpInfo", reflect.TypeOf((*MockDBRPsApi)(nil).DeleteDBRPIDExecuteWithHttpInfo), arg0)
+}
+
 // GetDBRPs mocks base method.
 func (m *MockDBRPsApi) GetDBRPs(arg0 context.Context) api.ApiGetDBRPsRequest {
 	m.ctrl.T.Helper()
@@ -92,6 +108,22 @@ func (mr *MockDBRPsApiMockRecorder) GetDBRPsExecute(arg0 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDBRPsExecute", reflect.TypeOf((*MockDBRPsApi)(nil).GetDBRPsExecute), arg0)
 }
 
+// GetDBRPsExecuteWithHttpInfo mocks base method.
+func (m *MockDBRPsApi) GetDBRPsExecuteWithHttpInfo(arg0 api.ApiGetDBRPsRequest) (api.DBRPs, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDBRPsExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.DBRPs)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDBRPsExecuteWithHttpInfo indicates an expected call of GetDBRPsExecuteWithHttpInfo.
+func (mr *MockDBRPsApiMockRecorder) GetDBRPsExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDBRPsExecuteWithHttpInfo", reflect.TypeOf((*MockDBRPsApi)(nil).GetDBRPsExecuteWithHttpInfo), arg0)
+}
+
 // GetDBRPsID mocks base method.
 func (m *MockDBRPsApi) GetDBRPsID(arg0 context.Context, arg1 string) api.ApiGetDBRPsIDRequest {
 	m.ctrl.T.Helper()
@@ -119,6 +151,22 @@ func (m *MockDBRPsApi) GetDBRPsIDExecute(arg0 api.ApiGetDBRPsIDRequest) (api.DBR
 func (mr *MockDBRPsApiMockRecorder) GetDBRPsIDExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDBRPsIDExecute", reflect.TypeOf((*MockDBRPsApi)(nil).GetDBRPsIDExecute), arg0)
+}
+
+// GetDBRPsIDExecuteWithHttpInfo mocks base method.
+func (m *MockDBRPsApi) GetDBRPsIDExecuteWithHttpInfo(arg0 api.ApiGetDBRPsIDRequest) (api.DBRPGet, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDBRPsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.DBRPGet)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetDBRPsIDExecuteWithHttpInfo indicates an expected call of GetDBRPsIDExecuteWithHttpInfo.
+func (mr *MockDBRPsApiMockRecorder) GetDBRPsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDBRPsIDExecuteWithHttpInfo", reflect.TypeOf((*MockDBRPsApi)(nil).GetDBRPsIDExecuteWithHttpInfo), arg0)
 }
 
 // OnlyCloud mocks base method.
@@ -178,6 +226,22 @@ func (mr *MockDBRPsApiMockRecorder) PatchDBRPIDExecute(arg0 interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDBRPIDExecute", reflect.TypeOf((*MockDBRPsApi)(nil).PatchDBRPIDExecute), arg0)
 }
 
+// PatchDBRPIDExecuteWithHttpInfo mocks base method.
+func (m *MockDBRPsApi) PatchDBRPIDExecuteWithHttpInfo(arg0 api.ApiPatchDBRPIDRequest) (api.DBRPGet, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchDBRPIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.DBRPGet)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PatchDBRPIDExecuteWithHttpInfo indicates an expected call of PatchDBRPIDExecuteWithHttpInfo.
+func (mr *MockDBRPsApiMockRecorder) PatchDBRPIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchDBRPIDExecuteWithHttpInfo", reflect.TypeOf((*MockDBRPsApi)(nil).PatchDBRPIDExecuteWithHttpInfo), arg0)
+}
+
 // PostDBRP mocks base method.
 func (m *MockDBRPsApi) PostDBRP(arg0 context.Context) api.ApiPostDBRPRequest {
 	m.ctrl.T.Helper()
@@ -205,4 +269,20 @@ func (m *MockDBRPsApi) PostDBRPExecute(arg0 api.ApiPostDBRPRequest) (api.DBRP, e
 func (mr *MockDBRPsApiMockRecorder) PostDBRPExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDBRPExecute", reflect.TypeOf((*MockDBRPsApi)(nil).PostDBRPExecute), arg0)
+}
+
+// PostDBRPExecuteWithHttpInfo mocks base method.
+func (m *MockDBRPsApi) PostDBRPExecuteWithHttpInfo(arg0 api.ApiPostDBRPRequest) (api.DBRP, *http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostDBRPExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(api.DBRP)
+	ret1, _ := ret[1].(*http.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// PostDBRPExecuteWithHttpInfo indicates an expected call of PostDBRPExecuteWithHttpInfo.
+func (mr *MockDBRPsApiMockRecorder) PostDBRPExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostDBRPExecuteWithHttpInfo", reflect.TypeOf((*MockDBRPsApi)(nil).PostDBRPExecuteWithHttpInfo), arg0)
 }

--- a/internal/mock/api_write.gen.go
+++ b/internal/mock/api_write.gen.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	context "context"
+	http "net/http"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -89,4 +90,19 @@ func (m *MockWriteApi) PostWriteExecute(arg0 api.ApiPostWriteRequest) error {
 func (mr *MockWriteApiMockRecorder) PostWriteExecute(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostWriteExecute", reflect.TypeOf((*MockWriteApi)(nil).PostWriteExecute), arg0)
+}
+
+// PostWriteExecuteWithHttpInfo mocks base method.
+func (m *MockWriteApi) PostWriteExecuteWithHttpInfo(arg0 api.ApiPostWriteRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PostWriteExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PostWriteExecuteWithHttpInfo indicates an expected call of PostWriteExecuteWithHttpInfo.
+func (mr *MockWriteApiMockRecorder) PostWriteExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PostWriteExecuteWithHttpInfo", reflect.TypeOf((*MockWriteApi)(nil).PostWriteExecuteWithHttpInfo), arg0)
 }


### PR DESCRIPTION
Closes #335

This creates additional methods for generated API clients that can be used to obtain the full HTTP response object. This is needed for things like the OSS 2.x replications feature, which must inspect response codes and headers to determine appropriate retry actions. No existing CLI operations should be impacted by these additional methods, although they could use them in the future if needed.