### PR TITLE
feat: Add --version option to influx query

### DIFF
--- a/clients/helpers.go
+++ b/clients/helpers.go
@@ -51,3 +51,8 @@ func ReadQuery(filepath string, args []string) (string, error) {
 		return arg, nil
 	}
 }
+
+const VersionQuery = `import "array"
+import "runtime"
+array.from(rows: [{version: runtime.version()}])
+`

--- a/clients/query/version_printer.go
+++ b/clients/query/version_printer.go
@@ -1,0 +1,34 @@
+package query
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/influxdata/influx-cli/v2/pkg/fluxcsv"
+)
+
+type versionPrinter struct{}
+
+// VersionPrinter reads the result of the version query and outputs a single line.
+var VersionPrinter ResultPrinter = &versionPrinter{}
+
+func (v versionPrinter) PrintQueryResults(resultStream io.ReadCloser, out io.Writer) error {
+	res := fluxcsv.NewQueryTableResult(resultStream)
+	defer res.Close()
+
+	// Only one row.
+	if !res.Next() {
+		return res.Err()
+	}
+
+	// The key doesn't matter except that it's not table.
+	record := res.Record()
+	for k, v := range record.Values() {
+		if k == "table" {
+			continue
+		}
+		_, _ = fmt.Fprintf(out, "flux %s\n", v)
+		break
+	}
+	return nil
+}


### PR DESCRIPTION
The --version option will execute a query against influxdb that returns
the current flux version on the server.

It uses the query from the docs:
https://docs.influxdata.com/influxdb/v2.2/query-data/flux/flux-version/