### PR TITLE
fix: jsonnet files in `influx apply` return a 422 error

### DIFF
--- a/pkg/template/source.go
+++ b/pkg/template/source.go
@@ -87,7 +87,7 @@ func SourcesFromPath(path string, recur bool, encoding Encoding) ([]Source, erro
 		}
 
 		sources[i] = Source{
-			Name:     path,
+			Name:     strings.TrimSuffix(path, filepath.Ext(path)),
 			Encoding: encoding,
 			Open: func(context.Context) (io.ReadCloser, error) {
 				return os.Open(path)


### PR DESCRIPTION
Closes #351 

This isn't the "ideal" fix, as much of the code in `client.gen.go`/`client.mustache` is unnecessary and overcomplicated, but this PR fixes the `jsonnet` file ext being passed along to the server, which is simply incorrect since we are correctly sending JSON-serialized data. The `Content-Type` header is properly being set as `application/json`, so there should be no risk of data confusion.

I will open a follow-up issue to fix the panic on receiving a 422 error, and to refactor the code further to not send the data as a form and follow a better API call structure