### PR TITLE
build: upgrade to Go 1.18.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
       # then update the version here to match. Until we finish the migration to using the cross-builder image,
       # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
-      - image: quay.io/influxdb/cross-builder:go1.18.1-52b299506343dfbb3f138d8a740bcfd0d97c1888
+      - image: quay.io/influxdb/cross-builder:go1.18.3-c75d304717395a43913dcc3d576d4f3545375253
     resource_class: medium
   linux-amd64:
     machine:


### PR DESCRIPTION
Upgrade to Go 1.18.3 (latest)