### PR TITLE
feat: updated openapi to support tasks containing scripts

### DIFF
--- a/api/api_invokable_scripts.gen.go
+++ b/api/api_invokable_scripts.gen.go
@@ -48,10 +48,30 @@ type InvokableScriptsApi interface {
 	DeleteScriptsIDExecuteWithHttpInfo(r ApiDeleteScriptsIDRequest) (*_nethttp.Response, error)
 
 	/*
-	 * GetScripts List scripts
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return ApiGetScriptsRequest
-	 */
+			 * GetScripts List scripts
+			 * Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+
+		#### Limitations
+
+		- Paging with an `offset` greater than the number of records will result in
+		an empty response--for example:
+
+		  The following request is paging to the 50th record, but the user has only
+		  created two scripts.
+
+		    ```sh
+		    $ curl --request GET "INFLUX_URL/api/v2/scripts?limit=1&offset=50"
+
+		    $ {"scripts":[]}
+		    ```
+
+		#### Related Guides
+
+		- [Invoke custom scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @return ApiGetScriptsRequest
+	*/
 	GetScripts(ctx _context.Context) ApiGetScriptsRequest
 
 	/*
@@ -116,10 +136,18 @@ type InvokableScriptsApi interface {
 	PatchScriptsIDExecuteWithHttpInfo(r ApiPatchScriptsIDRequest) (Script, *_nethttp.Response, error)
 
 	/*
-	 * PostScripts Create a script
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return ApiPostScriptsRequest
-	 */
+			 * PostScripts Create a script
+			 * Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
+		and returns the created script.
+
+		#### Related Guides
+
+		- [Invokable scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+		- [Creating custom InfluxDB endpoints](https://docs.influxdata.com/resources/videos/api-invokable-scripts/).
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @return ApiPostScriptsRequest
+	*/
 	PostScripts(ctx _context.Context) ApiPostScriptsRequest
 
 	/*
@@ -327,9 +355,29 @@ func (r ApiGetScriptsRequest) ExecuteWithHttpInfo() (Scripts, *_nethttp.Response
 
 /*
  * GetScripts List scripts
+ * Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+
+#### Limitations
+
+- Paging with an `offset` greater than the number of records will result in
+an empty response--for example:
+
+  The following request is paging to the 50th record, but the user has only
+  created two scripts.
+
+    ```sh
+    $ curl --request GET "INFLUX_URL/api/v2/scripts?limit=1&offset=50"
+
+    $ {"scripts":[]}
+    ```
+
+#### Related Guides
+
+- [Invoke custom scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiGetScriptsRequest
- */
+*/
 func (a *InvokableScriptsApiService) GetScripts(ctx _context.Context) ApiGetScriptsRequest {
 	return ApiGetScriptsRequest{
 		ApiService: a,
@@ -425,6 +473,17 @@ func (a *InvokableScriptsApiService) GetScriptsExecuteWithHttpInfo(r ApiGetScrip
 		}
 		newErr.body = localVarBody
 		newErr.error = localVarHTTPResponse.Status
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+			newErr.model = &v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -803,9 +862,17 @@ func (r ApiPostScriptsRequest) ExecuteWithHttpInfo() (Script, *_nethttp.Response
 
 /*
  * PostScripts Create a script
+ * Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
+and returns the created script.
+
+#### Related Guides
+
+- [Invokable scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+- [Creating custom InfluxDB endpoints](https://docs.influxdata.com/resources/videos/api-invokable-scripts/).
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiPostScriptsRequest
- */
+*/
 func (a *InvokableScriptsApiService) PostScripts(ctx _context.Context) ApiPostScriptsRequest {
 	return ApiPostScriptsRequest{
 		ApiService: a,
@@ -900,6 +967,28 @@ func (a *InvokableScriptsApiService) PostScriptsExecuteWithHttpInfo(r ApiPostScr
 		}
 		newErr.body = localVarBody
 		newErr.error = localVarHTTPResponse.Status
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+			newErr.model = &v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 422 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+			newErr.model = &v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {

--- a/api/api_tasks.gen.go
+++ b/api/api_tasks.gen.go
@@ -28,12 +28,18 @@ var (
 type TasksApi interface {
 
 	/*
-	 * DeleteTasksID Delete a task
-	 * Deletes a task and all associated records
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param taskID The ID of the task to delete.
-	 * @return ApiDeleteTasksIDRequest
-	 */
+			 * DeleteTasksID Delete a task
+			 * Deletes a task and associated records.
+
+		Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+		Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+		If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param taskID The ID of the task to delete.
+			 * @return ApiDeleteTasksIDRequest
+	*/
 	DeleteTasksID(ctx _context.Context, taskID string) ApiDeleteTasksIDRequest
 
 	/*
@@ -49,12 +55,20 @@ type TasksApi interface {
 	DeleteTasksIDExecuteWithHttpInfo(r ApiDeleteTasksIDRequest) (*_nethttp.Response, error)
 
 	/*
-	 * DeleteTasksIDRunsID Cancel a running task.  #### InfluxDB Cloud    - Doesn't support this operation.
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param taskID The task ID.
-	 * @param runID The run ID.
-	 * @return ApiDeleteTasksIDRunsIDRequest
-	 */
+			 * DeleteTasksIDRunsID Cancel a running task
+			 * Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+		Use this endpoint with InfluxDB OSS to cancel a running task.
+
+		#### InfluxDB Cloud
+
+		  - Doesn't support this operation.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param taskID The task ID.
+			 * @param runID The ID of the task run to cancel.
+			 * @return ApiDeleteTasksIDRunsIDRequest
+	*/
 	DeleteTasksIDRunsID(ctx _context.Context, taskID string, runID string) ApiDeleteTasksIDRunsIDRequest
 
 	/*
@@ -70,10 +84,15 @@ type TasksApi interface {
 	DeleteTasksIDRunsIDExecuteWithHttpInfo(r ApiDeleteTasksIDRunsIDRequest) (*_nethttp.Response, error)
 
 	/*
-	 * GetTasks List all tasks
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return ApiGetTasksRequest
-	 */
+			 * GetTasks List all tasks
+			 * Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
+
+		To limit which tasks are returned, pass query parameters in your request.
+		If no query parameters are passed, InfluxDB returns all tasks up to the default `limit`.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @return ApiGetTasksRequest
+	*/
 	GetTasks(ctx _context.Context) ApiGetTasksRequest
 
 	/*
@@ -91,11 +110,14 @@ type TasksApi interface {
 	GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tasks, *_nethttp.Response, error)
 
 	/*
-	 * GetTasksID Retrieve a task
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param taskID The task ID.
-	 * @return ApiGetTasksIDRequest
-	 */
+			 * GetTasksID Retrieve a task
+			 * Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
+		by task ID.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param taskID The task ID.
+			 * @return ApiGetTasksIDRequest
+	*/
 	GetTasksID(ctx _context.Context, taskID string) ApiGetTasksIDRequest
 
 	/*
@@ -113,11 +135,19 @@ type TasksApi interface {
 	GetTasksIDExecuteWithHttpInfo(r ApiGetTasksIDRequest) (Task, *_nethttp.Response, error)
 
 	/*
-	 * GetTasksIDLogs Retrieve all logs for a task
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param taskID The task ID.
-	 * @return ApiGetTasksIDLogsRequest
-	 */
+			 * GetTasksIDLogs Retrieve all logs for a task
+			 * Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+		When an InfluxDB task runs, a “run” record is created in the task’s history.
+		Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
+
+		Use this endpoint to retrieve only the log events for a task,
+		without additional task metadata.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param taskID The task ID.
+			 * @return ApiGetTasksIDLogsRequest
+	*/
 	GetTasksIDLogs(ctx _context.Context, taskID string) ApiGetTasksIDLogsRequest
 
 	/*
@@ -157,12 +187,16 @@ type TasksApi interface {
 	GetTasksIDRunsExecuteWithHttpInfo(r ApiGetTasksIDRunsRequest) (Runs, *_nethttp.Response, error)
 
 	/*
-	 * GetTasksIDRunsID Retrieve a single run for a task.
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param taskID The task ID.
-	 * @param runID The run ID.
-	 * @return ApiGetTasksIDRunsIDRequest
-	 */
+			 * GetTasksIDRunsID Retrieve a run for a task.
+			 * Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+		Use this endpoint to retrieve detail and logs for a specific task run.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param taskID The task ID.
+			 * @param runID The run ID.
+			 * @return ApiGetTasksIDRunsIDRequest
+	*/
 	GetTasksIDRunsID(ctx _context.Context, taskID string, runID string) ApiGetTasksIDRunsIDRequest
 
 	/*
@@ -203,12 +237,20 @@ type TasksApi interface {
 	GetTasksIDRunsIDLogsExecuteWithHttpInfo(r ApiGetTasksIDRunsIDLogsRequest) (Logs, *_nethttp.Response, error)
 
 	/*
-	 * PatchTasksID Update a task
-	 * Update a task. This will cancel all queued runs.
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param taskID The task ID.
-	 * @return ApiPatchTasksIDRequest
-	 */
+			 * PatchTasksID Update a task
+			 * Updates a task and then cancels all scheduled runs of the task.
+
+		Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+		Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+		To update a task, pass an object that contains the updated key-value pairs.
+		To activate or inactivate a task, set the `status` property.
+		_`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param taskID The task ID.
+			 * @return ApiPatchTasksIDRequest
+	*/
 	PatchTasksID(ctx _context.Context, taskID string) ApiPatchTasksIDRequest
 
 	/*
@@ -226,10 +268,28 @@ type TasksApi interface {
 	PatchTasksIDExecuteWithHttpInfo(r ApiPatchTasksIDRequest) (Task, *_nethttp.Response, error)
 
 	/*
-	 * PostTasks Create a new task
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @return ApiPostTasksRequest
-	 */
+			 * PostTasks Create a task
+			 * Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
+
+		Use this endpoint to create a scheduled task that runs a Flux script.
+		In your task, provide one of the following:
+
+		  - _`flux`_ property with an inline Flux script
+		  - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID
+
+		#### InfluxDB Cloud
+
+		  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.
+
+		#### Related guides
+
+		- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
+		- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
+		- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @return ApiPostTasksRequest
+	*/
 	PostTasks(ctx _context.Context) ApiPostTasksRequest
 
 	/*
@@ -328,11 +388,17 @@ func (r ApiDeleteTasksIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, erro
 
 /*
  * DeleteTasksID Delete a task
- * Deletes a task and all associated records
+ * Deletes a task and associated records.
+
+Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
+Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
+
+If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param taskID The ID of the task to delete.
  * @return ApiDeleteTasksIDRequest
- */
+*/
 func (a *TasksApiService) DeleteTasksID(ctx _context.Context, taskID string) ApiDeleteTasksIDRequest {
 	return ApiDeleteTasksIDRequest{
 		ApiService: a,
@@ -479,12 +545,20 @@ func (r ApiDeleteTasksIDRunsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response
 }
 
 /*
- * DeleteTasksIDRunsID Cancel a running task.  #### InfluxDB Cloud    - Doesn't support this operation.
+ * DeleteTasksIDRunsID Cancel a running task
+ * Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+Use this endpoint with InfluxDB OSS to cancel a running task.
+
+#### InfluxDB Cloud
+
+  - Doesn't support this operation.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param taskID The task ID.
- * @param runID The run ID.
+ * @param runID The ID of the task run to cancel.
  * @return ApiDeleteTasksIDRunsIDRequest
- */
+*/
 func (a *TasksApiService) DeleteTasksIDRunsID(ctx _context.Context, taskID string, runID string) ApiDeleteTasksIDRunsIDRequest {
 	return ApiDeleteTasksIDRunsIDRequest{
 		ApiService: a,
@@ -614,6 +688,8 @@ type ApiGetTasksRequest struct {
 	orgID        *string
 	status       *string
 	limit        *int32
+	offset       *int32
+	sortBy       *string
 	type_        *string
 }
 
@@ -681,6 +757,22 @@ func (r ApiGetTasksRequest) GetLimit() *int32 {
 	return r.limit
 }
 
+func (r ApiGetTasksRequest) Offset(offset int32) ApiGetTasksRequest {
+	r.offset = &offset
+	return r
+}
+func (r ApiGetTasksRequest) GetOffset() *int32 {
+	return r.offset
+}
+
+func (r ApiGetTasksRequest) SortBy(sortBy string) ApiGetTasksRequest {
+	r.sortBy = &sortBy
+	return r
+}
+func (r ApiGetTasksRequest) GetSortBy() *string {
+	return r.sortBy
+}
+
 func (r ApiGetTasksRequest) Type_(type_ string) ApiGetTasksRequest {
 	r.type_ = &type_
 	return r
@@ -699,9 +791,14 @@ func (r ApiGetTasksRequest) ExecuteWithHttpInfo() (Tasks, *_nethttp.Response, er
 
 /*
  * GetTasks List all tasks
+ * Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/).
+
+To limit which tasks are returned, pass query parameters in your request.
+If no query parameters are passed, InfluxDB returns all tasks up to the default `limit`.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiGetTasksRequest
- */
+*/
 func (a *TasksApiService) GetTasks(ctx _context.Context) ApiGetTasksRequest {
 	return ApiGetTasksRequest{
 		ApiService: a,
@@ -766,6 +863,12 @@ func (a *TasksApiService) GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tas
 	if r.limit != nil {
 		localVarQueryParams.Add("limit", parameterToString(*r.limit, ""))
 	}
+	if r.offset != nil {
+		localVarQueryParams.Add("offset", parameterToString(*r.offset, ""))
+	}
+	if r.sortBy != nil {
+		localVarQueryParams.Add("sortBy", parameterToString(*r.sortBy, ""))
+	}
 	if r.type_ != nil {
 		localVarQueryParams.Add("type", parameterToString(*r.type_, ""))
 	}
@@ -818,6 +921,28 @@ func (a *TasksApiService) GetTasksExecuteWithHttpInfo(r ApiGetTasksRequest) (Tas
 		}
 		newErr.body = localVarBody
 		newErr.error = localVarHTTPResponse.Status
+		if localVarHTTPResponse.StatusCode == 401 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+			newErr.model = &v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
+		if localVarHTTPResponse.StatusCode == 500 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+			newErr.model = &v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -884,10 +1009,13 @@ func (r ApiGetTasksIDRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, e
 
 /*
  * GetTasksID Retrieve a task
+ * Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)
+by task ID.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param taskID The task ID.
  * @return ApiGetTasksIDRequest
- */
+*/
 func (a *TasksApiService) GetTasksID(ctx _context.Context, taskID string) ApiGetTasksIDRequest {
 	return ApiGetTasksIDRequest{
 		ApiService: a,
@@ -982,6 +1110,17 @@ func (a *TasksApiService) GetTasksIDExecuteWithHttpInfo(r ApiGetTasksIDRequest) 
 		}
 		newErr.body = localVarBody
 		newErr.error = localVarHTTPResponse.Status
+		if localVarHTTPResponse.StatusCode == 400 {
+			var v Error
+			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+			if err != nil {
+				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+				return localVarReturnValue, localVarHTTPResponse, newErr
+			}
+			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+			newErr.model = &v
+			return localVarReturnValue, localVarHTTPResponse, newErr
+		}
 		var v Error
 		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 		if err != nil {
@@ -1048,10 +1187,18 @@ func (r ApiGetTasksIDLogsRequest) ExecuteWithHttpInfo() (Logs, *_nethttp.Respons
 
 /*
  * GetTasksIDLogs Retrieve all logs for a task
+ * Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+When an InfluxDB task runs, a “run” record is created in the task’s history.
+Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
+
+Use this endpoint to retrieve only the log events for a task,
+without additional task metadata.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param taskID The task ID.
  * @return ApiGetTasksIDLogsRequest
- */
+*/
 func (a *TasksApiService) GetTasksIDLogs(ctx _context.Context, taskID string) ApiGetTasksIDLogsRequest {
 	return ApiGetTasksIDLogsRequest{
 		ApiService: a,
@@ -1432,12 +1579,16 @@ func (r ApiGetTasksIDRunsIDRequest) ExecuteWithHttpInfo() (Run, *_nethttp.Respon
 }
 
 /*
- * GetTasksIDRunsID Retrieve a single run for a task.
+ * GetTasksIDRunsID Retrieve a run for a task.
+ * Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+
+Use this endpoint to retrieve detail and logs for a specific task run.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param taskID The task ID.
  * @param runID The run ID.
  * @return ApiGetTasksIDRunsIDRequest
- */
+*/
 func (a *TasksApiService) GetTasksIDRunsID(ctx _context.Context, taskID string, runID string) ApiGetTasksIDRunsIDRequest {
 	return ApiGetTasksIDRunsIDRequest{
 		ApiService: a,
@@ -1785,11 +1936,19 @@ func (r ApiPatchTasksIDRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response,
 
 /*
  * PatchTasksID Update a task
- * Update a task. This will cancel all queued runs.
+ * Updates a task and then cancels all scheduled runs of the task.
+
+Use this endpoint to modify task properties (for example: `cron`, `name`, `flux`, `status`).
+Once InfluxDB applies the update, it cancels all scheduled runs of the task.
+
+To update a task, pass an object that contains the updated key-value pairs.
+To activate or inactivate a task, set the `status` property.
+_`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the task.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param taskID The task ID.
  * @return ApiPatchTasksIDRequest
- */
+*/
 func (a *TasksApiService) PatchTasksID(ctx _context.Context, taskID string) ApiPatchTasksIDRequest {
 	return ApiPatchTasksIDRequest{
 		ApiService: a,
@@ -1954,10 +2113,28 @@ func (r ApiPostTasksRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, er
 }
 
 /*
- * PostTasks Create a new task
+ * PostTasks Create a task
+ * Creates a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/) and returns the created task.
+
+Use this endpoint to create a scheduled task that runs a Flux script.
+In your task, provide one of the following:
+
+  - _`flux`_ property with an inline Flux script
+  - _`scriptID`_ property with an [invokable script](#tag/Invokable-Scripts) ID
+
+#### InfluxDB Cloud
+
+  - Requires either _`flux`_ (Flux query) or _`scriptID`_ (invokable script ID) in the task.
+
+#### Related guides
+
+- [Create a task]({{% INFLUXDB_DOCS_URL %}}/process-data/manage-tasks/create-task/).
+- [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
+- [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @return ApiPostTasksRequest
- */
+*/
 func (a *TasksApiService) PostTasks(ctx _context.Context) ApiPostTasksRequest {
 	return ApiPostTasksRequest{
 		ApiService: a,

--- a/api/api_users.gen.go
+++ b/api/api_users.gen.go
@@ -133,11 +133,16 @@ type UsersApi interface {
 	PostUsersExecuteWithHttpInfo(r ApiPostUsersRequest) (UserResponse, *_nethttp.Response, error)
 
 	/*
-	 * PostUsersIDPassword Update a password
-	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-	 * @param userID The user ID.
-	 * @return ApiPostUsersIDPasswordRequest
-	 */
+			 * PostUsersIDPassword Update a password
+			 * #### InfluxDB Cloud
+
+		InfluxDB Cloud does not support changing user passwords through the API.
+		Use the InfluxDB Cloud user interface to update your password.
+
+			 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+			 * @param userID The user ID.
+			 * @return ApiPostUsersIDPasswordRequest
+	*/
 	PostUsersIDPassword(ctx _context.Context, userID string) ApiPostUsersIDPasswordRequest
 
 	/*
@@ -1060,10 +1065,15 @@ func (r ApiPostUsersIDPasswordRequest) ExecuteWithHttpInfo() (*_nethttp.Response
 
 /*
  * PostUsersIDPassword Update a password
+ * #### InfluxDB Cloud
+
+InfluxDB Cloud does not support changing user passwords through the API.
+Use the InfluxDB Cloud user interface to update your password.
+
  * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
  * @param userID The user ID.
  * @return ApiPostUsersIDPasswordRequest
- */
+*/
 func (a *UsersApiService) PostUsersIDPassword(ctx _context.Context, userID string) ApiPostUsersIDPasswordRequest {
 	return ApiPostUsersIDPasswordRequest{
 		ApiService: a,

--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -373,17 +373,6 @@ func (a *WriteApiService) PostWriteExecuteWithHttpInfo(r ApiPostWriteRequest) (*
 			newErr.model = &v
 			return localVarHTTPResponse, newErr
 		}
-		if localVarHTTPResponse.StatusCode == 401 {
-			var v Error
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarHTTPResponse, newErr
-			}
-			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
-			newErr.model = &v
-			return localVarHTTPResponse, newErr
-		}
 		if localVarHTTPResponse.StatusCode == 404 {
 			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
@@ -397,17 +386,6 @@ func (a *WriteApiService) PostWriteExecuteWithHttpInfo(r ApiPostWriteRequest) (*
 		}
 		if localVarHTTPResponse.StatusCode == 413 {
 			var v LineProtocolLengthError
-			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
-			if err != nil {
-				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
-				return localVarHTTPResponse, newErr
-			}
-			v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
-			newErr.model = &v
-			return localVarHTTPResponse, newErr
-		}
-		if localVarHTTPResponse.StatusCode == 500 {
-			var v Error
 			err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())

--- a/api/contract/cli.yml
+++ b/api/contract/cli.yml
@@ -58,9 +58,9 @@ paths:
   /api/v2/delete:
     $ref: "./openapi/src/common/paths/delete.yml"
   /api/v2/tasks:
-    $ref: "./openapi/src/common/paths/tasks.yml"
+    $ref: "./openapi/src/cloud/paths/tasks.yml"
   /api/v2/tasks/{taskID}:
-    $ref: "./openapi/src/common/paths/tasks_taskID.yml"
+    $ref: "./openapi/src/cloud/paths/tasks_taskID.yml"
   /api/v2/tasks/{taskID}/runs:
     $ref: "./openapi/src/common/paths/tasks_taskID_runs.yml"
   /api/v2/tasks/{taskID}/runs/{runID}:
@@ -252,15 +252,15 @@ components:
     DeletePredicateRequest:
       $ref: "./openapi/src/common/schemas/DeletePredicateRequest.yml"
     Tasks:
-      $ref: "./openapi/src/common/schemas/Tasks.yml"
+      $ref: "./openapi/src/cloud/schemas/Tasks.yml"
     Task:
-      $ref: "./openapi/src/common/schemas/Task.yml"
+      $ref: "./openapi/src/cloud/schemas/Task.yml"
     TaskCreateRequest:
-      $ref: "./openapi/src/common/schemas/TaskCreateRequest.yml"
+      $ref: "./openapi/src/cloud/schemas/TaskCreateRequest.yml"
     TaskStatusType:
       $ref: "./openapi/src/common/schemas/TaskStatusType.yml"
     TaskUpdateRequest:
-      $ref: "./openapi/src/common/schemas/TaskUpdateRequest.yml"
+      $ref: "./openapi/src/cloud/schemas/TaskUpdateRequest.yml"
     Runs:
       $ref: "./openapi/src/common/schemas/Runs.yml"
     Run:

--- a/api/model_label.gen.go
+++ b/api/model_label.gen.go
@@ -19,7 +19,7 @@ type Label struct {
 	Id    *string `json:"id,omitempty" yaml:"id,omitempty"`
 	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
 	Name  *string `json:"name,omitempty" yaml:"name,omitempty"`
-	// Key/Value pairs associated with this label. Keys can be removed by sending an update with an empty value.
+	// Key-value pairs associated with this label. To remove a property, send an update with an empty value (`\"\"`) for the key.
 	Properties *map[string]string `json:"properties,omitempty" yaml:"properties,omitempty"`
 }
 

--- a/api/model_post_organization_request.gen.go
+++ b/api/model_post_organization_request.gen.go
@@ -18,8 +18,6 @@ import (
 type PostOrganizationRequest struct {
 	Name        string  `json:"name" yaml:"name"`
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
-	// An optional list of email address's to be invited to the organization
-	Users *[]string `json:"users,omitempty" yaml:"users,omitempty"`
 }
 
 // NewPostOrganizationRequest instantiates a new PostOrganizationRequest object
@@ -96,38 +94,6 @@ func (o *PostOrganizationRequest) SetDescription(v string) {
 	o.Description = &v
 }
 
-// GetUsers returns the Users field value if set, zero value otherwise.
-func (o *PostOrganizationRequest) GetUsers() []string {
-	if o == nil || o.Users == nil {
-		var ret []string
-		return ret
-	}
-	return *o.Users
-}
-
-// GetUsersOk returns a tuple with the Users field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *PostOrganizationRequest) GetUsersOk() (*[]string, bool) {
-	if o == nil || o.Users == nil {
-		return nil, false
-	}
-	return o.Users, true
-}
-
-// HasUsers returns a boolean if a field has been set.
-func (o *PostOrganizationRequest) HasUsers() bool {
-	if o != nil && o.Users != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetUsers gets a reference to the given []string and assigns it to the Users field.
-func (o *PostOrganizationRequest) SetUsers(v []string) {
-	o.Users = &v
-}
-
 func (o PostOrganizationRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -135,9 +101,6 @@ func (o PostOrganizationRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
-	}
-	if o.Users != nil {
-		toSerialize["users"] = o.Users
 	}
 	return json.Marshal(toSerialize)
 }

--- a/api/model_script_create_request.gen.go
+++ b/api/model_script_create_request.gen.go
@@ -16,8 +16,9 @@ import (
 
 // ScriptCreateRequest struct for ScriptCreateRequest
 type ScriptCreateRequest struct {
-	// The name of the script. The name must be unique within the organization.
-	Name        string `json:"name" yaml:"name"`
+	// Script name. The name must be unique within the organization.
+	Name string `json:"name" yaml:"name"`
+	// Script description. A description of the script.
 	Description string `json:"description" yaml:"description"`
 	// The script to execute.
 	Script   string         `json:"script" yaml:"script"`

--- a/api/model_task.gen.go
+++ b/api/model_task.gen.go
@@ -18,15 +18,13 @@ import (
 // Task struct for Task
 type Task struct {
 	Id string `json:"id" yaml:"id"`
-	// The type of the task, useful for filtering a task list.
-	Type *string `json:"type,omitempty" yaml:"type,omitempty"`
 	// The ID of the organization that owns the task.
 	OrgID string `json:"orgID" yaml:"orgID"`
 	// The name of the organization that owns the task.
 	Org *string `json:"org,omitempty" yaml:"org,omitempty"`
 	// The name of the task.
 	Name string `json:"name" yaml:"name"`
-	// The ID of the user who owns this Task.
+	// The ID of the user who owns the task.
 	OwnerID *string `json:"ownerID,omitempty" yaml:"ownerID,omitempty"`
 	// The description of the task.
 	Description *string         `json:"description,omitempty" yaml:"description,omitempty"`
@@ -34,11 +32,11 @@ type Task struct {
 	Labels      *[]Label        `json:"labels,omitempty" yaml:"labels,omitempty"`
 	// The ID of the authorization used when the task communicates with the query engine.
 	AuthorizationID *string `json:"authorizationID,omitempty" yaml:"authorizationID,omitempty"`
-	// The Flux script to run for this task.
-	Flux string `json:"flux" yaml:"flux"`
-	// An interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+	// The Flux script that the task runs.  #### Limitations  - If you use the `flux` property, you can't use the `scriptID` and `scriptParameters` properties.
+	Flux *string `json:"flux,omitempty" yaml:"flux,omitempty"`
+	// The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.
 	Every *string `json:"every,omitempty" yaml:"every,omitempty"`
-	// [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB bases cron runs on the system time.
+	// A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB bases cron runs on the system time.
 	Cron *string `json:"cron,omitempty" yaml:"cron,omitempty"`
 	// A [duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
 	Offset *string `json:"offset,omitempty" yaml:"offset,omitempty"`
@@ -49,18 +47,21 @@ type Task struct {
 	CreatedAt       *time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
 	UpdatedAt       *time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 	Links           *TaskLinks `json:"links,omitempty" yaml:"links,omitempty"`
+	// The ID of the script that the task runs.  #### Limitations  - If you use the `scriptID` property, you can't use the `flux` property.
+	ScriptID *string `json:"scriptID,omitempty" yaml:"scriptID,omitempty"`
+	// The parameter key-value pairs passed to the script (referenced by `scriptID`) during the task run.  #### Limitations  - `scriptParameters` requires `scriptID`. - If you use the `scriptID` and `scriptParameters` properties, you can't use the `flux` property.
+	ScriptParameters *map[string]interface{} `json:"scriptParameters,omitempty" yaml:"scriptParameters,omitempty"`
 }
 
 // NewTask instantiates a new Task object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTask(id string, orgID string, name string, flux string) *Task {
+func NewTask(id string, orgID string, name string) *Task {
 	this := Task{}
 	this.Id = id
 	this.OrgID = orgID
 	this.Name = name
-	this.Flux = flux
 	return &this
 }
 
@@ -94,38 +95,6 @@ func (o *Task) GetIdOk() (*string, bool) {
 // SetId sets field value
 func (o *Task) SetId(v string) {
 	o.Id = v
-}
-
-// GetType returns the Type field value if set, zero value otherwise.
-func (o *Task) GetType() string {
-	if o == nil || o.Type == nil {
-		var ret string
-		return ret
-	}
-	return *o.Type
-}
-
-// GetTypeOk returns a tuple with the Type field value if set, nil otherwise
-// and a boolean to check if the value has been set.
-func (o *Task) GetTypeOk() (*string, bool) {
-	if o == nil || o.Type == nil {
-		return nil, false
-	}
-	return o.Type, true
-}
-
-// HasType returns a boolean if a field has been set.
-func (o *Task) HasType() bool {
-	if o != nil && o.Type != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetType gets a reference to the given string and assigns it to the Type field.
-func (o *Task) SetType(v string) {
-	o.Type = &v
 }
 
 // GetOrgID returns the OrgID field value
@@ -368,28 +337,36 @@ func (o *Task) SetAuthorizationID(v string) {
 	o.AuthorizationID = &v
 }
 
-// GetFlux returns the Flux field value
+// GetFlux returns the Flux field value if set, zero value otherwise.
 func (o *Task) GetFlux() string {
-	if o == nil {
+	if o == nil || o.Flux == nil {
 		var ret string
 		return ret
 	}
-
-	return o.Flux
+	return *o.Flux
 }
 
-// GetFluxOk returns a tuple with the Flux field value
+// GetFluxOk returns a tuple with the Flux field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *Task) GetFluxOk() (*string, bool) {
-	if o == nil {
+	if o == nil || o.Flux == nil {
 		return nil, false
 	}
-	return &o.Flux, true
+	return o.Flux, true
 }
 
-// SetFlux sets field value
+// HasFlux returns a boolean if a field has been set.
+func (o *Task) HasFlux() bool {
+	if o != nil && o.Flux != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFlux gets a reference to the given string and assigns it to the Flux field.
 func (o *Task) SetFlux(v string) {
-	o.Flux = v
+	o.Flux = &v
 }
 
 // GetEvery returns the Every field value if set, zero value otherwise.
@@ -680,13 +657,74 @@ func (o *Task) SetLinks(v TaskLinks) {
 	o.Links = &v
 }
 
+// GetScriptID returns the ScriptID field value if set, zero value otherwise.
+func (o *Task) GetScriptID() string {
+	if o == nil || o.ScriptID == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptID
+}
+
+// GetScriptIDOk returns a tuple with the ScriptID field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Task) GetScriptIDOk() (*string, bool) {
+	if o == nil || o.ScriptID == nil {
+		return nil, false
+	}
+	return o.ScriptID, true
+}
+
+// HasScriptID returns a boolean if a field has been set.
+func (o *Task) HasScriptID() bool {
+	if o != nil && o.ScriptID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptID gets a reference to the given string and assigns it to the ScriptID field.
+func (o *Task) SetScriptID(v string) {
+	o.ScriptID = &v
+}
+
+// GetScriptParameters returns the ScriptParameters field value if set, zero value otherwise.
+func (o *Task) GetScriptParameters() map[string]interface{} {
+	if o == nil || o.ScriptParameters == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return *o.ScriptParameters
+}
+
+// GetScriptParametersOk returns a tuple with the ScriptParameters field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *Task) GetScriptParametersOk() (*map[string]interface{}, bool) {
+	if o == nil || o.ScriptParameters == nil {
+		return nil, false
+	}
+	return o.ScriptParameters, true
+}
+
+// HasScriptParameters returns a boolean if a field has been set.
+func (o *Task) HasScriptParameters() bool {
+	if o != nil && o.ScriptParameters != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptParameters gets a reference to the given map[string]interface{} and assigns it to the ScriptParameters field.
+func (o *Task) SetScriptParameters(v map[string]interface{}) {
+	o.ScriptParameters = &v
+}
+
 func (o Task) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
 		toSerialize["id"] = o.Id
-	}
-	if o.Type != nil {
-		toSerialize["type"] = o.Type
 	}
 	if true {
 		toSerialize["orgID"] = o.OrgID
@@ -712,7 +750,7 @@ func (o Task) MarshalJSON() ([]byte, error) {
 	if o.AuthorizationID != nil {
 		toSerialize["authorizationID"] = o.AuthorizationID
 	}
-	if true {
+	if o.Flux != nil {
 		toSerialize["flux"] = o.Flux
 	}
 	if o.Every != nil {
@@ -741,6 +779,12 @@ func (o Task) MarshalJSON() ([]byte, error) {
 	}
 	if o.Links != nil {
 		toSerialize["links"] = o.Links
+	}
+	if o.ScriptID != nil {
+		toSerialize["scriptID"] = o.ScriptID
+	}
+	if o.ScriptParameters != nil {
+		toSerialize["scriptParameters"] = o.ScriptParameters
 	}
 	return json.Marshal(toSerialize)
 }

--- a/api/model_task_create_request.gen.go
+++ b/api/model_task_create_request.gen.go
@@ -16,24 +16,35 @@ import (
 
 // TaskCreateRequest struct for TaskCreateRequest
 type TaskCreateRequest struct {
-	// The ID of the organization that owns this Task.
+	// The ID of the organization that owns the task.
 	OrgID *string `json:"orgID,omitempty" yaml:"orgID,omitempty"`
-	// The name of the organization that owns this Task.
+	// The name of the organization that owns the task.
 	Org    *string         `json:"org,omitempty" yaml:"org,omitempty"`
 	Status *TaskStatusType `json:"status,omitempty" yaml:"status,omitempty"`
-	// The Flux script to run for this task.
-	Flux string `json:"flux" yaml:"flux"`
-	// An optional description of the task.
+	// The Flux script that the task runs.  #### Limitations  - If you use the `flux` property, you can't use the `scriptID` and `scriptParameters` properties.
+	Flux *string `json:"flux,omitempty" yaml:"flux,omitempty"`
+	// The description of the task.
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	// The ID of the script that the task runs.  #### Limitations  - If you use the `scriptID` property, you can't use the `flux` property.
+	ScriptID *string `json:"scriptID,omitempty" yaml:"scriptID,omitempty"`
+	// The parameter key-value pairs passed to the script (referenced by `scriptID`) during the task run.  #### Limitations  - `scriptParameters` requires `scriptID`. - If you use the `scriptID` and `scriptParameters` properties, you can't use the `flux` property.
+	ScriptParameters *map[string]interface{} `json:"scriptParameters,omitempty" yaml:"scriptParameters,omitempty"`
+	// The name of the task
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+	// The interval ([duration literal](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals))) at which the task runs. `every` also determines when the task first runs, depending on the specified time.
+	Every *string `json:"every,omitempty" yaml:"every,omitempty"`
+	// A [Cron expression](https://en.wikipedia.org/wiki/Cron#Overview) that defines the schedule on which the task runs. InfluxDB bases cron runs on the system time.
+	Cron *string `json:"cron,omitempty" yaml:"cron,omitempty"`
+	// A [duration](https://docs.influxdata.com/flux/v0.x/spec/lexical-elements/#duration-literals) to delay execution of the task after the scheduled time has elapsed. `0` removes the offset.
+	Offset *string `json:"offset,omitempty" yaml:"offset,omitempty"`
 }
 
 // NewTaskCreateRequest instantiates a new TaskCreateRequest object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewTaskCreateRequest(flux string) *TaskCreateRequest {
+func NewTaskCreateRequest() *TaskCreateRequest {
 	this := TaskCreateRequest{}
-	this.Flux = flux
 	return &this
 }
 
@@ -141,28 +152,36 @@ func (o *TaskCreateRequest) SetStatus(v TaskStatusType) {
 	o.Status = &v
 }
 
-// GetFlux returns the Flux field value
+// GetFlux returns the Flux field value if set, zero value otherwise.
 func (o *TaskCreateRequest) GetFlux() string {
-	if o == nil {
+	if o == nil || o.Flux == nil {
 		var ret string
 		return ret
 	}
-
-	return o.Flux
+	return *o.Flux
 }
 
-// GetFluxOk returns a tuple with the Flux field value
+// GetFluxOk returns a tuple with the Flux field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *TaskCreateRequest) GetFluxOk() (*string, bool) {
-	if o == nil {
+	if o == nil || o.Flux == nil {
 		return nil, false
 	}
-	return &o.Flux, true
+	return o.Flux, true
 }
 
-// SetFlux sets field value
+// HasFlux returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasFlux() bool {
+	if o != nil && o.Flux != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFlux gets a reference to the given string and assigns it to the Flux field.
 func (o *TaskCreateRequest) SetFlux(v string) {
-	o.Flux = v
+	o.Flux = &v
 }
 
 // GetDescription returns the Description field value if set, zero value otherwise.
@@ -197,6 +216,198 @@ func (o *TaskCreateRequest) SetDescription(v string) {
 	o.Description = &v
 }
 
+// GetScriptID returns the ScriptID field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetScriptID() string {
+	if o == nil || o.ScriptID == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptID
+}
+
+// GetScriptIDOk returns a tuple with the ScriptID field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetScriptIDOk() (*string, bool) {
+	if o == nil || o.ScriptID == nil {
+		return nil, false
+	}
+	return o.ScriptID, true
+}
+
+// HasScriptID returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasScriptID() bool {
+	if o != nil && o.ScriptID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptID gets a reference to the given string and assigns it to the ScriptID field.
+func (o *TaskCreateRequest) SetScriptID(v string) {
+	o.ScriptID = &v
+}
+
+// GetScriptParameters returns the ScriptParameters field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetScriptParameters() map[string]interface{} {
+	if o == nil || o.ScriptParameters == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return *o.ScriptParameters
+}
+
+// GetScriptParametersOk returns a tuple with the ScriptParameters field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetScriptParametersOk() (*map[string]interface{}, bool) {
+	if o == nil || o.ScriptParameters == nil {
+		return nil, false
+	}
+	return o.ScriptParameters, true
+}
+
+// HasScriptParameters returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasScriptParameters() bool {
+	if o != nil && o.ScriptParameters != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptParameters gets a reference to the given map[string]interface{} and assigns it to the ScriptParameters field.
+func (o *TaskCreateRequest) SetScriptParameters(v map[string]interface{}) {
+	o.ScriptParameters = &v
+}
+
+// GetName returns the Name field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetName() string {
+	if o == nil || o.Name == nil {
+		var ret string
+		return ret
+	}
+	return *o.Name
+}
+
+// GetNameOk returns a tuple with the Name field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetNameOk() (*string, bool) {
+	if o == nil || o.Name == nil {
+		return nil, false
+	}
+	return o.Name, true
+}
+
+// HasName returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasName() bool {
+	if o != nil && o.Name != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetName gets a reference to the given string and assigns it to the Name field.
+func (o *TaskCreateRequest) SetName(v string) {
+	o.Name = &v
+}
+
+// GetEvery returns the Every field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetEvery() string {
+	if o == nil || o.Every == nil {
+		var ret string
+		return ret
+	}
+	return *o.Every
+}
+
+// GetEveryOk returns a tuple with the Every field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetEveryOk() (*string, bool) {
+	if o == nil || o.Every == nil {
+		return nil, false
+	}
+	return o.Every, true
+}
+
+// HasEvery returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasEvery() bool {
+	if o != nil && o.Every != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetEvery gets a reference to the given string and assigns it to the Every field.
+func (o *TaskCreateRequest) SetEvery(v string) {
+	o.Every = &v
+}
+
+// GetCron returns the Cron field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetCron() string {
+	if o == nil || o.Cron == nil {
+		var ret string
+		return ret
+	}
+	return *o.Cron
+}
+
+// GetCronOk returns a tuple with the Cron field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetCronOk() (*string, bool) {
+	if o == nil || o.Cron == nil {
+		return nil, false
+	}
+	return o.Cron, true
+}
+
+// HasCron returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasCron() bool {
+	if o != nil && o.Cron != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetCron gets a reference to the given string and assigns it to the Cron field.
+func (o *TaskCreateRequest) SetCron(v string) {
+	o.Cron = &v
+}
+
+// GetOffset returns the Offset field value if set, zero value otherwise.
+func (o *TaskCreateRequest) GetOffset() string {
+	if o == nil || o.Offset == nil {
+		var ret string
+		return ret
+	}
+	return *o.Offset
+}
+
+// GetOffsetOk returns a tuple with the Offset field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskCreateRequest) GetOffsetOk() (*string, bool) {
+	if o == nil || o.Offset == nil {
+		return nil, false
+	}
+	return o.Offset, true
+}
+
+// HasOffset returns a boolean if a field has been set.
+func (o *TaskCreateRequest) HasOffset() bool {
+	if o != nil && o.Offset != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetOffset gets a reference to the given string and assigns it to the Offset field.
+func (o *TaskCreateRequest) SetOffset(v string) {
+	o.Offset = &v
+}
+
 func (o TaskCreateRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.OrgID != nil {
@@ -208,11 +419,29 @@ func (o TaskCreateRequest) MarshalJSON() ([]byte, error) {
 	if o.Status != nil {
 		toSerialize["status"] = o.Status
 	}
-	if true {
+	if o.Flux != nil {
 		toSerialize["flux"] = o.Flux
 	}
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
+	}
+	if o.ScriptID != nil {
+		toSerialize["scriptID"] = o.ScriptID
+	}
+	if o.ScriptParameters != nil {
+		toSerialize["scriptParameters"] = o.ScriptParameters
+	}
+	if o.Name != nil {
+		toSerialize["name"] = o.Name
+	}
+	if o.Every != nil {
+		toSerialize["every"] = o.Every
+	}
+	if o.Cron != nil {
+		toSerialize["cron"] = o.Cron
+	}
+	if o.Offset != nil {
+		toSerialize["offset"] = o.Offset
 	}
 	return json.Marshal(toSerialize)
 }

--- a/api/model_task_status_type.gen.go
+++ b/api/model_task_status_type.gen.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 )
 
-// TaskStatusType the model 'TaskStatusType'
+// TaskStatusType `inactive` cancels scheduled runs and prevents manual runs of the task.
 type TaskStatusType string
 
 // List of TaskStatusType

--- a/api/model_task_update_request.gen.go
+++ b/api/model_task_update_request.gen.go
@@ -17,18 +17,22 @@ import (
 // TaskUpdateRequest struct for TaskUpdateRequest
 type TaskUpdateRequest struct {
 	Status *TaskStatusType `json:"status,omitempty" yaml:"status,omitempty"`
-	// The Flux script to run for this task.
+	// Update the Flux script that the task runs.
 	Flux *string `json:"flux,omitempty" yaml:"flux,omitempty"`
-	// Override the 'name' option in the flux script.
+	// Update the 'name' option in the flux script.
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
-	// Override the 'every' option in the flux script.
+	// Update the 'every' option in the flux script.
 	Every *string `json:"every,omitempty" yaml:"every,omitempty"`
-	// Override the 'cron' option in the flux script.
+	// Update the 'cron' option in the flux script.
 	Cron *string `json:"cron,omitempty" yaml:"cron,omitempty"`
-	// Override the 'offset' option in the flux script.
+	// Update the 'offset' option in the flux script.
 	Offset *string `json:"offset,omitempty" yaml:"offset,omitempty"`
-	// An optional description of the task.
+	// Update the description of the task.
 	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+	// Update the 'scriptID' of the task.
+	ScriptID *string `json:"scriptID,omitempty" yaml:"scriptID,omitempty"`
+	// Update the 'scriptParameters' of the task.
+	ScriptParameters *map[string]interface{} `json:"scriptParameters,omitempty" yaml:"scriptParameters,omitempty"`
 }
 
 // NewTaskUpdateRequest instantiates a new TaskUpdateRequest object
@@ -272,6 +276,70 @@ func (o *TaskUpdateRequest) SetDescription(v string) {
 	o.Description = &v
 }
 
+// GetScriptID returns the ScriptID field value if set, zero value otherwise.
+func (o *TaskUpdateRequest) GetScriptID() string {
+	if o == nil || o.ScriptID == nil {
+		var ret string
+		return ret
+	}
+	return *o.ScriptID
+}
+
+// GetScriptIDOk returns a tuple with the ScriptID field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskUpdateRequest) GetScriptIDOk() (*string, bool) {
+	if o == nil || o.ScriptID == nil {
+		return nil, false
+	}
+	return o.ScriptID, true
+}
+
+// HasScriptID returns a boolean if a field has been set.
+func (o *TaskUpdateRequest) HasScriptID() bool {
+	if o != nil && o.ScriptID != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptID gets a reference to the given string and assigns it to the ScriptID field.
+func (o *TaskUpdateRequest) SetScriptID(v string) {
+	o.ScriptID = &v
+}
+
+// GetScriptParameters returns the ScriptParameters field value if set, zero value otherwise.
+func (o *TaskUpdateRequest) GetScriptParameters() map[string]interface{} {
+	if o == nil || o.ScriptParameters == nil {
+		var ret map[string]interface{}
+		return ret
+	}
+	return *o.ScriptParameters
+}
+
+// GetScriptParametersOk returns a tuple with the ScriptParameters field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *TaskUpdateRequest) GetScriptParametersOk() (*map[string]interface{}, bool) {
+	if o == nil || o.ScriptParameters == nil {
+		return nil, false
+	}
+	return o.ScriptParameters, true
+}
+
+// HasScriptParameters returns a boolean if a field has been set.
+func (o *TaskUpdateRequest) HasScriptParameters() bool {
+	if o != nil && o.ScriptParameters != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetScriptParameters gets a reference to the given map[string]interface{} and assigns it to the ScriptParameters field.
+func (o *TaskUpdateRequest) SetScriptParameters(v map[string]interface{}) {
+	o.ScriptParameters = &v
+}
+
 func (o TaskUpdateRequest) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Status != nil {
@@ -294,6 +362,12 @@ func (o TaskUpdateRequest) MarshalJSON() ([]byte, error) {
 	}
 	if o.Description != nil {
 		toSerialize["description"] = o.Description
+	}
+	if o.ScriptID != nil {
+		toSerialize["scriptID"] = o.ScriptID
+	}
+	if o.ScriptParameters != nil {
+		toSerialize["scriptParameters"] = o.ScriptParameters
 	}
 	return json.Marshal(toSerialize)
 }

--- a/clients/task/task.go
+++ b/clients/task/task.go
@@ -19,7 +19,9 @@ type Client struct {
 
 type CreateParams struct {
 	clients.OrgParams
-	FluxQuery string
+	FluxQuery    string
+	ScriptID     string
+	ScriptParams map[string]interface{}
 }
 
 type NameOrID struct {
@@ -73,9 +75,11 @@ func (c Client) Create(ctx context.Context, params *CreateParams) error {
 		return err
 	}
 	createRequest := api.TaskCreateRequest{
-		Flux:  params.FluxQuery,
-		OrgID: org.IDOrNil(),
-		Org:   org.NameOrNil(),
+		Flux:             &params.FluxQuery,
+		OrgID:            org.IDOrNil(),
+		Org:              org.NameOrNil(),
+		ScriptID:         &params.ScriptID,
+		ScriptParameters: &params.ScriptParams,
 	}
 	task, err := c.PostTasks(ctx).TaskCreateRequest(createRequest).Execute()
 	if err != nil {
@@ -258,9 +262,11 @@ Rerun without '--dry-run' to execute
 }
 
 type UpdateParams struct {
-	FluxQuery string
-	TaskID    string
-	Status    string
+	FluxQuery    string
+	TaskID       string
+	Status       string
+	ScriptID     string
+	ScriptParams map[string]interface{}
 }
 
 func (c Client) Update(ctx context.Context, params *UpdateParams) error {
@@ -278,8 +284,10 @@ func (c Client) Update(ctx context.Context, params *UpdateParams) error {
 		status = &s
 	}
 	task, err := c.PatchTasksID(ctx, params.TaskID).TaskUpdateRequest(api.TaskUpdateRequest{
-		Status: status,
-		Flux:   flux,
+		Status:           status,
+		Flux:             flux,
+		ScriptID:         &params.ScriptID,
+		ScriptParameters: &params.ScriptParams,
 	}).Execute()
 	if err != nil {
 		return err
@@ -352,6 +360,7 @@ func (c Client) printTasks(printOpts taskPrintOpts) error {
 			"Status":          derefOrEmpty((*string)(t.Status)),
 			"Every":           derefOrEmpty(t.Every),
 			"Cron":            derefOrEmpty(t.Cron),
+			"ScriptID":        derefOrEmpty(t.ScriptID),
 		}
 		rows = append(rows, row)
 	}


### PR DESCRIPTION
This PR updates the openapi submodule to include the new invokable scripts from tasks functionality for the cloud. The CLI commands have not been updated to allow access to the new features yet.

Note since the tasks api is available to both OSS and cloud, but they have different features available, the cloud yaml takes priority for generation.