### PR TITLE
fix: json suffix for json template from CLI

### DIFF
--- a/pkg/template/source.go
+++ b/pkg/template/source.go
@@ -228,7 +228,7 @@ func (s Source) Read(ctx context.Context) (api.TemplateApplyTemplate, error) {
 	}
 
 	return api.TemplateApplyTemplate{
-		Sources:  []string{s.Name},
+		Sources:  []string{s.Name + ".generated.json"},
 		Contents: entries,
 	}, nil
 }

--- a/pkg/template/source_test.go
+++ b/pkg/template/source_test.go
@@ -427,7 +427,7 @@ spec:
 			tmpl, err := source.Read(context.Background())
 			require.NoError(t, err)
 			expected := api.TemplateApplyTemplate{
-				Sources:  []string{source.Name},
+				Sources:  []string{source.Name + ".generated.json"},
 				Contents: parsed,
 			}
 			require.Equal(t, expected, tmpl)


### PR DESCRIPTION
Closes https://github.com/influxdata/influx-cli/issues/351

The server can reject jsonnet files due to security concerns, so don't pretend that our files are jsonnet templates.