### PR TITLE
fix: Use influx-debug-id header

### DIFF
--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -245,6 +245,13 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		}
 		log.Printf("\n%s\n", string(dump))
 	}
+	if resp.Header.Get("trace-sampled") == "true" {
+		tracePrefix := "trace-id: "
+		if prefix, found := os.LookupEnv("INFLUX_CLI_TRACE_PRINT_PREFIX"); found {
+			tracePrefix = prefix
+		}
+		fmt.Fprintf(os.Stderr, "%s%s\n", tracePrefix, resp.Header.Get("trace-id"))
+	}
 	return resp, err
 }
 

--- a/api/configuration_default.go
+++ b/api/configuration_default.go
@@ -37,6 +37,7 @@ func NewAPIConfig(params ConfigParams) *Configuration {
 		// use codegen'd logic to set the header on every HTTP request. Early versions of the CLI
 		// used that technique, and we found it to be error-prone and easy to forget during testing.
 		apiConfig.DefaultHeader["Zap-Trace-Span"] = *params.TraceId
+		apiConfig.DefaultHeader["influx-debug-id"] = *params.TraceId
 	}
 	apiConfig.Debug = params.Debug
 

--- a/api/templates/client.mustache
+++ b/api/templates/client.mustache
@@ -191,6 +191,13 @@ func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 		}
 		log.Printf("\n%s\n", string(dump))
 	}
+	if resp.Header.Get("trace-sampled") == "true" {
+		tracePrefix := "trace-id: "
+		if prefix, found := os.LookupEnv("INFLUX_CLI_TRACE_PRINT_PREFIX"); found {
+			tracePrefix = prefix
+		}
+		fmt.Fprintf(os.Stderr, "%s%s\n", tracePrefix, resp.Header.Get("trace-id"))
+	}
 	return resp, err
 }
 
@@ -354,7 +361,7 @@ func (c *APIClient) prepareRequest(
 				reader = strings.NewReader(body.String())
 			}
 
-			// Define default values for region and service to maintain backward compatibility 
+			// Define default values for region and service to maintain backward compatibility
 			region := auth.Region
 			if region == "" {
 				region = "eu-west-2"


### PR DESCRIPTION
Influxdata cloud2 uses a different mechanism to enable tracing.
You need to pass a `influx-debug-id` header (the value is ignored) and if the response contains
`trace-sampled: true` then the response's `trace-id` header contains a valid trace ID that can be
used to jump to the trace in jaeger.

If the request has been sampled, we print the trace-id to stderr.

Since modern terminals allow to click on hyperlinks, we could avoid a copy&paste of the trace id
if the `influx` binary wrote a the link to the jeager trace.
However, we don't want to hardcode the URL of the internal jaeger endpoint in the binary.

I tried adding a wrapper script on my machine that would just capture the trace-id and render it, but it's
hard to do without messing with the ordering of the stderr and stdout lines.
Thus I preferred adding a secret env var that controls the formatting of the trace-id and can be used
by our devs to generate links to our internal jaeger instance.

```console
$ export INFLUX_CLI_TRACE_PRINT_PREFIX="Trace: https://jaeger.my.cloud/trace/"
$ influx query --trace-debug-id 123 -f query.flux
Trace: https://jaeger.my.cloud/trace/f39a69354a3acca6
Result: _result
Table: keys: [_measurement]
...
```