### PR TITLE
chore: improve logging for creating a new remote

### DIFF
--- a/clients/remote/remote.go
+++ b/clients/remote/remote.go
@@ -55,7 +55,7 @@ func (c Client) Create(ctx context.Context, params *CreateParams) error {
 	// send post request
 	res, err := c.PostRemoteConnection(ctx).RemoteConnectionCreationRequest(body).Execute()
 	if err != nil {
-		return fmt.Errorf("failed to create remote connection %q: %w", params.Name, err)
+		return fmt.Errorf("failed to create remote connection %q in local InfluxDB: %w", params.Name, err)
 	}
 
 	// print confirmation of new connection

--- a/clients/remote/remote.go
+++ b/clients/remote/remote.go
@@ -29,7 +29,13 @@ func (c Client) Create(ctx context.Context, params *CreateParams) error {
 
 	orgID, err := params.GetOrgID(ctx, c.ActiveConfig, c.OrganizationsApi)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to find local org id: %w", err)
+	}
+
+	// Test that the local org can be properly found for better error displaying
+	_, err = c.OrganizationsApi.GetOrgs(ctx).OrgID(orgID).Execute()
+	if err != nil {
+		return fmt.Errorf("failed to lookup local org: %w", err)
 	}
 
 	// set up a struct with required params


### PR DESCRIPTION
Improves error logging for setting up a new remote connection.

Alternatively this could have been done as a different error returned from the server, but this should be sufficient to display errors more clearly.