### PR TITLE
chore: update generator image

### DIFF
--- a/api/response.gen.go
+++ b/api/response.gen.go
@@ -32,7 +32,7 @@ type APIResponse struct {
 	Payload []byte `json:"-"`
 }
 
-// NewAPIResponse returns a new APIResonse object.
+// NewAPIResponse returns a new APIResponse object.
 func NewAPIResponse(r *http.Response) *APIResponse {
 
 	response := &APIResponse{Response: r}

--- a/etc/generate-openapi.sh
+++ b/etc/generate-openapi.sh
@@ -7,7 +7,7 @@ declare -r API_DIR="${ROOT_DIR}/api"
 
 declare -r GENERATED_PATTERN='^// Code generated .* DO NOT EDIT\.$'
 declare -r MERGE_DOCKER_IMG=quay.io/influxdb/swagger-cli
-declare -r GENERATOR_DOCKER_IMG=openapitools/openapi-generator-cli:v5.1.0
+declare -r GENERATOR_DOCKER_IMG=openapitools/openapi-generator-cli:v5.1.1
 declare -r TAG_STRIP_IMG=python:3.9-alpine3.15
 
 # Clean up all the generated files in the target directory.


### PR DESCRIPTION
5.1.1 introduced arm images so now the build is not terribly slow on Apple Silicon Macs.