### PR TITLE
fix: show `remotes` and `replications` flags in `auth create`

### DIFF
--- a/cmd/influx/auth.go
+++ b/cmd/influx/auth.go
@@ -48,9 +48,7 @@ func helpText(perm string) struct{ readHelp, writeHelp string } {
 
 func hidden(perm string) bool {
 	var hiddenTypes = map[string]struct{}{
-		"functions":    {},
-		"remotes":      {},
-		"replications": {},
+		"functions": {},
 	}
 	_, ok := hiddenTypes[perm]
 	return ok


### PR DESCRIPTION
Fixes the `--read-remotes`, `--write-remotes`, `--read-replications`, and `--write-replications` flags from being hidden in `influx auth create -h`

These flags currently work if used, though are not displayed in help text or documentation