### PR TITLE
chore: fix up tabs vs. spaces mistakes in help prompt

### DIFF
--- a/clients/v1_shell/v1_shell.go
+++ b/clients/v1_shell/v1_shell.go
@@ -381,18 +381,18 @@ func (c *Client) help() {
         show measurements     show measurement information
         show tag keys         show tag key information
         show field keys       show field key information
-		insert <point>        insert point into currently-used database
+        insert <point>        insert point into currently-used database
 
         A full list of influxql commands can be found at:
         https://docs.influxdata.com/influxdb/latest/query_language/spec/
 		
 	Keybindings:
-		<CTRL+D>      exit 
-		<CTRL+L>      clear screen
-		<UP ARROW>    previous command
-		<DOWN ARROW>  next command
-		<TAB>         next suggestion
-		<SHIFT+TAB>   previous suggestion`)
+	  <CTRL+D>      exit 
+	  <CTRL+L>      clear screen
+	  <UP ARROW>    previous command
+	  <DOWN ARROW>  next command
+	  <TAB>         next suggestion
+	  <SHIFT+TAB>   previous suggestion`)
 }
 
 func (c *Client) settings() {


### PR DESCRIPTION
Before:
<img width="856" alt="Screen Shot 2022-06-24 at 10 00 15 AM" src="https://user-images.githubusercontent.com/32912555/175612337-f18927f0-1406-4fdf-863f-e862b9f1039f.png">

After:
<img width="880" alt="Screen Shot 2022-06-24 at 11 30 09 AM" src="https://user-images.githubusercontent.com/32912555/175612479-2f45b3dd-4575-409f-90cb-1922a1977eeb.png">

