### PR TITLE
Speed up backup process by downloading multiple Shard Groups in parallel

### DIFF
--- a/clients/backup/backup.go
+++ b/clients/backup/backup.go
@@ -43,6 +43,9 @@ type Params struct {
 
 	// Compression to use for local copies of snapshot files.
 	Compression br.FileCompression
+
+	// Amount of Workers to create to copy bucket data in parallel.
+	Workers int
 }
 
 func (p *Params) matches(bkt api.BucketMetadataManifest) bool {
@@ -282,7 +285,7 @@ func (c *Client) downloadBucketData(ctx context.Context, params *Params) error {
 		if !params.matches(b) {
 			continue
 		}
-		bktManifest, err := br.ConvertBucketManifest(b, func(shardId int64) (*br.ManifestFileEntry, error) {
+		bktManifest, err := br.ConvertBucketManifest(b, params.Workers, func(shardId int64) (*br.ManifestFileEntry, error) {
 			return c.downloadShardData(ctx, params, shardId)
 		})
 		if err != nil {

--- a/clients/restore/manifest.go
+++ b/clients/restore/manifest.go
@@ -76,7 +76,7 @@ func convertManifest(path string, lm legacyManifest) (br.Manifest, error) {
 		Buckets: make([]br.ManifestBucketEntry, len(metadata)),
 	}
 	for i, bkt := range metadata {
-		m.Buckets[i], err = br.ConvertBucketManifest(bkt, func(shardId int64) (*br.ManifestFileEntry, error) {
+		m.Buckets[i], err = br.ConvertBucketManifest(bkt, 1, func(shardId int64) (*br.ManifestFileEntry, error) {
 			shardManifest, ok := shardManifestsById[shardId]
 			if !ok {
 				return nil, nil

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -42,6 +42,11 @@ Examples:
 				Usage: "Compression to use for local backup files, either 'none' or 'gzip'",
 				Value: &params.Compression,
 			},
+			&cli.IntFlag{
+				Name:        "workers",
+				Usage:       "Amount of Workers to create to copy bucket data in parallel",
+				Destination: &params.Workers,
+			},
 		),
 		Action: func(ctx *cli.Context) error {
 			if ctx.NArg() != 1 {

--- a/internal/backup_restore/manifest_test.go
+++ b/internal/backup_restore/manifest_test.go
@@ -98,7 +98,7 @@ func TestConvertBucketManifest(t *testing.T) {
 		}, nil
 	}
 
-	converted, err := br.ConvertBucketManifest(manifest, fakeGetShard)
+	converted, err := br.ConvertBucketManifest(manifest, 1, fakeGetShard)
 	require.NoError(t, err)
 
 	expected := br.ManifestBucketEntry{


### PR DESCRIPTION
Currently, the backup process downloads one shard at a time from the Influx API and stores it on the file system. This process tends to be very slow on larger databases, as it doesn't take advantage of large IO capacity which could speed up this process tremendously.

This PR introduces a pool of workers downloading a bunch of shards in parallel, split at the layer of shard groups,
because a shard group only holds a single shard in the Influx OSS version, which obviously wouldn't make sense to parallelize.

My benchmarked speedup of the parallelization in a VM running on my machine with a limited IO capacity is already 2 to 3 times, but is probably even more on a beefier system.