### PR TITLE
fix: update unsupported xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ executors:
       resource_class: arm.medium
   mac:
     macos:
-      xcode: 12.4.0
+      xcode: 12.5.1
       resource_class: medium
     shell: /bin/bash -eo pipefail
   windows:


### PR DESCRIPTION
CircleCI was erroring:
```
Build-agent version 1.0.134103-8a9e13ee (2022-08-02T13:24:16+0000)
Creating a dedicated VM with xcode:12.4.0 image
failed to create host: Image xcode:12.4.0 is not supported

failed to create host: Image xcode:12.4.0 is not supported
```
This PR updates to the latest supported version.