### PR TITLE
feat: creating tasks with invokable scripts and more create params

### DIFF
--- a/api/model_task.gen.go
+++ b/api/model_task.gen.go
@@ -48,7 +48,11 @@ type Task struct {
 	LastRunError    *string    `json:"lastRunError,omitempty" yaml:"lastRunError,omitempty"`
 	CreatedAt       *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 	UpdatedAt       *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
-	Links           *TaskLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	// Script ID that is executed when the task runs instead of some given Flux.
+	ScriptID *string `json:"scriptID,omitempty" yaml:"scriptID,omitempty"`
+	// If the task executes a script instead of custom Flux, these are the parameter inputs fed to the script.
+	ScriptParameters *string    `json:"scriptParameters,omitempty" yaml:"scriptParameters,omitempty"`
+	Links            *TaskLinks `json:"links,omitempty" yaml:"links,omitempty"`
 }
 
 // NewTask instantiates a new Task object
@@ -648,6 +652,70 @@ func (o *Task) SetUpdatedAt(v time.Time) {
 	o.UpdatedAt = &v
 }
 
+// GetScriptID returns the ScriptID field value if set, zero value otherwise.
+func (o *Task) GetScriptID() string {
+	if o == nil || o.ScriptID == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptID
+}
+
+// GetScriptIDOk returns a tuple with the ScriptID field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Task) GetScriptIDOk() (*string, bool) {
+	if o == nil || o.ScriptID == nil {
+		return nil, false
+	}
+	return o.ScriptID, true
+}
+
+// HasScriptID returns a boolean if a field has been set.
+func (o *Task) HasScriptID() bool {
+	if o != nil && o.ScriptID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptID gets a reference to the given string and assigns it to the ScriptID field.
+func (o *Task) SetScriptID(v string) {
+	o.ScriptID = &v
+}
+
+// GetScriptParameters returns the ScriptParameters field value if set, zero value otherwise.
+func (o *Task) GetScriptParameters() string {
+	if o == nil || o.ScriptParameters == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptParameters
+}
+
+// GetScriptParametersOk returns a tuple with the ScriptParameters field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Task) GetScriptParametersOk() (*string, bool) {
+	if o == nil || o.ScriptParameters == nil {
+		return nil, false
+	}
+	return o.ScriptParameters, true
+}
+
+// HasScriptParameters returns a boolean if a field has been set.
+func (o *Task) HasScriptParameters() bool {
+	if o != nil && o.ScriptParameters != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptParameters gets a reference to the given string and assigns it to the ScriptParameters field.
+func (o *Task) SetScriptParameters(v string) {
+	o.ScriptParameters = &v
+}
+
 // GetLinks returns the Links field value if set, zero value otherwise.
 func (o *Task) GetLinks() TaskLinks {
 	if o == nil || o.Links == nil {
@@ -738,6 +806,12 @@ func (o Task) MarshalJSON() ([]byte, error) {
 	}
 	if o.UpdatedAt != nil {
 		toSerialize["updatedAt"] = o.UpdatedAt
+	}
+	if o.ScriptID != nil {
+		toSerialize["scriptID"] = o.ScriptID
+	}
+	if o.ScriptParameters != nil {
+		toSerialize["scriptParameters"] = o.ScriptParameters
 	}
 	if o.Links != nil {
 		toSerialize["links"] = o.Links

--- a/api/model_task_create_request.gen.go
+++ b/api/model_task_create_request.gen.go
@@ -22,18 +22,27 @@ type TaskCreateRequest struct {
 	Org    *string         `json:"org,omitempty" yaml:"org,omitempty"`
 	Status *TaskStatusType `json:"status,omitempty" yaml:"status,omitempty"`
 	// The Flux script to run for this task.
-	Flux string `json:"flux" yaml:"flux"`
+	Flux *string `json:"flux,omitempty" yaml:"flux,omitempty"`
 	// An optional description of the task.
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	// The name of the task.
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	// An interval at which the task runs.
+	Every *string `json:"every,omitempty" yaml:"every,omitempty"`
+	// Cron expression that defines the schedule on which the task runs.
+	Cron *string `json:"cron,omitempty" yaml:"cron,omitempty"`
+	// The optional script to execute instead of Flux.
+	ScriptID *string `json:"scriptID,omitempty" yaml:"scriptID,omitempty"`
+	// If a script is provided instead of Flux, these are the parameters to execute the script with.
+	ScriptParameters *string `json:"scriptParameters,omitempty" yaml:"scriptParameters,omitempty"`
 }
 
 // NewTaskCreateRequest instantiates a new TaskCreateRequest object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTaskCreateRequest(flux string) *TaskCreateRequest {
+func NewTaskCreateRequest() *TaskCreateRequest {
 	this := TaskCreateRequest{}
-	this.Flux = flux
 	return &this
 }
 
@@ -141,28 +150,36 @@ func (o *TaskCreateRequest) SetStatus(v TaskStatusType) {
 	o.Status = &v
 }
 
-// GetFlux returns the Flux field value
+// GetFlux returns the Flux field value if set, zero value otherwise.
 func (o *TaskCreateRequest) GetFlux() string {
-	if o == nil {
+	if o == nil || o.Flux == nil {
 		var ret string
 		return ret
 	}
-
-	return o.Flux
+	return *o.Flux
 }
 
-// GetFluxOk returns a tuple with the Flux field value
+// GetFluxOk returns a tuple with the Flux field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *TaskCreateRequest) GetFluxOk() (*string, bool) {
-	if o == nil {
+	if o == nil || o.Flux == nil {
 		return nil, false
 	}
-	return &o.Flux, true
+	return o.Flux, true
 }
 
-// SetFlux sets field value
+// HasFlux returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasFlux() bool {
+	if o != nil && o.Flux != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFlux gets a reference to the given string and assigns it to the Flux field.
 func (o *TaskCreateRequest) SetFlux(v string) {
-	o.Flux = v
+	o.Flux = &v
 }
 
 // GetDescription returns the Description field value if set, zero value otherwise.
@@ -197,6 +214,166 @@ func (o *TaskCreateRequest) SetDescription(v string) {
 	o.Description = &v
 }
 
+// GetName returns the Name field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetName() string {
+	if o == nil || o.Name == nil {
+		var ret string
+		return ret
+	}
+	return *o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetNameOk() (*string, bool) {
+	if o == nil || o.Name == nil {
+		return nil, false
+	}
+	return o.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasName() bool {
+	if o != nil && o.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given string and assigns it to the Name field.
+func (o *TaskCreateRequest) SetName(v string) {
+	o.Name = &v
+}
+
+// GetEvery returns the Every field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetEvery() string {
+	if o == nil || o.Every == nil {
+		var ret string
+		return ret
+	}
+	return *o.Every
+}
+
+// GetEveryOk returns a tuple with the Every field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetEveryOk() (*string, bool) {
+	if o == nil || o.Every == nil {
+		return nil, false
+	}
+	return o.Every, true
+}
+
+// HasEvery returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasEvery() bool {
+	if o != nil && o.Every != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEvery gets a reference to the given string and assigns it to the Every field.
+func (o *TaskCreateRequest) SetEvery(v string) {
+	o.Every = &v
+}
+
+// GetCron returns the Cron field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetCron() string {
+	if o == nil || o.Cron == nil {
+		var ret string
+		return ret
+	}
+	return *o.Cron
+}
+
+// GetCronOk returns a tuple with the Cron field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetCronOk() (*string, bool) {
+	if o == nil || o.Cron == nil {
+		return nil, false
+	}
+	return o.Cron, true
+}
+
+// HasCron returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasCron() bool {
+	if o != nil && o.Cron != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCron gets a reference to the given string and assigns it to the Cron field.
+func (o *TaskCreateRequest) SetCron(v string) {
+	o.Cron = &v
+}
+
+// GetScriptID returns the ScriptID field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetScriptID() string {
+	if o == nil || o.ScriptID == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptID
+}
+
+// GetScriptIDOk returns a tuple with the ScriptID field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetScriptIDOk() (*string, bool) {
+	if o == nil || o.ScriptID == nil {
+		return nil, false
+	}
+	return o.ScriptID, true
+}
+
+// HasScriptID returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasScriptID() bool {
+	if o != nil && o.ScriptID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptID gets a reference to the given string and assigns it to the ScriptID field.
+func (o *TaskCreateRequest) SetScriptID(v string) {
+	o.ScriptID = &v
+}
+
+// GetScriptParameters returns the ScriptParameters field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetScriptParameters() string {
+	if o == nil || o.ScriptParameters == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptParameters
+}
+
+// GetScriptParametersOk returns a tuple with the ScriptParameters field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetScriptParametersOk() (*string, bool) {
+	if o == nil || o.ScriptParameters == nil {
+		return nil, false
+	}
+	return o.ScriptParameters, true
+}
+
+// HasScriptParameters returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasScriptParameters() bool {
+	if o != nil && o.ScriptParameters != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptParameters gets a reference to the given string and assigns it to the ScriptParameters field.
+func (o *TaskCreateRequest) SetScriptParameters(v string) {
+	o.ScriptParameters = &v
+}
+
 func (o TaskCreateRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.OrgID != nil {
@@ -208,11 +385,26 @@ func (o TaskCreateRequest) MarshalJSON() ([]byte, error) {
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
-	if true {
+	if o.Flux != nil {
 		toSerialize["flux"] = o.Flux
 	}
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
+	}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	if o.Every != nil {
+		toSerialize["every"] = o.Every
+	}
+	if o.Cron != nil {
+		toSerialize["cron"] = o.Cron
+	}
+	if o.ScriptID != nil {
+		toSerialize["scriptID"] = o.ScriptID
+	}
+	if o.ScriptParameters != nil {
+		toSerialize["scriptParameters"] = o.ScriptParameters
 	}
 	return json.Marshal(toSerialize)
 }

--- a/clients/task/task.go
+++ b/clients/task/task.go
@@ -19,7 +19,12 @@ type Client struct {
 
 type CreateParams struct {
 	clients.OrgParams
-	FluxQuery string
+	FluxQuery    string
+	Name         string
+	Every        string
+	Cron         string
+	ScriptID     string
+	ScriptParams string
 }
 
 type NameOrID struct {
@@ -73,9 +78,14 @@ func (c Client) Create(ctx context.Context, params *CreateParams) error {
 		return err
 	}
 	createRequest := api.TaskCreateRequest{
-		Flux:  params.FluxQuery,
-		OrgID: org.IDOrNil(),
-		Org:   org.NameOrNil(),
+		OrgID:            org.IDOrNil(),
+		Org:              org.NameOrNil(),
+		Name:             &params.Name,
+		Every:            &params.Every,
+		Cron:             &params.Cron,
+		Flux:             &params.FluxQuery,
+		ScriptID:         &params.ScriptID,
+		ScriptParameters: &params.ScriptParams,
 	}
 	task, err := c.PostTasks(ctx).TaskCreateRequest(createRequest).Execute()
 	if err != nil {

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+
 	"github.com/influxdata/influx-cli/v2/clients"
 	"github.com/influxdata/influx-cli/v2/clients/task"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
@@ -28,19 +30,52 @@ func newTaskCommand() cli.Command {
 
 func newTaskCreateCmd() cli.Command {
 	var params task.CreateParams
+	var scriptID string
+	var scriptParams string
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
-	flags = append(flags, &cli.StringFlag{
-		Name:      "file, f",
-		Usage:     "Path to Flux script file",
-		TakesFile: true,
-	})
+	flags = append(flags,
+		&cli.StringFlag{
+			Name:        "name, n",
+			Usage:       "Name of the task",
+			Destination: &params.Name,
+		},
+		&cli.StringFlag{
+			Name:        "every, e",
+			Usage:       "Interval at which the task runs",
+			Destination: &params.Every,
+		},
+		&cli.StringFlag{
+			Name:        "cron, r",
+			Usage:       "Cron expression to define when the task should run",
+			Destination: &params.Cron,
+		},
+		&cli.StringFlag{
+			Name:      "file, f",
+			Usage:     "Path to Flux script file",
+			TakesFile: true,
+		},
+		&cli.StringFlag{
+			Name:        "script-id",
+			Usage:       "Script ID that gets executed instead of Flux",
+			Destination: &scriptID,
+		},
+		&cli.StringFlag{
+			Name:        "script-params",
+			Usage:       "JSON parameters for the script to be executed",
+			Destination: &scriptParams,
+		})
 	return cli.Command{
 		Name:      "create",
-		Usage:     "Create a task with a Flux script provided via the first argument or a file or stdin.",
+		Usage:     "Create a task with a Flux script provided via the first argument or a file or stdin or a script ID.",
 		ArgsUsage: "[flux script or '-' for stdin]",
 		Flags:     flags,
 		Before:    middleware.WithBeforeFns(withCli(), withApi(true)),
 		Action: func(ctx *cli.Context) error {
+			fluxFile := ctx.String("file")
+			if len(fluxFile) > 0 && len(scriptID) > 0 {
+				return errors.New("cannot specify both Flux from a file and a script ID")
+			}
+
 			if err := checkOrgFlags(&params.OrgParams); err != nil {
 				return err
 			}
@@ -49,11 +84,21 @@ func newTaskCreateCmd() cli.Command {
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			var err error
-			params.FluxQuery, err = clients.ReadQuery(ctx.String("file"), ctx.Args())
-			if err != nil {
-				return err
+
+			if len(fluxFile) > 0 {
+				if len(scriptParams) > 0 {
+					return errors.New("cannot specify script parameters when not using a script in the task")
+				}
+				var err error
+				params.FluxQuery, err = clients.ReadQuery(fluxFile, ctx.Args())
+				if err != nil {
+					return err
+				}
+			} else {
+				params.ScriptID = scriptID
+				params.ScriptParams = scriptParams
 			}
+
 			return client.Create(getContext(ctx), &params)
 		},
 	}


### PR DESCRIPTION
This PR allows users to create tasks with script IDs instead of Flux in the CLI. The following parameters are now exposed when creating a task:
 - name
 - every
 - cron
 - scriptID
 - scriptParameters

Only the last two are related to scripts, but if a name and schedule aren't provided the command will fail when trying to create a task (https://github.com/influxdata/idpe/blob/47a5a53d9d00313603ef6f3b5991f3a68122ac4f/task/task.go#L453)

Must merge https://github.com/influxdata/openapi/pull/349 and update the submodule before this PR can be merged!

Closes https://github.com/influxdata/influx-cli/issues/407