### PR TITLE
fix(stacks): Fix stack error typo

### DIFF
--- a/clients/stacks/stacks.go
+++ b/clients/stacks/stacks.go
@@ -134,7 +134,7 @@ func (c Client) Update(ctx context.Context, params *UpdateParams) error {
 
 	stack, err := c.UpdateStack(ctx, params.Id).StackPatchRequest(req).Execute()
 	if err != nil {
-		return fmt.Errorf("failed to udpate stack %q: %w", params.Id, err)
+		return fmt.Errorf("failed to update stack %q: %w", params.Id, err)
 	}
 	if err := c.printStacks(stackPrintOptions{stack: &stack}); err != nil {
 		return err


### PR DESCRIPTION
Spotted this typo whilst investigating a stack issue and is a simple fix in an error returned to the user.