### PR TITLE
fix: add mutual exclusion for OrgId and OrgName params

### DIFF
--- a/cmd/influx/apply.go
+++ b/cmd/influx/apply.go
@@ -165,6 +165,10 @@ https://github.com/influxdata/community-templates.
 				EnvVars:            make(map[string]string, len(params.envVars.Value())),
 				Filters:            make([]apply.ResourceFilter, len(params.filters.Value())),
 			}
+			// check that orgName and orgFlags aren't both set
+			if err := checkOrgFlags(&params.orgParams); err != nil {
+				return err
+			}
 
 			// Collect all the sources the CLI needs to read templates from.
 			var deprecationShown bool

--- a/cmd/influx/auth.go
+++ b/cmd/influx/auth.go
@@ -122,6 +122,9 @@ func newCreateCommand() cli.Command {
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			params.WriteBucketIds = ctx.StringSlice("write-bucket")
 			params.ReadBucketIds = ctx.StringSlice("read-bucket")
 
@@ -191,6 +194,9 @@ func newListCommand() cli.Command {
 		Flags:   flags,
 		Before:  middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := auth.Client{
 				CLI:               getCLI(ctx),

--- a/cmd/influx/backup.go
+++ b/cmd/influx/backup.go
@@ -44,6 +44,9 @@ Examples:
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			if ctx.NArg() != 1 {
 				return errors.New("backup path must be specified as a single positional argument")
 			}

--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -60,6 +60,9 @@ func newBucketCreateCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := bucket.Client{
 				CLI:              getCLI(ctx),
@@ -91,6 +94,9 @@ func newBucketDeleteCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := bucket.Client{
 				CLI:              getCLI(ctx),
@@ -139,6 +145,9 @@ func newBucketListCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := bucket.Client{
 				CLI:              getCLI(ctx),

--- a/cmd/influx/dashboards.go
+++ b/cmd/influx/dashboards.go
@@ -31,6 +31,9 @@ Examples:
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			rawIds := ctx.StringSlice("id")
 			params.Ids = rawIds
 

--- a/cmd/influx/export.go
+++ b/cmd/influx/export.go
@@ -310,6 +310,9 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/export/all/
 			parsedParams := export.AllParams{
 				OrgParams: params.orgParams,
 			}
+			if err := checkOrgFlags(&params.orgParams); err != nil {
+				return err
+			}
 
 			for _, filter := range params.filters.Value() {
 				components := strings.Split(filter, "=")

--- a/cmd/influx/global.go
+++ b/cmd/influx/global.go
@@ -339,6 +339,15 @@ func getOrgFlags(params *clients.OrgParams) []cli.Flag {
 	}
 }
 
+// checkOrgFlags returns an error if OrgId and OrgName are both set.
+func checkOrgFlags(params *clients.OrgParams) error {
+	if params.OrgID != "" && params.OrgName != "" {
+		return fmt.Errorf("ambiguous org: use OrgId or OrgName, but not both. OrgID: %s, OrgName: %s",
+			params.OrgID, params.OrgName)
+	}
+	return nil
+}
+
 // getBucketFlags returns flags used by commands that are scoped to a single bucket, binding
 // the flags to the given params container.
 func getBucketFlags(params *clients.BucketParams) []cli.Flag {

--- a/cmd/influx/query.go
+++ b/cmd/influx/query.go
@@ -35,6 +35,9 @@ func newQueryCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&orgParams); err != nil {
+				return err
+			}
 			queryString, err := clients.ReadQuery(ctx.String("file"), ctx.Args())
 			if err != nil {
 				return err

--- a/cmd/influx/remote.go
+++ b/cmd/influx/remote.go
@@ -64,6 +64,9 @@ func newRemoteCreateCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 
 			client := remote.Client{

--- a/cmd/influx/secret.go
+++ b/cmd/influx/secret.go
@@ -34,6 +34,9 @@ func newDeleteSecretCmd() cli.Command {
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := secret.Client{
 				CLI:              getCLI(ctx),
@@ -55,6 +58,9 @@ func newListSecretCmd() cli.Command {
 		Flags:   flags,
 		Before:  middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := secret.Client{
 				CLI:              getCLI(ctx),
@@ -88,6 +94,9 @@ func newUpdateSecretCmd() cli.Command {
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := secret.Client{
 				CLI:              getCLI(ctx),

--- a/cmd/influx/stacks.go
+++ b/cmd/influx/stacks.go
@@ -54,6 +54,9 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/stacks/`,
 			newStacksUpdateCmd(),
 		},
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			params.StackIds = ctx.StringSlice("stack-id")
 			params.StackNames = ctx.StringSlice("stack-name")
 			api := getAPI(ctx)
@@ -108,6 +111,9 @@ https://docs.influxdata.com/influxdb/latest/reference/cli/influx/stacks/init/`,
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			params.URLs = ctx.StringSlice("template-url")
 			api := getAPI(ctx)
 			client := stacks.Client{
@@ -141,6 +147,9 @@ func newStacksRemoveCmd() cli.Command {
 			},
 		),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			params.Ids = ctx.StringSlice("stack-id")
 			api := getAPI(ctx)
 			client := stacks.Client{

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -41,6 +41,9 @@ func newTaskCreateCmd() cli.Command {
 		Flags:     flags,
 		Before:    middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := task.Client{
 				CLI:      getCLI(ctx),
@@ -84,6 +87,9 @@ func newTaskFindCmd() cli.Command {
 		Flags:   flags,
 		Before:  middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := task.Client{
 				CLI:      getCLI(ctx),
@@ -138,6 +144,9 @@ func newTaskRetryFailedCmd() cli.Command {
 		Flags:   flags,
 		Before:  middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := task.Client{
 				CLI:      getCLI(ctx),

--- a/cmd/influx/telegrafs.go
+++ b/cmd/influx/telegrafs.go
@@ -41,6 +41,9 @@ Examples:
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := telegrafs.Client{
 				CLI:              getCLI(ctx),
@@ -89,6 +92,9 @@ Examples:
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			conf, err := readConfig(ctx.String("file"))
 			if err != nil {
 				return err

--- a/cmd/influx/template.go
+++ b/cmd/influx/template.go
@@ -108,6 +108,9 @@ func newTemplateCmd() cli.Command {
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.orgParams); err != nil {
+				return err
+			}
 			parsedParams := template.SummarizeParams{
 				OrgParams:          params.orgParams,
 				RenderTableColors:  !params.noColor,
@@ -138,6 +141,9 @@ func newTemplateValidateCmd() cli.Command {
 		Flags:  append(commonFlagsNoPrint(), templateFlags(&params)...),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.orgParams); err != nil {
+				return err
+			}
 			parsedParams := template.ValidateParams{
 				OrgParams: params.orgParams,
 			}

--- a/cmd/influx/user.go
+++ b/cmd/influx/user.go
@@ -43,6 +43,9 @@ func newUserCreateCmd() cli.Command {
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := user.Client{
 				CLI:              getCLI(ctx),

--- a/cmd/influx/v1_auth.go
+++ b/cmd/influx/v1_auth.go
@@ -80,6 +80,9 @@ func newCreateV1AuthCmd() cli.Command {
 		Flags:  flags,
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			params.ReadBucket = ctx.StringSlice("read-bucket")
 			params.WriteBucket = ctx.StringSlice("write-bucket")
 			api := getAPI(ctx)
@@ -142,6 +145,9 @@ func newListV1AuthCmd() cli.Command {
 		Flags:   flags,
 		Before:  middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := v1_auth.Client{
 				CLI:                     getCLI(ctx),

--- a/cmd/influx/v1_dbrp.go
+++ b/cmd/influx/v1_dbrp.go
@@ -58,6 +58,9 @@ func newV1DBRPListCmd() cli.Command {
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := v1dbrps.Client{
 				CLI:      getCLI(ctx),
@@ -103,6 +106,9 @@ func newV1DBRPCreateCmd() cli.Command {
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := v1dbrps.Client{
 				CLI:              getCLI(ctx),
@@ -132,6 +138,9 @@ func newV1DBRPDeleteCmd() cli.Command {
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := v1dbrps.Client{
 				CLI:      getCLI(ctx),
@@ -170,6 +179,9 @@ func newV1DBRPUpdateCmd() cli.Command {
 		),
 		Before: middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			api := getAPI(ctx)
 			client := v1dbrps.Client{
 				CLI:      getCLI(ctx),

--- a/cmd/influx/write.go
+++ b/cmd/influx/write.go
@@ -171,6 +171,9 @@ func newWriteCmd() cli.Command {
 		Before:      middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags:       append(commonFlagsNoPrint(), params.Flags()...),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			errorFile, err := params.makeErrorFile()
 			if err != nil {
 				return err
@@ -211,7 +214,11 @@ func newWriteDryRun() cli.Command {
 		Before:      middleware.WithBeforeFns(withCli(), withApi(true)),
 		Flags:       append(commonFlagsNoPrint(), params.Flags()...),
 		Action: func(ctx *cli.Context) error {
+			if err := checkOrgFlags(&params.OrgParams); err != nil {
+				return err
+			}
 			errorFile, err := params.makeErrorFile()
+			fmt.Println(params.OrgBucketParams.OrgName)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### Before
Environment variables did get correctly overridden by the command line flags already, but the problem was when a user would pass the `-o` flag (or `INFLUX_ORG` env var) and the `INFLUX_ORG_ID` env var (or `--org-id` flag), it wasn't made clear that only the OrgId was being used. OrgName would be ignored.

### After
Now, any command that uses the org flags enforces only one can be used, not both.
When both flags are passed together, the user will see an error like this: 
```
Error: ambiguous org: use OrgId or OrgName, but not both. OrgID: 844910ece80be8bc, OrgName: 9c5955fc99a60b8f
```

Closing #371  