### PR TITLE
feat: added script support when updating tasks for the cloud

### DIFF
--- a/clients/task/task.go
+++ b/clients/task/task.go
@@ -355,6 +355,7 @@ func (c Client) printTasks(printOpts taskPrintOpts) error {
 		"Status",
 		"Every",
 		"Cron",
+		"ScriptID",
 	}
 
 	if printOpts.task != nil {

--- a/clients/task/task.go
+++ b/clients/task/task.go
@@ -283,11 +283,22 @@ func (c Client) Update(ctx context.Context, params *UpdateParams) error {
 		}
 		status = &s
 	}
+
+	scriptID := &params.ScriptID
+	if len(params.ScriptID) == 0 {
+		scriptID = nil
+	}
+
+	scriptParams := &params.ScriptParams
+	if len(params.ScriptParams) == 0 {
+		scriptParams = nil
+	}
+
 	task, err := c.PatchTasksID(ctx, params.TaskID).TaskUpdateRequest(api.TaskUpdateRequest{
 		Status:           status,
 		Flux:             flux,
-		ScriptID:         &params.ScriptID,
-		ScriptParameters: &params.ScriptParams,
+		ScriptID:         scriptID,
+		ScriptParameters: scriptParams,
 	}).Execute()
 	if err != nil {
 		return err

--- a/cmd/influx/task.go
+++ b/cmd/influx/task.go
@@ -1,6 +1,10 @@
 package main
 
 import (
+	"encoding/json"
+	"errors"
+	"strings"
+
 	"github.com/influxdata/influx-cli/v2/clients"
 	"github.com/influxdata/influx-cli/v2/clients/task"
 	"github.com/influxdata/influx-cli/v2/pkg/cli/middleware"
@@ -159,6 +163,8 @@ func newTaskRetryFailedCmd() cli.Command {
 
 func newTaskUpdateCmd() cli.Command {
 	var params task.UpdateParams
+	var scriptID string
+	var scriptParams string
 	flags := commonFlags()
 	flags = append(flags, []cli.Flag{
 		&cli.StringFlag{
@@ -177,6 +183,16 @@ func newTaskUpdateCmd() cli.Command {
 			Usage:     "Path to Flux script file",
 			TakesFile: true,
 		},
+		&cli.StringFlag{
+			Name:        "script-id",
+			Usage:       "[Cloud only] Path to Flux script file",
+			Destination: &scriptID,
+		},
+		&cli.StringFlag{
+			Name:        "script-params",
+			Usage:       "[Cloud only] Path to Flux script file",
+			Destination: &scriptParams,
+		},
 	}...)
 	return cli.Command{
 		Name:      "update",
@@ -185,16 +201,32 @@ func newTaskUpdateCmd() cli.Command {
 		Flags:     flags,
 		Before:    middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Action: func(ctx *cli.Context) error {
+			fluxFile := ctx.String("file")
+			if len(fluxFile) > 0 && len(scriptID) > 0 {
+				return errors.New("cannot specify both Flux from a file and a script ID")
+			}
+
 			api := getAPI(ctx)
 			client := task.Client{
 				CLI:      getCLI(ctx),
 				TasksApi: api.TasksApi,
 			}
-			var err error
-			if ctx.String("file") != "" || ctx.NArg() != 0 {
-				params.FluxQuery, err = clients.ReadQuery(ctx.String("file"), ctx.Args())
-				if err != nil {
-					return err
+			if len(fluxFile) > 0 {
+				var err error
+				if ctx.String("file") != "" || ctx.NArg() != 0 {
+					params.FluxQuery, err = clients.ReadQuery(ctx.String("file"), ctx.Args())
+					if err != nil {
+						return err
+					}
+				}
+			} else {
+				params.ScriptID = scriptID
+				params.ScriptParams = make(map[string]interface{})
+
+				if len(scriptParams) > 0 {
+					if err := json.NewDecoder(strings.NewReader(scriptParams)).Decode(&params.ScriptParams); err != nil {
+						return err
+					}
 				}
 			}
 			return client.Update(getContext(ctx), &params)


### PR DESCRIPTION
This PR adds invokable script functionality to the task update command, which is only available for the cloud. Tested on OSS and cloud, OSS will ignore the flags marked as cloud-only.

Also properly print the script ID when tasks are listed in table format.

closes https://github.com/influxdata/influx-cli/issues/408, closes https://github.com/influxdata/influx-cli/issues/409, closes https://github.com/influxdata/influx-cli/issues/410