### PR TITLE
feat: Add --extra-http-header flag

### DIFF
--- a/cmd/influx/util.go
+++ b/cmd/influx/util.go
@@ -1,0 +1,9 @@
+//go:build go1.18
+
+package main
+
+import "strings"
+
+func stringsCut(s, sep string) (before, after string, found bool) {
+	return strings.Cut(s, sep)
+}

--- a/cmd/influx/util_go117.go
+++ b/cmd/influx/util_go117.go
@@ -1,0 +1,16 @@
+//go:build !go1.18
+
+// remove this backward compat shim once we either:
+// a) upgrade cross-builder docker image in https://github.com/influxdata/edge/
+// b) switch the CI system for this repo away from using cross-builder docker image.
+
+package main
+
+import "strings"
+
+func stringsCut(s, sep string) (before, after string, found bool) {
+	if i := strings.Index(s, sep); i >= 0 {
+		return s[:i], s[i+len(sep):], true
+	}
+	return s, "", false
+}


### PR DESCRIPTION
Some influxdb feature flags can be controlled by headers; let's add a way to play with those headers without forcing us back into raw `curl`.