### PR TITLE
Clarify difference in virtual vs physical dbrps when listing

### DIFF
--- a/clients/v1_dbrps/v1_dbrps.go
+++ b/clients/v1_dbrps/v1_dbrps.go
@@ -219,7 +219,6 @@ func (c Client) printDBRPs(opts dbrpPrintOpts) error {
 		"Bucket ID",
 		"Retention Policy",
 		"Default",
-		"Virtual",
 		"Organization ID",
 	}
 
@@ -234,7 +233,6 @@ func (c Client) printDBRPs(opts dbrpPrintOpts) error {
 			"Database":         t.Database,
 			"Retention Policy": t.RetentionPolicy,
 			"Default":          t.Default,
-			"Virtual":          t.GetVirtual(),
 			"Organization ID":  t.OrgID,
 			"Bucket ID":        t.BucketID,
 		}

--- a/clients/v1_dbrps/v1_dbrps.go
+++ b/clients/v1_dbrps/v1_dbrps.go
@@ -68,8 +68,20 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to list dbrps: %w", err)
 	}
+	var virtDbrps []api.DBRP
+	var physDbrps []api.DBRP
+	for _, dbrp := range dbrps.GetContent() {
+		if dbrp.GetVirtual() {
+			virtDbrps = append(virtDbrps, dbrp)
+		} else {
+			physDbrps = append(physDbrps, dbrp)
+		}
+	}
 
-	c.printDBRPs(dbrpPrintOpts{dbrps: dbrps.GetContent()})
+	c.printDBRPs(dbrpPrintOpts{dbrps: physDbrps})
+	fmt.Fprintln(c.StdIO, "\nVIRTUAL DBRP MAPPINGS (READ-ONLY)")
+	fmt.Fprintln(c.StdIO, "----------------------------------")
+	c.printDBRPs(dbrpPrintOpts{dbrps: virtDbrps})
 
 	return nil
 }

--- a/clients/v1_dbrps/v1_dbrps_test.go
+++ b/clients/v1_dbrps/v1_dbrps_test.go
@@ -31,6 +31,7 @@ func TestClient_List(t *testing.T) {
 		registerExpectations func(*testing.T, *mock.MockDBRPsApi)
 		expectedError        error
 		outLines             []string
+		virtLines            []string
 	}{
 		{
 			name:          "no org id or org name",
@@ -74,6 +75,16 @@ func TestClient_List(t *testing.T) {
 							BucketID:        "456",
 							RetentionPolicy: "someRP",
 							Default:         true,
+							Virtual:         api.PtrBool(false),
+							OrgID:           "1234123412341234",
+						},
+						{
+							Id:              "567",
+							Database:        "someDB",
+							BucketID:        "456",
+							RetentionPolicy: "someRP",
+							Default:         true,
+							Virtual:         api.PtrBool(true),
 							OrgID:           "1234123412341234",
 						},
 					},
@@ -82,6 +93,9 @@ func TestClient_List(t *testing.T) {
 			outLines: []string{
 				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
 				`234\s+someDB\s+456\s+someRP\s+true\s+1234123412341234`,
+			},
+			virtLines: []string{
+				`567\s+someDB\s+456\s+someRP\s+true\s+1234123412341234`,
 			},
 		},
 		{
@@ -124,10 +138,10 @@ func TestClient_List(t *testing.T) {
 				testutils.MatchLines(t,
 					append([]string{header},
 						append(tc.outLines,
-							[]string{
+							append([]string{
 								`VIRTUAL DBRP MAPPINGS \(READ-ONLY\)`,
 								"----------------------------------",
-								header}...)...),
+								header}, tc.virtLines...)...)...),
 					strings.Split(stdout.String(), "\n"))
 			}
 		})

--- a/clients/v1_dbrps/v1_dbrps_test.go
+++ b/clients/v1_dbrps/v1_dbrps_test.go
@@ -80,8 +80,8 @@ func TestClient_List(t *testing.T) {
 				}, nil)
 			},
 			outLines: []string{
-				`123\s+someDB\s+456\s+someRP\s+false\s+false\s+1234123412341234`,
-				`234\s+someDB\s+456\s+someRP\s+true\s+false\s+1234123412341234`,
+				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
+				`234\s+someDB\s+456\s+someRP\s+true\s+1234123412341234`,
 			},
 		},
 		{
@@ -120,7 +120,15 @@ func TestClient_List(t *testing.T) {
 			require.Equal(t, tc.expectedError, err)
 
 			if tc.expectedError == nil {
-				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Virtual\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
+				header := `ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Organization ID`
+				testutils.MatchLines(t,
+					append([]string{header},
+						append(tc.outLines,
+							[]string{
+								`VIRTUAL DBRP MAPPINGS \(READ-ONLY\)`,
+								"----------------------------------",
+								header}...)...),
+					strings.Split(stdout.String(), "\n"))
 			}
 		})
 	}
@@ -160,7 +168,7 @@ func TestClient_Create(t *testing.T) {
 				}, nil)
 			},
 			outLines: []string{
-				`123\s+someDB\s+456\s+someRP\s+false\s+false\s+1234123412341234`,
+				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
 			},
 		},
 		{
@@ -200,7 +208,7 @@ func TestClient_Create(t *testing.T) {
 			require.Equal(t, tc.expectedError, err)
 
 			if tc.expectedError == nil {
-				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Virtual\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
+				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
 			}
 		})
 	}
@@ -243,7 +251,7 @@ func TestClient_Update(t *testing.T) {
 				}, nil)
 			},
 			outLines: []string{
-				`123\s+someDB\s+456\s+someRP\s+false\s+false\s+1234123412341234`,
+				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
 			},
 		},
 		{
@@ -268,7 +276,7 @@ func TestClient_Update(t *testing.T) {
 				}, nil)
 			},
 			outLines: []string{
-				`123\s+someDB\s+456\s+someRP\s+false\s+false\s+1234123412341234`,
+				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
 			},
 		},
 		{
@@ -308,7 +316,7 @@ func TestClient_Update(t *testing.T) {
 			require.Equal(t, tc.expectedError, err)
 
 			if tc.expectedError == nil {
-				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Virtual\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
+				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
 			}
 		})
 	}
@@ -355,7 +363,7 @@ func TestClient_Delete(t *testing.T) {
 				DBRPsApi.EXPECT().DeleteDBRPIDExecute(gomock.Any()).Return(nil)
 			},
 			outLines: []string{
-				`123\s+someDB\s+456\s+someRP\s+false\s+false\s+1234123412341234`,
+				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
 			},
 		},
 		{
@@ -384,7 +392,7 @@ func TestClient_Delete(t *testing.T) {
 				DBRPsApi.EXPECT().DeleteDBRPIDExecute(gomock.Any()).Return(nil)
 			},
 			outLines: []string{
-				`123\s+someDB\s+456\s+someRP\s+false\s+false\s+1234123412341234`,
+				`123\s+someDB\s+456\s+someRP\s+false\s+1234123412341234`,
 			},
 		},
 		{
@@ -453,7 +461,7 @@ func TestClient_Delete(t *testing.T) {
 			require.Equal(t, tc.expectedError, err)
 
 			if tc.expectedError == nil {
-				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Virtual\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
+				testutils.MatchLines(t, append([]string{`ID\s+Database\s+Bucket\s+ID\s+Retention Policy\s+Default\s+Organization ID`}, tc.outLines...), strings.Split(stdout.String(), "\n"))
 			}
 		})
 	}

--- a/cmd/influx/v1_dbrp.go
+++ b/cmd/influx/v1_dbrp.go
@@ -25,8 +25,13 @@ func newV1DBRPListCmd() cli.Command {
 	flags := append(commonFlags(), getOrgFlags(&params.OrgParams)...)
 
 	return cli.Command{
-		Name:    "list",
-		Usage:   "List database and retention policy mappings",
+		Name:  "list",
+		Usage: "List database and retention policy mappings",
+		Description: `List database and retention policy mappings, both standard and virtual.
+
+   Virtual DBRP mappings (InfluxDB OSS only) are created automatically using the bucket name.
+   Virtual mappings are read-only. To modify a virtual DBRP mapping, create a new, explicit DBRP mapping.
+   For more information, see https://docs.influxdata.com/influxdb/latest/query-data/influxql/dbrp/`,
 		Aliases: []string{"find", "ls"},
 		Flags: append(
 			flags,


### PR DESCRIPTION
- Add new help info about virtual DBRPs for `influx v1 dbrp list -h` 
![image](https://user-images.githubusercontent.com/32912555/184994040-51646149-cc32-4650-a3bf-26db5abe3e98.png)


- Split `influx v1 dbrp list` into physical and virtual DBRP tables
![command line screenshot](https://user-images.githubusercontent.com/32912555/184993690-463b4fd2-a664-4b46-b537-3541e06a75b6.png)