### PR TITLE
build: upload "latest" artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -335,6 +335,12 @@ jobs:
             - run:
                 name: Publish tagged release
                 command: goreleaser release --rm-dist
+            - run:
+                command: |
+                  export DEBIAN_FRONTEND=noninteractive
+                  sudo apt-get update
+                  sudo apt-get install awscli
+                  .circleci/scripts/upload-latest-artifacts
       - store_artifacts:
           path: dist
 

--- a/.circleci/scripts/upload-latest-artifacts
+++ b/.circleci/scripts/upload-latest-artifacts
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -o errexit \
+    -o nounset \
+    -o pipefail
+
+REGEX='^dist/influxdb2-client-([[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+)(.*)'
+
+for target in dist/*
+do
+  # `dist` contains more than just the packages. This will match
+  # only the artifacts with a "package" filename.
+  if [[ "${target}" =~ ${REGEX} ]]
+  then
+    mv -v "${target}" "dist/influxdb2-client-latest${BASH_REMATCH[2]}"
+
+    # After renaming the artifact to the "lastest" version, append the
+    # artifact to the `invalidations` file. Since `dl.influxdata.com`
+    # contains many 100GBs, this should only invalidate artifacts
+    # that have changed.
+    printf '/influxdb/releases/influxdb2-client-latest%s\n' "${BASH_REMATCH[2]}" >>invalidations
+  fi
+done
+
+aws s3 sync dist 's3://dl.influxdata.com/influxdb/releases/'
+
+aws cloudfront create-invalidation --distribution-id "${AWS_DISTRIBUTION_ID}" --paths $(<invalidations)


### PR DESCRIPTION
When a release is triggered, this uploads the release packages as both `influxdb2-client-<version>` and `influxdb2-client-latest`.