### PR TITLE
fix: users and orgs permissions should not be scoped under an org

### DIFF
--- a/clients/auth/auth.go
+++ b/clients/auth/auth.go
@@ -444,6 +444,9 @@ func (c Client) printAuth(opts printParams) error {
 }
 
 func makePermResource(permType string, id string, orgId string) api.PermissionResource {
+	if permType == "orgs" || permType == "users" {
+		orgId = ""
+	}
 	pr := api.PermissionResource{Type: permType}
 	if id != "" {
 		pr.Id = &id

--- a/clients/auth/auth_internal_test.go
+++ b/clients/auth/auth_internal_test.go
@@ -41,6 +41,20 @@ func Test_makePermResource(t *testing.T) {
 			inOrgId:  "45678",
 			expected: api.PermissionResource{Type: "qux", Id: api.PtrString("12345"), OrgID: api.PtrString("45678")},
 		},
+		{
+			name:     "users",
+			inType:   "users",
+			inId:     "12345",
+			inOrgId:  "45678",
+			expected: api.PermissionResource{Type: "users", Id: api.PtrString("12345"), OrgID: nil},
+		},
+		{
+			name:     "orgs",
+			inType:   "orgs",
+			inId:     "12345",
+			inOrgId:  "45678",
+			expected: api.PermissionResource{Type: "orgs", Id: api.PtrString("12345"), OrgID: nil},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Closes #293 

Users and Orgs permissions shouldn't be scoped under a specific organization, this fixes that.