### PR TITLE
feat: add max age to replications create and update

### DIFF
--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -44,6 +44,7 @@ type WriteApi interface {
 		For more information and examples, see the following:
 		- [Write data with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/api).
 		- [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/).
+		- [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)
 
 			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 			 * @return ApiPostWriteRequest
@@ -188,6 +189,7 @@ InfluxDB Cloud enforces rate and size limits different from InfluxDB OSS. For de
 For more information and examples, see the following:
 - [Write data with the InfluxDB API]({{% INFLUXDB_DOCS_URL %}}/write-data/developer-tools/api).
 - [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/).
+- [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)
 
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiPostWriteRequest

--- a/api/model_replication_creation_request.gen.go
+++ b/api/model_replication_creation_request.gen.go
@@ -24,13 +24,14 @@ type ReplicationCreationRequest struct {
 	RemoteBucketID       string  `json:"remoteBucketID" yaml:"remoteBucketID"`
 	MaxQueueSizeBytes    int64   `json:"maxQueueSizeBytes" yaml:"maxQueueSizeBytes"`
 	DropNonRetryableData *bool   `json:"dropNonRetryableData,omitempty" yaml:"dropNonRetryableData,omitempty"`
+	MaxAgeSeconds        int64   `json:"maxAgeSeconds" yaml:"maxAgeSeconds"`
 }
 
 // NewReplicationCreationRequest instantiates a new ReplicationCreationRequest object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewReplicationCreationRequest(name string, orgID string, remoteID string, localBucketID string, remoteBucketID string, maxQueueSizeBytes int64) *ReplicationCreationRequest {
+func NewReplicationCreationRequest(name string, orgID string, remoteID string, localBucketID string, remoteBucketID string, maxQueueSizeBytes int64, maxAgeSeconds int64) *ReplicationCreationRequest {
 	this := ReplicationCreationRequest{}
 	this.Name = name
 	this.OrgID = orgID
@@ -40,6 +41,7 @@ func NewReplicationCreationRequest(name string, orgID string, remoteID string, l
 	this.MaxQueueSizeBytes = maxQueueSizeBytes
 	var dropNonRetryableData bool = false
 	this.DropNonRetryableData = &dropNonRetryableData
+	this.MaxAgeSeconds = maxAgeSeconds
 	return &this
 }
 
@@ -52,6 +54,8 @@ func NewReplicationCreationRequestWithDefaults() *ReplicationCreationRequest {
 	this.MaxQueueSizeBytes = maxQueueSizeBytes
 	var dropNonRetryableData bool = false
 	this.DropNonRetryableData = &dropNonRetryableData
+	var maxAgeSeconds int64 = 604800
+	this.MaxAgeSeconds = maxAgeSeconds
 	return &this
 }
 
@@ -263,6 +267,30 @@ func (o *ReplicationCreationRequest) SetDropNonRetryableData(v bool) {
 	o.DropNonRetryableData = &v
 }
 
+// GetMaxAgeSeconds returns the MaxAgeSeconds field value
+func (o *ReplicationCreationRequest) GetMaxAgeSeconds() int64 {
+	if o == nil {
+		var ret int64
+		return ret
+	}
+
+	return o.MaxAgeSeconds
+}
+
+// GetMaxAgeSecondsOk returns a tuple with the MaxAgeSeconds field value
+// and a boolean to check if the value has been set.
+func (o *ReplicationCreationRequest) GetMaxAgeSecondsOk() (*int64, bool) {
+	if o == nil {
+		return nil, false
+	}
+	return &o.MaxAgeSeconds, true
+}
+
+// SetMaxAgeSeconds sets field value
+func (o *ReplicationCreationRequest) SetMaxAgeSeconds(v int64) {
+	o.MaxAgeSeconds = v
+}
+
 func (o ReplicationCreationRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -288,6 +316,9 @@ func (o ReplicationCreationRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.DropNonRetryableData != nil {
 		toSerialize["dropNonRetryableData"] = o.DropNonRetryableData
+	}
+	if true {
+		toSerialize["maxAgeSeconds"] = o.MaxAgeSeconds
 	}
 	return json.Marshal(toSerialize)
 }

--- a/api/model_replication_update_request.gen.go
+++ b/api/model_replication_update_request.gen.go
@@ -22,6 +22,7 @@ type ReplicationUpdateRequest struct {
 	RemoteBucketID       *string `json:"remoteBucketID,omitempty" yaml:"remoteBucketID,omitempty"`
 	MaxQueueSizeBytes    *int64  `json:"maxQueueSizeBytes,omitempty" yaml:"maxQueueSizeBytes,omitempty"`
 	DropNonRetryableData *bool   `json:"dropNonRetryableData,omitempty" yaml:"dropNonRetryableData,omitempty"`
+	MaxAgeSeconds        *int64  `json:"maxAgeSeconds,omitempty" yaml:"maxAgeSeconds,omitempty"`
 }
 
 // NewReplicationUpdateRequest instantiates a new ReplicationUpdateRequest object
@@ -233,6 +234,38 @@ func (o *ReplicationUpdateRequest) SetDropNonRetryableData(v bool) {
 	o.DropNonRetryableData = &v
 }
 
+// GetMaxAgeSeconds returns the MaxAgeSeconds field value if set, zero value otherwise.
+func (o *ReplicationUpdateRequest) GetMaxAgeSeconds() int64 {
+	if o == nil || o.MaxAgeSeconds == nil {
+		var ret int64
+		return ret
+	}
+	return *o.MaxAgeSeconds
+}
+
+// GetMaxAgeSecondsOk returns a tuple with the MaxAgeSeconds field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ReplicationUpdateRequest) GetMaxAgeSecondsOk() (*int64, bool) {
+	if o == nil || o.MaxAgeSeconds == nil {
+		return nil, false
+	}
+	return o.MaxAgeSeconds, true
+}
+
+// HasMaxAgeSeconds returns a boolean if a field has been set.
+func (o *ReplicationUpdateRequest) HasMaxAgeSeconds() bool {
+	if o != nil && o.MaxAgeSeconds != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetMaxAgeSeconds gets a reference to the given int64 and assigns it to the MaxAgeSeconds field.
+func (o *ReplicationUpdateRequest) SetMaxAgeSeconds(v int64) {
+	o.MaxAgeSeconds = &v
+}
+
 func (o ReplicationUpdateRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Name != nil {
@@ -252,6 +285,9 @@ func (o ReplicationUpdateRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.DropNonRetryableData != nil {
 		toSerialize["dropNonRetryableData"] = o.DropNonRetryableData
+	}
+	if o.MaxAgeSeconds != nil {
+		toSerialize["maxAgeSeconds"] = o.MaxAgeSeconds
 	}
 	return json.Marshal(toSerialize)
 }

--- a/clients/replication/replication.go
+++ b/clients/replication/replication.go
@@ -25,6 +25,7 @@ type CreateParams struct {
 	MaxQueueSize           int64
 	DropNonRetryableData   bool
 	NoDropNonRetryableData bool
+	MaxAge                 int64
 }
 
 func (c Client) Create(ctx context.Context, params *CreateParams) error {
@@ -41,6 +42,7 @@ func (c Client) Create(ctx context.Context, params *CreateParams) error {
 		LocalBucketID:     params.LocalBucketID,
 		RemoteBucketID:    params.RemoteBucketID,
 		MaxQueueSizeBytes: params.MaxQueueSize,
+		MaxAgeSeconds:     params.MaxAge,
 	}
 
 	// set optional params if specified
@@ -118,6 +120,7 @@ type UpdateParams struct {
 	MaxQueueSize           int64
 	DropNonRetryableData   bool
 	NoDropNonRetryableData bool
+	MaxAge                 int64
 }
 
 func (c Client) Update(ctx context.Context, params *UpdateParams) error {
@@ -151,6 +154,10 @@ func (c Client) Update(ctx context.Context, params *UpdateParams) error {
 
 	if dropNonRetryableDataBoolPtr != nil {
 		body.SetDropNonRetryableData(*dropNonRetryableDataBoolPtr)
+	}
+
+	if params.MaxAge != 0 {
+		body.SetMaxAgeSeconds(params.MaxAge)
 	}
 
 	// send patch request

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -85,6 +85,12 @@ func newReplicationCreateCmd() cli.Command {
 				Usage:       "Do not drop data when a non-retryable error is encountered",
 				Destination: &params.NoDropNonRetryableData,
 			},
+			&cli.Int64Flag{
+				Name:        "max-age",
+				Usage:       "Specify a maximum age (in seconds) for replications data before it is dropped, or 0 for infinite",
+				Value:       604800, // 1 week in seconds TODO Link to OpenAPI default like above
+				Destination: &params.MaxAge,
+			},
 		),
 		Action: func(ctx *cli.Context) error {
 			api := getAPI(ctx)
@@ -227,6 +233,11 @@ func newReplicationUpdateCmd() cli.Command {
 				Name:        "no-drop-non-retryable-data",
 				Usage:       "Do not drop data when a non-retryable error is encountered",
 				Destination: &params.NoDropNonRetryableData,
+			},
+			&cli.Int64Flag{
+				Name:        "max-age",
+				Usage:       "Specify a maximum age (in seconds) for replications data before it is dropped, or 0 for infinite",
+				Destination: &params.MaxAge,
 			},
 		),
 		Action: func(ctx *cli.Context) error {

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -72,7 +72,7 @@ func newReplicationCreateCmd() cli.Command {
 			&cli.Int64Flag{
 				Name:        "max-queue-bytes",
 				Usage:       "Max queue size in bytes",
-				Value:       67108860, // source: https://github.com/influxdata/openapi/blob/588064fe68e7dfeebd019695aa805832632cbfb6/src/oss/schemas/ReplicationCreationRequest.yml#L19
+				Value:       67108860, // source: https://github.com/influxdata/openapi/blob/master/src/oss/schemas/ReplicationCreationRequest.yml
 				Destination: &params.MaxQueueSize,
 			},
 			&cli.BoolFlag{
@@ -88,7 +88,7 @@ func newReplicationCreateCmd() cli.Command {
 			&cli.Int64Flag{
 				Name:        "max-age",
 				Usage:       "Specify a maximum age (in seconds) for replications data before it is dropped, or 0 for infinite",
-				Value:       604800, // source: https://github.com/influxdata/openapi/blob/6ea7df4daa5735a063be3db60d0165b34b26c096/src/oss/schemas/ReplicationCreationRequest.yml#L27
+				Value:       604800, // source: https://github.com/influxdata/openapi/blob/master/src/oss/schemas/ReplicationCreationRequest.yml
 				Destination: &params.MaxAge,
 			},
 		),

--- a/cmd/influx/replication.go
+++ b/cmd/influx/replication.go
@@ -88,7 +88,7 @@ func newReplicationCreateCmd() cli.Command {
 			&cli.Int64Flag{
 				Name:        "max-age",
 				Usage:       "Specify a maximum age (in seconds) for replications data before it is dropped, or 0 for infinite",
-				Value:       604800, // 1 week in seconds TODO Link to OpenAPI default like above
+				Value:       604800, // source: https://github.com/influxdata/openapi/blob/6ea7df4daa5735a063be3db60d0165b34b26c096/src/oss/schemas/ReplicationCreationRequest.yml#L27
 				Destination: &params.MaxAge,
 			},
 		),


### PR DESCRIPTION
Adds the max age fields to the `replications create` and `replications update` commands.

Part of https://github.com/influxdata/influxdb/issues/23109