### PR TITLE
fix: 422 error handling panic

### DIFF
--- a/api/client.gen.go
+++ b/api/client.gen.go
@@ -596,10 +596,13 @@ func (e GenericOpenAPIError) BuildHeader() string {
 
 // Error returns non-empty string if there was an error.
 func (e GenericOpenAPIError) Error() string {
+	if e.error != "" {
+		return e.error
+	}
 	if e.model != nil {
 		return e.model.Error()
 	}
-	return e.error
+	panic("errorless GenericOpenAPIError used as an error!")
 }
 
 // Model returns the unpacked model of the error

--- a/api/templates/client.mustache
+++ b/api/templates/client.mustache
@@ -580,10 +580,13 @@ func (e GenericOpenAPIError) BuildHeader() string {
 
 // Error returns non-empty string if there was an error.
 func (e GenericOpenAPIError) Error() string {
+	if e.error != "" {
+		return e.error
+	}
 	if e.model != nil {
 		return e.model.Error()
 	}
-	return e.error
+	panic("errorless GenericOpenAPIError used as an error!")
 }
 
 // Model returns the unpacked model of the error


### PR DESCRIPTION
Previously, the error handling code in `client.gen.go` would panic when a 422 status code was received, because it prioritized calling `e.model.Error()`, but the 422 error only set the error in `e.error`, leading to the panic. This PR reverses the checked order for the error, though required a new panic case for if both `e.error` and `e.model.Error()` are errorless.