### PR TITLE
Replace token flags with = to prevent bad parsing of leading dash in token

### DIFF
--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -96,30 +96,22 @@ func newApp() cli.App {
 // This creates a new slice and replaces `-t "-FOO-TOKEN"` with `-t=-FOO-TOKEN`
 // This is necessary to do because the command line arg:
 //  `-t "-FOO-TOKEN"`` will be parsed as two separate flags instead of a flag and token value.
-func replaceTokenArg(args []string) []string {
+func ReplaceTokenArg(args []string) []string {
+	if len(args) == 0 {
+		return []string{}
+	}
 	newArgs := make([]string, len(args))
 	copy(newArgs, args)
-	for i, arg := range newArgs {
+	for i, arg := range newArgs[:len(newArgs)-1] {
 		switch arg {
 		case "--token", "-t":
-			// if last element, this will be invalid later
-			if i == len(args)-1 {
-				break
-			}
 			if strings.HasPrefix(newArgs[i+1], "-") {
-				color.HiYellow("warning: %s %s interpreted as %s=%s, consider using %s=%s syntax when tokens start with a hyphen",
-					newArgs[i], newArgs[i+1],
-					newArgs[i], newArgs[i+1],
+				color.HiYellow("warning: %[1]s %[2]s interpreted as %[1]s=%[2]s, consider using %[1]s=%[2]s syntax when tokens start with a hyphen",
 					newArgs[i], newArgs[i+1],
 				)
 			}
 			newArgs[i] = strings.Join(newArgs[i:i+2], "=")
-			// if there are 2+ elements after this
-			if len(newArgs) > i+2 {
-				newArgs = append(newArgs[:i+1], newArgs[i+2:]...)
-			} else {
-				newArgs = newArgs[:i+1]
-			}
+			newArgs = append(newArgs[:i+1], newArgs[i+2:]...)
 		}
 	}
 	return newArgs
@@ -127,7 +119,7 @@ func replaceTokenArg(args []string) []string {
 
 func main() {
 	app := newApp()
-	args := replaceTokenArg(os.Args)
+	args := ReplaceTokenArg(os.Args)
 	if err := app.Run(args); err != nil {
 		// Errors will normally be handled by cli.HandleExitCoder via ExitErrHandler set on app. Any error not implementing
 		// the cli.ExitCoder interface can be handled here.

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -2,12 +2,13 @@ package main
 
 import (
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli"
 	"os"
 	"strings"
 	"time"
+
+	"github.com/fatih/color"
+	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
+	"github.com/urfave/cli"
 )
 
 // Fields set via ldflags at build time.

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -92,32 +92,35 @@ func newApp() cli.App {
 	}
 }
 
-// This replaces `-t "-FOO-TOKEN"` with `-t=-FOO-TOKEN` in os.Args
+// This creates a new slice and replaces `-t "-FOO-TOKEN"` with `-t=-FOO-TOKEN`
 // This is necessary to do because the command line arg:
 //  `-t "-FOO-TOKEN"`` will be parsed as two separate flags instead of a flag and token value.
-func replaceTokenArg() {
-	for i, arg := range os.Args {
+func replaceTokenArg(args []string) []string {
+	newArgs := make([]string, len(args))
+	copy(newArgs, args)
+	for i, arg := range newArgs {
 		switch arg {
 		case "--token", "-t":
 			// if last element, this will be invalid later
-			if i == len(os.Args)-1 {
+			if i == len(args)-1 {
 				break
 			}
-			os.Args[i] = strings.Join(os.Args[i:i+2], "=")
+			newArgs[i] = strings.Join(newArgs[i:i+2], "=")
 			// if there are 2+ elements after this
-			if len(os.Args) > i+2 {
-				os.Args = append(os.Args[:i+1], os.Args[i+2:]...)
+			if len(newArgs) > i+2 {
+				newArgs = append(newArgs[:i+1], newArgs[i+2:]...)
 			} else {
-				os.Args = os.Args[:i+1]
+				newArgs = newArgs[:i+1]
 			}
 		}
 	}
+	return newArgs
 }
 
 func main() {
 	app := newApp()
-	replaceTokenArg()
-	if err := app.Run(os.Args); err != nil {
+	args := replaceTokenArg(os.Args)
+	if err := app.Run(args); err != nil {
 		// Errors will normally be handled by cli.HandleExitCoder via ExitErrHandler set on app. Any error not implementing
 		// the cli.ExitCoder interface can be handled here.
 		_, _ = fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/cmd/influx/main.go
+++ b/cmd/influx/main.go
@@ -2,12 +2,12 @@ package main
 
 import (
 	"fmt"
+	"github.com/fatih/color"
+	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
+	"github.com/urfave/cli"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
-	"github.com/urfave/cli"
 )
 
 // Fields set via ldflags at build time.
@@ -104,6 +104,13 @@ func replaceTokenArg(args []string) []string {
 			// if last element, this will be invalid later
 			if i == len(args)-1 {
 				break
+			}
+			if strings.HasPrefix(newArgs[i+1], "-") {
+				color.HiYellow("warning: %s %s interpreted as %s=%s, consider using %s=%s syntax when tokens start with a hyphen",
+					newArgs[i], newArgs[i+1],
+					newArgs[i], newArgs[i+1],
+					newArgs[i], newArgs[i+1],
+				)
 			}
 			newArgs[i] = strings.Join(newArgs[i:i+2], "=")
 			// if there are 2+ elements after this

--- a/cmd/influx/main_test.go
+++ b/cmd/influx/main_test.go
@@ -148,6 +148,171 @@ func TestApp_HostSpecificErrors(t *testing.T) {
 	}
 }
 
+func TestReplaceTokenArg(t *testing.T) {
+	tests := []struct {
+		name       string
+		argsBefore []string
+		argsAfter  []string
+	}{
+		{
+			name: "short token flag second to last arg",
+			argsBefore: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"-t",
+				"-therestofmytoken",
+				"-o",
+				"organisation",
+			},
+			argsAfter: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"-t=-therestofmytoken",
+				"-o",
+				"organisation",
+			},
+		},
+		{
+			name: "long token flag second to last arg",
+			argsBefore: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"--token",
+				"-foo_token",
+				"-o",
+				"organisation",
+			},
+			argsAfter: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"--token=-foo_token",
+				"-o",
+				"organisation",
+			},
+		},
+		{
+			name: "short token flag last arg",
+			argsBefore: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"-o",
+				"organisation",
+				"-t",
+				"-therestofmytoken",
+			},
+			argsAfter: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"-o",
+				"organisation",
+				"-t=-therestofmytoken",
+			},
+		},
+		{
+			name: "long token flag last arg",
+			argsBefore: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"-o",
+				"organisation",
+				"--token",
+				"-foo_token",
+			},
+			argsAfter: []string{
+				"config",
+				"create",
+				"-n",
+				"targetflux",
+				"-u",
+				"http://localhost:8087",
+				"-o",
+				"organisation",
+				"--token=-foo_token",
+			},
+		},
+		{
+			name: "no token flag",
+			argsBefore: []string{
+				"v1",
+				"shell",
+			},
+			argsAfter: []string{
+				"v1",
+				"shell",
+			},
+		},
+		{
+			name: "unprovided token value for flag",
+			argsBefore: []string{
+				"v1",
+				"shell",
+				"--token",
+			},
+			argsAfter: []string{
+				"v1",
+				"shell",
+				"--token",
+			},
+		},
+		{
+			name: "no token flag, other flags",
+			argsBefore: []string{
+				"v1",
+				"shell",
+				"-u",
+				"http://localhost:8087",
+				"-o",
+				"organisation",
+			},
+			argsAfter: []string{
+				"v1",
+				"shell",
+				"-u",
+				"http://localhost:8087",
+				"-o",
+				"organisation",
+			},
+		},
+		{
+			name:       "no args",
+			argsBefore: []string{},
+			argsAfter:  []string{},
+		},
+	}
+	for _, tt := range tests {
+		newArgs := ReplaceTokenArg(tt.argsBefore)
+		require.Equal(t, tt.argsAfter, newArgs)
+	}
+}
+
 type testWriter struct {
 	b       *bytes.Buffer
 	written bool


### PR DESCRIPTION
This is a pretty awkward problem, and it stems from the fact that those wrapping quotes are parsed away when Go gets the program's arguments for `os.Args`.

I ran `dlv debug ./cmd/influx -- config create -n targetflux -u "http://localhost:8087" -o "organization" -t "-therestofmytoken"`
And this is the `os.Args` value which `urfave/cli` uses directly.
```
(dlv) p os.Args
[]string len: 11, cap: 11, [
        "...+2 more",
        "config",
        "create",
        "-n",
        "targetflux",
        "-u",
        "http://localhost:8087",
        "-o",
        "organization",
        "-t",
        "-therestofmytoken",      <--- no wrapping quotes
]
```
It seems like a bespoke method specifically for replacing `-t "-FOO-TOKEN"` with `-t=-FOO-TOKEN` in `os.Args` before passing into `urfave/cli` makes the most sense here.

Closing #376 and #378 