### PR TITLE
fix: updated api for deleting secrets so "influx secret delete" command works again

### DIFF
--- a/api/api_authorizations.gen.go
+++ b/api/api_authorizations.gen.go
@@ -383,18 +383,18 @@ func (r ApiGetAuthorizationsRequest) ExecuteWithHttpInfo() (Authorizations, *_ne
 }
 
 /*
-  - GetAuthorizations List authorizations
-  - Retrieves a list of authorizations.
+ * GetAuthorizations List authorizations
+ * Retrieves a list of authorizations.
 
 To limit which authorizations are returned, pass query parameters in your request.
 If no query parameters are passed, InfluxDB returns all authorizations.
 
 #### InfluxDB OSS
 
-  - Returns
-    [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token) values in authorizations.
-  - If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,
-    InfluxDB OSS returns authorizations for all organizations in the instance.
+- Returns
+  [API token]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#token) values in authorizations.
+- If the request uses an  _[operator token](https://docs.influxdata.com/influxdb/latest/security/tokens/#operator-token)_,
+  InfluxDB OSS returns authorizations for all organizations in the instance.
 
 #### Required permissions
 
@@ -404,8 +404,8 @@ If no query parameters are passed, InfluxDB returns all authorizations.
 
 - [View tokens]({{% INFLUXDB_DOCS_URL %}}/security/tokens/view-tokens/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetAuthorizationsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetAuthorizationsRequest
 */
 func (a *AuthorizationsApiService) GetAuthorizations(ctx _context.Context) ApiGetAuthorizationsRequest {
 	return ApiGetAuthorizationsRequest{
@@ -940,8 +940,8 @@ func (r ApiPostAuthorizationsRequest) ExecuteWithHttpInfo() (Authorization, *_ne
 }
 
 /*
-  - PostAuthorizations Create an authorization
-  - Creates an authorization.
+ * PostAuthorizations Create an authorization
+ * Creates an authorization.
 
 Use this endpoint to create an authorization, which generates an API token
 with permissions to `read` or `write` to a specific resource or `type` of resource.
@@ -955,11 +955,11 @@ Keep the following in mind when creating and updating authorizations:
 
 #### Limitations
 
-  - In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any
-    user with an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_.
-  - Even if an API token has `read-authorizations` permission, the
-    token can't be used to view its authorization details.
-  - Tokens stop working when the user who created the token is deleted.
+- In InfluxDB OSS, API tokens are visible to the user who created the authorization and to any
+  user with an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_.
+- Even if an API token has `read-authorizations` permission, the
+  token can't be used to view its authorization details.
+- Tokens stop working when the user who created the token is deleted.
 
 We recommend creating a generic user to create and manage tokens for writing data.
 
@@ -967,8 +967,8 @@ We recommend creating a generic user to create and manage tokens for writing dat
 
 - [Create a token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/create-token/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostAuthorizationsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostAuthorizationsRequest
 */
 func (a *AuthorizationsApiService) PostAuthorizations(ctx _context.Context) ApiPostAuthorizationsRequest {
 	return ApiPostAuthorizationsRequest{

--- a/api/api_backup.gen.go
+++ b/api/api_backup.gen.go
@@ -122,14 +122,13 @@ func (r ApiGetBackupKVRequest) ExecuteWithHttpInfo() (*_nethttp.Response, *_neth
 }
 
 /*
-  - GetBackupKV Download snapshot of metadata stored in the server's embedded KV store. Don't use with InfluxDB versions greater than InfluxDB 2.1.x.
-  - Retrieves a snapshot of metadata stored in the server's embedded KV store.
-
+ * GetBackupKV Download snapshot of metadata stored in the server's embedded KV store. Don't use with InfluxDB versions greater than InfluxDB 2.1.x.
+ * Retrieves a snapshot of metadata stored in the server's embedded KV store.
 InfluxDB versions greater than 2.1.x don't include metadata stored in embedded SQL;
 avoid using this endpoint with versions greater than 2.1.x.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetBackupKVRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetBackupKVRequest
 */
 func (a *BackupApiService) GetBackupKV(ctx _context.Context) ApiGetBackupKVRequest {
 	return ApiGetBackupKVRequest{

--- a/api/api_bucket_schemas.gen.go
+++ b/api/api_bucket_schemas.gen.go
@@ -221,9 +221,8 @@ func (r ApiCreateMeasurementSchemaRequest) ExecuteWithHttpInfo() (MeasurementSch
 }
 
 /*
-  - CreateMeasurementSchema Create a measurement schema for a bucket
-  - Creates an _explict_ measurement [schema]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)
-
+ * CreateMeasurementSchema Create a measurement schema for a bucket
+ * Creates an _explict_ measurement [schema]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)
 for a bucket.
 
 _Explicit_ schemas are used to enforce column names, tags, fields, and data
@@ -244,9 +243,9 @@ schemas.
 - [Manage bucket schemas]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/bucket-schema/).
 - [Create a bucket with an explicit schema]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/create-bucket/#create-a-bucket-with-an-explicit-schema)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param bucketID A bucket ID. Adds a schema for the specified bucket.
-  - @return ApiCreateMeasurementSchemaRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID A bucket ID. Adds a schema for the specified bucket.
+ * @return ApiCreateMeasurementSchemaRequest
 */
 func (a *BucketSchemasApiService) CreateMeasurementSchema(ctx _context.Context, bucketID string) ApiCreateMeasurementSchemaRequest {
 	return ApiCreateMeasurementSchemaRequest{
@@ -444,13 +443,13 @@ func (r ApiGetMeasurementSchemaRequest) ExecuteWithHttpInfo() (MeasurementSchema
 }
 
 /*
-* GetMeasurementSchema Retrieve a measurement schema
-* Retrieves an explicit measurement [schema]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema).
+ * GetMeasurementSchema Retrieve a measurement schema
+ * Retrieves an explicit measurement [schema]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema).
 
-* @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-* @param bucketID A bucket ID. Retrieves schemas for the specified bucket.
-* @param measurementID The measurement schema ID. Specifies the measurement schema to retrieve.
-* @return ApiGetMeasurementSchemaRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID A bucket ID. Retrieves schemas for the specified bucket.
+ * @param measurementID The measurement schema ID. Specifies the measurement schema to retrieve.
+ * @return ApiGetMeasurementSchemaRequest
  */
 func (a *BucketSchemasApiService) GetMeasurementSchema(ctx _context.Context, bucketID string, measurementID string) ApiGetMeasurementSchemaRequest {
 	return ApiGetMeasurementSchemaRequest{
@@ -637,9 +636,8 @@ func (r ApiGetMeasurementSchemasRequest) ExecuteWithHttpInfo() (MeasurementSchem
 }
 
 /*
-  - GetMeasurementSchemas List measurement schemas of a bucket
-  - Retrieves a list of _explicit_
-
+ * GetMeasurementSchemas List measurement schemas of a bucket
+ * Retrieves a list of _explicit_
 [schemas]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema)
 (`"schemaType": "explicit"`) for a bucket.
 
@@ -653,9 +651,9 @@ that conforms to your data.
 
 - [Using bucket schemas](https://www.influxdata.com/blog/new-bucket-schema-option-protect-from-unwanted-schema-changes/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param bucketID A bucket ID. Lists measurement schemas for the specified bucket.
-  - @return ApiGetMeasurementSchemasRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID A bucket ID. Lists measurement schemas for the specified bucket.
+ * @return ApiGetMeasurementSchemasRequest
 */
 func (a *BucketSchemasApiService) GetMeasurementSchemas(ctx _context.Context, bucketID string) ApiGetMeasurementSchemasRequest {
 	return ApiGetMeasurementSchemasRequest{
@@ -863,8 +861,8 @@ func (r ApiUpdateMeasurementSchemaRequest) ExecuteWithHttpInfo() (MeasurementSch
 }
 
 /*
-  - UpdateMeasurementSchema Update a measurement schema
-  - Updates a measurement [schema]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema).
+ * UpdateMeasurementSchema Update a measurement schema
+ * Updates a measurement [schema]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#schema).
 
 Use this endpoint to update the fields (`name`, `type`, and `dataType`) of a
 measurement schema.
@@ -878,10 +876,10 @@ measurement schema.
 - [Manage bucket schemas]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/bucket-schema/).
 - [Using bucket schemas](https://www.influxdata.com/blog/new-bucket-schema-option-protect-from-unwanted-schema-changes/).
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param bucketID A bucket ID. Specifies the bucket to retrieve schemas for.
-  - @param measurementID A measurement schema ID. Retrieves the specified measurement schema.
-  - @return ApiUpdateMeasurementSchemaRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID A bucket ID. Specifies the bucket to retrieve schemas for.
+ * @param measurementID A measurement schema ID. Retrieves the specified measurement schema.
+ * @return ApiUpdateMeasurementSchemaRequest
 */
 func (a *BucketSchemasApiService) UpdateMeasurementSchema(ctx _context.Context, bucketID string, measurementID string) ApiUpdateMeasurementSchemaRequest {
 	return ApiUpdateMeasurementSchemaRequest{

--- a/api/api_buckets.gen.go
+++ b/api/api_buckets.gen.go
@@ -271,16 +271,16 @@ func (r ApiDeleteBucketsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, er
 }
 
 /*
-  - DeleteBucketsID Delete a bucket
-  - Deletes a bucket and all associated records.
+ * DeleteBucketsID Delete a bucket
+ * Deletes a bucket and all associated records.
 
 #### InfluxDB Cloud
 
 - Does the following when you send a delete request:
 
- 1. Validates the request and queues the delete.
- 2. Returns an HTTP `204` status code if queued; _error_ otherwise.
- 3. Handles the delete asynchronously.
+  1. Validates the request and queues the delete.
+  2. Returns an HTTP `204` status code if queued; _error_ otherwise.
+  3. Handles the delete asynchronously.
 
 #### InfluxDB OSS
 
@@ -295,9 +295,9 @@ and then responds with success or failure.
 
 - [Delete a bucket]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/delete-bucket/#delete-a-bucket-in-the-influxdb-ui)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param bucketID Bucket ID. The ID of the bucket to delete.
-  - @return ApiDeleteBucketsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID Bucket ID. The ID of the bucket to delete.
+ * @return ApiDeleteBucketsIDRequest
 */
 func (a *BucketsApiService) DeleteBucketsID(ctx _context.Context, bucketID string) ApiDeleteBucketsIDRequest {
 	return ApiDeleteBucketsIDRequest{
@@ -523,8 +523,8 @@ func (r ApiGetBucketsRequest) ExecuteWithHttpInfo() (Buckets, *_nethttp.Response
 }
 
 /*
-  - GetBuckets List buckets
-  - Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
+ * GetBuckets List buckets
+ * Retrieves a list of [buckets]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket).
 
 InfluxDB retrieves buckets owned by the
 [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)
@@ -540,11 +540,11 @@ default `limit`.
 
 #### InfluxDB OSS
 
-  - If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_
-    to authenticate your request, InfluxDB retrieves resources for _all
-    organizations_ in the instance.
-    To retrieve resources for only a specific organization, use the
-    `org` parameter or the `orgID` parameter to specify the organization.
+- If you use an _[operator token]({{% INFLUXDB_DOCS_URL %}}/security/tokens/#operator-token)_
+  to authenticate your request, InfluxDB retrieves resources for _all
+  organizations_ in the instance.
+  To retrieve resources for only a specific organization, use the
+  `org` parameter or the `orgID` parameter to specify the organization.
 
 #### Required permissions
 
@@ -557,8 +557,8 @@ default `limit`.
 
 - [Manage buckets]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetBucketsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetBucketsRequest
 */
 func (a *BucketsApiService) GetBuckets(ctx _context.Context) ApiGetBucketsRequest {
 	return ApiGetBucketsRequest{
@@ -749,14 +749,14 @@ func (r ApiGetBucketsIDRequest) ExecuteWithHttpInfo() (Bucket, *_nethttp.Respons
 }
 
 /*
-  - GetBucketsID Retrieve a bucket
-  - Retrieves a bucket.
+ * GetBucketsID Retrieve a bucket
+ * Retrieves a bucket.
 
 Use this endpoint to retrieve information for a specific bucket.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param bucketID The ID of the bucket to retrieve.
-  - @return ApiGetBucketsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID The ID of the bucket to retrieve.
+ * @return ApiGetBucketsIDRequest
 */
 func (a *BucketsApiService) GetBucketsID(ctx _context.Context, bucketID string) ApiGetBucketsIDRequest {
 	return ApiGetBucketsIDRequest{
@@ -948,8 +948,8 @@ func (r ApiPatchBucketsIDRequest) ExecuteWithHttpInfo() (Bucket, *_nethttp.Respo
 }
 
 /*
-  - PatchBucketsID Update a bucket
-  - Updates a bucket.
+ * PatchBucketsID Update a bucket
+ * Updates a bucket.
 
 Use this endpoint to update properties
 (`name`, `description`, and `retentionRules`) of a bucket.
@@ -967,9 +967,9 @@ provide `retentionRules`, InfluxDB responds with an HTTP `403` status code.
 
 - [Update a bucket]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/update-bucket/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param bucketID The bucket ID.
-  - @return ApiPatchBucketsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param bucketID The bucket ID.
+ * @return ApiPatchBucketsIDRequest
 */
 func (a *BucketsApiService) PatchBucketsID(ctx _context.Context, bucketID string) ApiPatchBucketsIDRequest {
 	return ApiPatchBucketsIDRequest{
@@ -1179,9 +1179,8 @@ func (r ApiPostBucketsRequest) ExecuteWithHttpInfo() (Bucket, *_nethttp.Response
 }
 
 /*
-  - PostBuckets Create a bucket
-  - Creates a [bucket]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket)
-
+ * PostBuckets Create a bucket
+ * Creates a [bucket]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#bucket)
 and returns the bucket resource.
 The default data
 [retention period]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#retention-period)
@@ -1206,8 +1205,8 @@ For additional information regarding InfluxDB Cloud offerings, see
 - [Create a bucket]({{% INFLUXDB_DOCS_URL %}}/organizations/buckets/create-bucket/)
 - [Create bucket CLI reference]({{% INFLUXDB_DOCS_URL %}}/reference/cli/influx/bucket/create)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostBucketsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostBucketsRequest
 */
 func (a *BucketsApiService) PostBuckets(ctx _context.Context) ApiPostBucketsRequest {
 	return ApiPostBucketsRequest{

--- a/api/api_config.gen.go
+++ b/api/api_config.gen.go
@@ -82,8 +82,8 @@ func (r ApiGetConfigRequest) ExecuteWithHttpInfo() (Config, *_nethttp.Response, 
 }
 
 /*
-  - GetConfig Retrieve runtime configuration
-  - Returns the active runtime configuration of the InfluxDB instance.
+ * GetConfig Retrieve runtime configuration
+ * Returns the active runtime configuration of the InfluxDB instance.
 
 In InfluxDB v2.2+, use this endpoint to view your active runtime configuration,
 including flags and environment variables.
@@ -92,8 +92,8 @@ including flags and environment variables.
 
 - [View your runtime server configuration]({{% INFLUXDB_DOCS_URL %}}/reference/config-options/#view-your-runtime-server-configuration)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetConfigRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetConfigRequest
 */
 func (a *ConfigApiService) GetConfig(ctx _context.Context) ApiGetConfigRequest {
 	return ApiGetConfigRequest{

--- a/api/api_delete.gen.go
+++ b/api/api_delete.gen.go
@@ -157,8 +157,8 @@ func (r ApiPostDeleteRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) 
 }
 
 /*
-  - PostDelete Delete data
-  - Deletes data from a bucket.
+ * PostDelete Delete data
+ * Deletes data from a bucket.
 
 Use this endpoint to delete points from a bucket in a specified time range.
 
@@ -166,9 +166,9 @@ Use this endpoint to delete points from a bucket in a specified time range.
 
 - Does the following when you send a delete request:
 
- 1. Validates the request and queues the delete.
- 2. If queued, responds with _success_ (HTTP `2xx` status code); _error_ otherwise.
- 3. Handles the delete asynchronously and reaches eventual consistency.
+  1. Validates the request and queues the delete.
+  2. If queued, responds with _success_ (HTTP `2xx` status code); _error_ otherwise.
+  3. Handles the delete asynchronously and reaches eventual consistency.
 
 To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,
 wait for a success response (HTTP `2xx` status code) before you send the next request.
@@ -178,8 +178,8 @@ when you receive the response.
 
 #### InfluxDB OSS
 
-  - Validates the request, handles the delete synchronously,
-    and then responds with success or failure.
+- Validates the request, handles the delete synchronously,
+  and then responds with success or failure.
 
 #### Required permissions
 
@@ -194,16 +194,13 @@ For more information, see [limits and adjustable quotas](https://docs.influxdata
 
 #### Related guides
 
-  - [Delete data]({{% INFLUXDB_DOCS_URL %}}/write-data/delete-data/)
+- [Delete data]({{% INFLUXDB_DOCS_URL %}}/write-data/delete-data/)
+- Learn how to use [delete predicate syntax]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/delete-predicate/).
+- Learn how InfluxDB handles [deleted tags](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementtagkeys/)
+  and [deleted fields](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementfieldkeys/).
 
-  - Learn how to use [delete predicate syntax]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/delete-predicate/).
-
-  - Learn how InfluxDB handles [deleted tags](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementtagkeys/)
-    and [deleted fields](https://docs.influxdata.com/flux/v0.x/stdlib/influxdata/influxdb/schema/measurementfieldkeys/).
-
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-
-  - @return ApiPostDeleteRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostDeleteRequest
 */
 func (a *DeleteApiService) PostDelete(ctx _context.Context) ApiPostDeleteRequest {
 	return ApiPostDeleteRequest{

--- a/api/api_invokable_scripts.gen.go
+++ b/api/api_invokable_scripts.gen.go
@@ -382,15 +382,15 @@ func (r ApiGetScriptsRequest) ExecuteWithHttpInfo() (Scripts, *_nethttp.Response
 }
 
 /*
-  - GetScripts List scripts
-  - Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+ * GetScripts List scripts
+ * Retrieves a list of [scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 
 #### Related guides
 
 - [Invoke custom scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetScriptsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetScriptsRequest
 */
 func (a *InvokableScriptsApiService) GetScripts(ctx _context.Context) ApiGetScriptsRequest {
 	return ApiGetScriptsRequest{
@@ -582,12 +582,12 @@ func (r ApiGetScriptsIDRequest) ExecuteWithHttpInfo() (Script, *_nethttp.Respons
 }
 
 /*
-* GetScriptsID Retrieve a script
-* Retrieves a [script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
+ * GetScriptsID Retrieve a script
+ * Retrieves a [script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/).
 
-* @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-* @param scriptID A script ID. Retrieves the specified script.
-* @return ApiGetScriptsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param scriptID A script ID. Retrieves the specified script.
+ * @return ApiGetScriptsIDRequest
  */
 func (a *InvokableScriptsApiService) GetScriptsID(ctx _context.Context, scriptID string) ApiGetScriptsIDRequest {
 	return ApiGetScriptsIDRequest{
@@ -756,14 +756,14 @@ func (r ApiPatchScriptsIDRequest) ExecuteWithHttpInfo() (Script, *_nethttp.Respo
 }
 
 /*
-  - PatchScriptsID Update a script
-  - Updates a [script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/) and returns the script.
+ * PatchScriptsID Update a script
+ * Updates a [script](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/) and returns the script.
 
 Use this endpoint to update the properties (`name`, `description`, and `script`) of an invokable script.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param scriptID A script ID. Updates the specified script.
-  - @return ApiPatchScriptsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param scriptID A script ID. Updates the specified script.
+ * @return ApiPatchScriptsIDRequest
 */
 func (a *InvokableScriptsApiService) PatchScriptsID(ctx _context.Context, scriptID string) ApiPatchScriptsIDRequest {
 	return ApiPatchScriptsIDRequest{
@@ -928,9 +928,8 @@ func (r ApiPostScriptsRequest) ExecuteWithHttpInfo() (Script, *_nethttp.Response
 }
 
 /*
-  - PostScripts Create a script
-  - Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
-
+ * PostScripts Create a script
+ * Creates an [invokable script](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
 and returns the script.
 
 #### Related guides
@@ -938,8 +937,8 @@ and returns the script.
 - [Invokable scripts](https://docs.influxdata.com/influxdb/cloud/api-guide/api-invokable-scripts/)
 - [Creating custom InfluxDB endpoints](https://docs.influxdata.com/resources/videos/api-invokable-scripts/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostScriptsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostScriptsRequest
 */
 func (a *InvokableScriptsApiService) PostScripts(ctx _context.Context) ApiPostScriptsRequest {
 	return ApiPostScriptsRequest{

--- a/api/api_legacy_authorizations.gen.go
+++ b/api/api_legacy_authorizations.gen.go
@@ -904,8 +904,8 @@ func (r ApiPostLegacyAuthorizationsRequest) ExecuteWithHttpInfo() (Authorization
 }
 
 /*
-  - PostLegacyAuthorizations Create a legacy authorization
-  - Creates a legacy authorization and returns the legacy authorization.
+ * PostLegacyAuthorizations Create a legacy authorization
+ * Creates a legacy authorization and returns the legacy authorization.
 
 #### Required permissions
 
@@ -913,8 +913,8 @@ func (r ApiPostLegacyAuthorizationsRequest) ExecuteWithHttpInfo() (Authorization
 
 *`USER_ID`* is the ID of the user that you want to scope the authorization to.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostLegacyAuthorizationsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostLegacyAuthorizationsRequest
 */
 func (a *LegacyAuthorizationsApiService) PostLegacyAuthorizations(ctx _context.Context) ApiPostLegacyAuthorizationsRequest {
 	return ApiPostLegacyAuthorizationsRequest{

--- a/api/api_organizations.gen.go
+++ b/api/api_organizations.gen.go
@@ -519,8 +519,8 @@ func (r ApiDeleteOrgsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error
 }
 
 /*
-  - DeleteOrgsID Delete an organization
-  - Deletes an organization.
+ * DeleteOrgsID Delete an organization
+ * Deletes an organization.
 
 Deleting an organization from InfluxDB Cloud can't be undone.
 Once deleted, all data associated with the organization is removed.
@@ -529,9 +529,9 @@ Once deleted, all data associated with the organization is removed.
 
 - Does the following when you send a delete request:
 
- 1. Validates the request and queues the delete.
- 2. Returns an HTTP `204` status code if queued; _error_ otherwise.
- 3. Handles the delete asynchronously.
+  1. Validates the request and queues the delete.
+  2. Returns an HTTP `204` status code if queued; _error_ otherwise.
+  3. Handles the delete asynchronously.
 
 #### InfluxDB OSS
 
@@ -546,9 +546,9 @@ and then responds with success or failure.
 
 - [Delete organizations]({{% INFLUXDB_DOCS_URL %}}/organizations/delete-orgs/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization to delete.
-  - @return ApiDeleteOrgsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization to delete.
+ * @return ApiDeleteOrgsIDRequest
 */
 func (a *OrganizationsApiService) DeleteOrgsID(ctx _context.Context, orgID string) ApiDeleteOrgsIDRequest {
 	return ApiDeleteOrgsIDRequest{
@@ -718,16 +718,16 @@ func (r ApiDeleteOrgsIDMembersIDRequest) ExecuteWithHttpInfo() (*_nethttp.Respon
 }
 
 /*
-  - DeleteOrgsIDMembersID Remove a member from an organization
-  - Removes a member from an organization.
+ * DeleteOrgsIDMembersID Remove a member from an organization
+ * Removes a member from an organization.
 
 Use this endpoint to remove a user's member privileges from a bucket. This
 removes the user's `read` and `write` permissions from the organization.
 
 #### InfluxDB Cloud
 
-  - Doesn't use `owner` and `member` roles.
-    Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
+- Doesn't use `owner` and `member` roles.
+  Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
 
 #### Limitations
 
@@ -745,10 +745,10 @@ owner from.
 
 - [Manage members]({{% INFLUXDB_DOCS_URL %}}/organizations/members/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID The ID of the user to remove.
-  - @param orgID The ID of the organization to remove a user from.
-  - @return ApiDeleteOrgsIDMembersIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID The ID of the user to remove.
+ * @param orgID The ID of the organization to remove a user from.
+ * @return ApiDeleteOrgsIDMembersIDRequest
 */
 func (a *OrganizationsApiService) DeleteOrgsIDMembersID(ctx _context.Context, userID string, orgID string) ApiDeleteOrgsIDMembersIDRequest {
 	return ApiDeleteOrgsIDMembersIDRequest{
@@ -909,17 +909,16 @@ func (r ApiDeleteOrgsIDOwnersIDRequest) ExecuteWithHttpInfo() (*_nethttp.Respons
 }
 
 /*
-  - DeleteOrgsIDOwnersID Remove an owner from an organization
-  - Removes an [owner]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#owner) from
-
+ * DeleteOrgsIDOwnersID Remove an owner from an organization
+ * Removes an [owner]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#owner) from
 the organization.
 
 Organization owners have permission to delete organizations and remove user and member
 permissions from the organization.
 
 #### InfluxDB Cloud
-  - Doesn't use `owner` and `member` roles.
-    Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
+- Doesn't use `owner` and `member` roles.
+  Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
 
 #### Limitations
 
@@ -936,10 +935,10 @@ remove an owner from.
 #### Related endpoints
 - [Authorizations](#tag/Authorizations)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID The ID of the user to remove.
-  - @param orgID The ID of the organization to remove an owner from.
-  - @return ApiDeleteOrgsIDOwnersIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID The ID of the user to remove.
+ * @param orgID The ID of the organization to remove an owner from.
+ * @return ApiDeleteOrgsIDOwnersIDRequest
 */
 func (a *OrganizationsApiService) DeleteOrgsIDOwnersID(ctx _context.Context, userID string, orgID string) ApiDeleteOrgsIDOwnersIDRequest {
 	return ApiDeleteOrgsIDOwnersIDRequest{
@@ -1136,8 +1135,8 @@ func (r ApiGetOrgsRequest) ExecuteWithHttpInfo() (Organizations, *_nethttp.Respo
 }
 
 /*
-  - GetOrgs List organizations
-  - Retrieves a list of [organizations]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization/).
+ * GetOrgs List organizations
+ * Retrieves a list of [organizations]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization/).
 
 To limit which organizations are returned, pass query parameters in your request.
 If no query parameters are passed, InfluxDB returns all organizations up to the default `limit`.
@@ -1150,8 +1149,8 @@ If no query parameters are passed, InfluxDB returns all organizations up to the 
 
 - [View organizations]({{% INFLUXDB_DOCS_URL %}}/organizations/view-orgs/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetOrgsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetOrgsRequest
 */
 func (a *OrganizationsApiService) GetOrgs(ctx _context.Context) ApiGetOrgsRequest {
 	return ApiGetOrgsRequest{
@@ -1372,8 +1371,8 @@ func (r ApiGetOrgsIDRequest) ExecuteWithHttpInfo() (Organization, *_nethttp.Resp
 }
 
 /*
-  - GetOrgsID Retrieve an organization
-  - Retrieves an organization.
+ * GetOrgsID Retrieve an organization
+ * Retrieves an organization.
 
 Use this endpoint to retrieve information for a specific organization.
 
@@ -1381,9 +1380,9 @@ Use this endpoint to retrieve information for a specific organization.
 
 - [View organizations]({{% INFLUXDB_DOCS_URL %}}/organizations/view-orgs/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization to retrieve.
-  - @return ApiGetOrgsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization to retrieve.
+ * @return ApiGetOrgsIDRequest
 */
 func (a *OrganizationsApiService) GetOrgsID(ctx _context.Context, orgID string) ApiGetOrgsIDRequest {
 	return ApiGetOrgsIDRequest{
@@ -1566,8 +1565,8 @@ func (r ApiGetOrgsIDMembersRequest) ExecuteWithHttpInfo() (ResourceMembers, *_ne
 }
 
 /*
-  - GetOrgsIDMembers List all members of an organization
-  - Retrieves a list of all users that belong to an organization.
+ * GetOrgsIDMembers List all members of an organization
+ * Retrieves a list of all users that belong to an organization.
 
 InfluxDB [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) have
 permission to access InfluxDB.
@@ -1577,8 +1576,8 @@ within the organization.
 
 #### InfluxDB Cloud
 
-  - Doesn't use `owner` and `member` roles.
-    Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
+- Doesn't use `owner` and `member` roles.
+  Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
 
 #### Limitations
 
@@ -1597,9 +1596,9 @@ members for.
 - [Manage users]({{% INFLUXDB_DOCS_URL %}}/users/)
 - [Manage members]({{% INFLUXDB_DOCS_URL %}}/organizations/members/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization to retrieve users for.
-  - @return ApiGetOrgsIDMembersRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization to retrieve users for.
+ * @return ApiGetOrgsIDMembersRequest
 */
 func (a *OrganizationsApiService) GetOrgsIDMembers(ctx _context.Context, orgID string) ApiGetOrgsIDMembersRequest {
 	return ApiGetOrgsIDMembersRequest{
@@ -1782,13 +1781,13 @@ func (r ApiGetOrgsIDOwnersRequest) ExecuteWithHttpInfo() (ResourceOwners, *_neth
 }
 
 /*
-  - GetOrgsIDOwners List all owners of an organization
-  - Retrieves a list of all owners of an organization.
+ * GetOrgsIDOwners List all owners of an organization
+ * Retrieves a list of all owners of an organization.
 
 #### InfluxDB Cloud
 
-  - Doesn't use `owner` and `member` roles.
-    Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
+- Doesn't use `owner` and `member` roles.
+  Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
 
 #### Required permissions
 
@@ -1797,9 +1796,9 @@ func (r ApiGetOrgsIDOwnersRequest) ExecuteWithHttpInfo() (ResourceOwners, *_neth
 *`INFLUX_ORG_ID`* is the ID of the organization that you want to retrieve a
 list of owners from.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization to list owners for.
-  - @return ApiGetOrgsIDOwnersRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization to list owners for.
+ * @return ApiGetOrgsIDOwnersRequest
 */
 func (a *OrganizationsApiService) GetOrgsIDOwners(ctx _context.Context, orgID string) ApiGetOrgsIDOwnersRequest {
 	return ApiGetOrgsIDOwnersRequest{
@@ -1980,8 +1979,8 @@ func (r ApiPatchOrgsIDRequest) ExecuteWithHttpInfo() (Organization, *_nethttp.Re
 }
 
 /*
-  - PatchOrgsID Update an organization
-  - Updates an organization.
+ * PatchOrgsID Update an organization
+ * Updates an organization.
 
 Use this endpoint to update properties
 (`name`, `description`) of an organization.
@@ -2002,9 +2001,9 @@ in these resources as well.
 
 - [Update an organization]({{% INFLUXDB_DOCS_URL %}}/organizations/update-org/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization to update.
-  - @return ApiPatchOrgsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization to update.
+ * @return ApiPatchOrgsIDRequest
 */
 func (a *OrganizationsApiService) PatchOrgsID(ctx _context.Context, orgID string) ApiPatchOrgsIDRequest {
 	return ApiPatchOrgsIDRequest{
@@ -2181,9 +2180,8 @@ func (r ApiPostOrgsRequest) ExecuteWithHttpInfo() (Organization, *_nethttp.Respo
 }
 
 /*
-  - PostOrgs Create an organization
-  - Creates an [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)
-
+ * PostOrgs Create an organization
+ * Creates an [organization]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#organization)
 and returns the newly created organization.
 
 #### InfluxDB Cloud
@@ -2194,8 +2192,8 @@ and returns the newly created organization.
 
 - [Manage organizations]({{% INFLUXDB_DOCS_URL %}}/organizations)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostOrgsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostOrgsRequest
 */
 func (a *OrganizationsApiService) PostOrgs(ctx _context.Context) ApiPostOrgsRequest {
 	return ApiPostOrgsRequest{
@@ -2379,8 +2377,8 @@ func (r ApiPostOrgsIDMembersRequest) ExecuteWithHttpInfo() (ResourceMember, *_ne
 }
 
 /*
-  - PostOrgsIDMembers Add a member to an organization
-  - Add a user to an organization.
+ * PostOrgsIDMembers Add a member to an organization
+ * Add a user to an organization.
 
 InfluxDB [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) have
 permission to access InfluxDB.
@@ -2389,8 +2387,8 @@ permission to access InfluxDB.
 within the organization.
 
 #### InfluxDB Cloud
-  - Doesn't use `owner` and `member` roles.
-    Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
+- Doesn't use `owner` and `member` roles.
+  Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
 
 #### Limitations
 
@@ -2408,9 +2406,9 @@ within the organization.
 - [Manage users]({{% INFLUXDB_DOCS_URL %}}/users/)
 - [Manage members]({{% INFLUXDB_DOCS_URL %}}/organizations/members/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization.
-  - @return ApiPostOrgsIDMembersRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization.
+ * @return ApiPostOrgsIDMembersRequest
 */
 func (a *OrganizationsApiService) PostOrgsIDMembers(ctx _context.Context, orgID string) ApiPostOrgsIDMembersRequest {
 	return ApiPostOrgsIDMembersRequest{
@@ -2596,15 +2594,15 @@ func (r ApiPostOrgsIDOwnersRequest) ExecuteWithHttpInfo() (ResourceOwner, *_neth
 }
 
 /*
-  - PostOrgsIDOwners Add an owner to an organization
-  - Adds an owner to an organization.
+ * PostOrgsIDOwners Add an owner to an organization
+ * Adds an owner to an organization.
 
 Use this endpoint to assign the organization `owner` role to a user.
 
 #### InfluxDB Cloud
 
-  - Doesn't use `owner` and `member` roles.
-    Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
+- Doesn't use `owner` and `member` roles.
+  Use [`/api/v2/authorizations`](#tag/Authorizations) to assign user permissions.
 
 #### Required permissions
 
@@ -2616,9 +2614,9 @@ Use this endpoint to assign the organization `owner` role to a user.
 
 - [Authorizations](#tag/Authorizations)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param orgID The ID of the organization that you want to add an owner for.
-  - @return ApiPostOrgsIDOwnersRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The ID of the organization that you want to add an owner for.
+ * @return ApiPostOrgsIDOwnersRequest
 */
 func (a *OrganizationsApiService) PostOrgsIDOwners(ctx _context.Context, orgID string) ApiPostOrgsIDOwnersRequest {
 	return ApiPostOrgsIDOwnersRequest{

--- a/api/api_ping.gen.go
+++ b/api/api_ping.gen.go
@@ -106,8 +106,8 @@ func (r ApiGetPingRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
 }
 
 /*
-  - GetPing Get the status of the instance
-  - Retrieves the status and InfluxDB version of the instance.
+ * GetPing Get the status of the instance
+ * Retrieves the status and InfluxDB version of the instance.
 
 Use this endpoint to monitor uptime for the InfluxDB instance. The response
 returns a HTTP `204` status code to inform you the instance is available.
@@ -120,8 +120,8 @@ returns a HTTP `204` status code to inform you the instance is available.
 
 - [Influx ping]({{% INFLUXDB_DOCS_URL %}}/reference/cli/influx/ping/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetPingRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetPingRequest
 */
 func (a *PingApiService) GetPing(ctx _context.Context) ApiGetPingRequest {
 	return ApiGetPingRequest{
@@ -229,8 +229,8 @@ func (r ApiHeadPingRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
 }
 
 /*
-  - HeadPing Get the status of the instance
-  - Returns the status and InfluxDB version of the instance.
+ * HeadPing Get the status of the instance
+ * Returns the status and InfluxDB version of the instance.
 
 Use this endpoint to monitor uptime for the InfluxDB instance. The response
 returns a HTTP `204` status code to inform you the instance is available.
@@ -243,8 +243,8 @@ returns a HTTP `204` status code to inform you the instance is available.
 
 - [Influx ping]({{% INFLUXDB_DOCS_URL %}}/reference/cli/influx/ping/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiHeadPingRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiHeadPingRequest
 */
 func (a *PingApiService) HeadPing(ctx _context.Context) ApiHeadPingRequest {
 	return ApiHeadPingRequest{

--- a/api/api_secrets.gen.go
+++ b/api/api_secrets.gen.go
@@ -27,6 +27,27 @@ var (
 type SecretsApi interface {
 
 	/*
+	 * DeleteOrgsIDSecretsID Delete a secret from an organization
+	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+	 * @param orgID The organization ID.
+	 * @param secretID The secret ID.
+	 * @return ApiDeleteOrgsIDSecretsIDRequest
+	 */
+	DeleteOrgsIDSecretsID(ctx _context.Context, orgID string, secretID string) ApiDeleteOrgsIDSecretsIDRequest
+
+	/*
+	 * DeleteOrgsIDSecretsIDExecute executes the request
+	 */
+	DeleteOrgsIDSecretsIDExecute(r ApiDeleteOrgsIDSecretsIDRequest) error
+
+	/*
+	 * DeleteOrgsIDSecretsIDExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not
+	 * available on the returned HTTP response as it will have already been read and closed; access to the response body
+	 * content should be achieved through the returned response model if applicable.
+	 */
+	DeleteOrgsIDSecretsIDExecuteWithHttpInfo(r ApiDeleteOrgsIDSecretsIDRequest) (*_nethttp.Response, error)
+
+	/*
 	 * GetOrgsIDSecrets List all secret keys for an organization
 	 * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
 	 * @param orgID The organization ID.
@@ -91,6 +112,160 @@ type SecretsApi interface {
 
 // SecretsApiService SecretsApi service
 type SecretsApiService service
+
+type ApiDeleteOrgsIDSecretsIDRequest struct {
+	ctx          _context.Context
+	ApiService   SecretsApi
+	orgID        string
+	secretID     string
+	zapTraceSpan *string
+}
+
+func (r ApiDeleteOrgsIDSecretsIDRequest) OrgID(orgID string) ApiDeleteOrgsIDSecretsIDRequest {
+	r.orgID = orgID
+	return r
+}
+func (r ApiDeleteOrgsIDSecretsIDRequest) GetOrgID() string {
+	return r.orgID
+}
+
+func (r ApiDeleteOrgsIDSecretsIDRequest) SecretID(secretID string) ApiDeleteOrgsIDSecretsIDRequest {
+	r.secretID = secretID
+	return r
+}
+func (r ApiDeleteOrgsIDSecretsIDRequest) GetSecretID() string {
+	return r.secretID
+}
+
+func (r ApiDeleteOrgsIDSecretsIDRequest) ZapTraceSpan(zapTraceSpan string) ApiDeleteOrgsIDSecretsIDRequest {
+	r.zapTraceSpan = &zapTraceSpan
+	return r
+}
+func (r ApiDeleteOrgsIDSecretsIDRequest) GetZapTraceSpan() *string {
+	return r.zapTraceSpan
+}
+
+func (r ApiDeleteOrgsIDSecretsIDRequest) Execute() error {
+	return r.ApiService.DeleteOrgsIDSecretsIDExecute(r)
+}
+
+func (r ApiDeleteOrgsIDSecretsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
+	return r.ApiService.DeleteOrgsIDSecretsIDExecuteWithHttpInfo(r)
+}
+
+/*
+ * DeleteOrgsIDSecretsID Delete a secret from an organization
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param orgID The organization ID.
+ * @param secretID The secret ID.
+ * @return ApiDeleteOrgsIDSecretsIDRequest
+ */
+func (a *SecretsApiService) DeleteOrgsIDSecretsID(ctx _context.Context, orgID string, secretID string) ApiDeleteOrgsIDSecretsIDRequest {
+	return ApiDeleteOrgsIDSecretsIDRequest{
+		ApiService: a,
+		ctx:        ctx,
+		orgID:      orgID,
+		secretID:   secretID,
+	}
+}
+
+/*
+ * Execute executes the request
+ */
+func (a *SecretsApiService) DeleteOrgsIDSecretsIDExecute(r ApiDeleteOrgsIDSecretsIDRequest) error {
+	_, err := a.DeleteOrgsIDSecretsIDExecuteWithHttpInfo(r)
+	return err
+}
+
+/*
+ * ExecuteWithHttpInfo executes the request with HTTP response info returned. The response body is not available on the
+ * returned HTTP response as it will have already been read and closed; access to the response body content should be
+ * achieved through the returned response model if applicable.
+ */
+func (a *SecretsApiService) DeleteOrgsIDSecretsIDExecuteWithHttpInfo(r ApiDeleteOrgsIDSecretsIDRequest) (*_nethttp.Response, error) {
+	var (
+		localVarHTTPMethod   = _nethttp.MethodDelete
+		localVarPostBody     interface{}
+		localVarFormFileName string
+		localVarFileName     string
+		localVarFileBytes    []byte
+	)
+
+	localBasePath, err := a.client.cfg.ServerURLWithContext(r.ctx, "SecretsApiService.DeleteOrgsIDSecretsID")
+	if err != nil {
+		return nil, GenericOpenAPIError{error: err.Error()}
+	}
+
+	localVarPath := localBasePath + "/api/v2/orgs/{orgID}/secrets/{secretID}"
+	localVarPath = strings.Replace(localVarPath, "{"+"orgID"+"}", _neturl.PathEscape(parameterToString(r.orgID, "")), -1)
+	localVarPath = strings.Replace(localVarPath, "{"+"secretID"+"}", _neturl.PathEscape(parameterToString(r.secretID, "")), -1)
+
+	localVarHeaderParams := make(map[string]string)
+	localVarQueryParams := _neturl.Values{}
+	localVarFormParams := _neturl.Values{}
+
+	// to determine the Content-Type header
+	localVarHTTPContentTypes := []string{}
+
+	// set Content-Type header
+	localVarHTTPContentType := selectHeaderContentType(localVarHTTPContentTypes)
+	if localVarHTTPContentType != "" {
+		localVarHeaderParams["Content-Type"] = localVarHTTPContentType
+	}
+
+	// to determine the Accept header
+	localVarHTTPHeaderAccepts := []string{"application/json"}
+
+	// set Accept header
+	localVarHTTPHeaderAccept := selectHeaderAccept(localVarHTTPHeaderAccepts)
+	if localVarHTTPHeaderAccept != "" {
+		localVarHeaderParams["Accept"] = localVarHTTPHeaderAccept
+	}
+	if r.zapTraceSpan != nil {
+		localVarHeaderParams["Zap-Trace-Span"] = parameterToString(*r.zapTraceSpan, "")
+	}
+	req, err := a.client.prepareRequest(r.ctx, localVarPath, localVarHTTPMethod, localVarPostBody, localVarHeaderParams, localVarQueryParams, localVarFormParams, localVarFormFileName, localVarFileName, localVarFileBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	localVarHTTPResponse, err := a.client.callAPI(req)
+	if err != nil || localVarHTTPResponse == nil {
+		return localVarHTTPResponse, err
+	}
+
+	newErr := GenericOpenAPIError{
+		buildHeader: localVarHTTPResponse.Header.Get("X-Influxdb-Build"),
+	}
+
+	if localVarHTTPResponse.StatusCode >= 300 {
+		body, err := GunzipIfNeeded(localVarHTTPResponse)
+		if err != nil {
+			body.Close()
+			newErr.error = err.Error()
+			return localVarHTTPResponse, newErr
+		}
+		localVarBody, err := _io.ReadAll(body)
+		body.Close()
+		if err != nil {
+			newErr.error = err.Error()
+			return localVarHTTPResponse, newErr
+		}
+		newErr.body = localVarBody
+		newErr.error = localVarHTTPResponse.Status
+		var v Error
+		err = a.client.decode(&v, localVarBody, localVarHTTPResponse.Header.Get("Content-Type"))
+		if err != nil {
+			newErr.error = _fmt.Sprintf("%s: %s", newErr.Error(), err.Error())
+			return localVarHTTPResponse, newErr
+		}
+		v.SetMessage(_fmt.Sprintf("%s: %s", newErr.Error(), v.GetMessage()))
+		newErr.model = &v
+		return localVarHTTPResponse, newErr
+	}
+
+	return localVarHTTPResponse, nil
+}
 
 type ApiGetOrgsIDSecretsRequest struct {
 	ctx          _context.Context

--- a/api/api_signin.gen.go
+++ b/api/api_signin.gen.go
@@ -97,9 +97,8 @@ func (r ApiPostSigninRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) 
 }
 
 /*
-  - PostSignin Create a user session.
-  - Authenticates [Basic authentication credentials](#section/Authentication/BasicAuthentication)
-
+ * PostSignin Create a user session.
+ * Authenticates [Basic authentication credentials](#section/Authentication/BasicAuthentication)
 for a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user),
 and then, if successful, generates a user session.
 
@@ -116,17 +115,17 @@ They expire within ten minutes and during restarts of the InfluxDB instance.
 
 #### User sessions with authorizations
 
-  - In InfluxDB Cloud, a user session inherits all the user's permissions for
-    the organization.
-  - In InfluxDB OSS, a user session inherits all the user's permissions for all
-    the organizations that the user belongs to.
+- In InfluxDB Cloud, a user session inherits all the user's permissions for
+  the organization.
+- In InfluxDB OSS, a user session inherits all the user's permissions for all
+  the organizations that the user belongs to.
 
 #### Related endpoints
 
 - [Signout](#tag/Signout)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostSigninRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostSigninRequest
 */
 func (a *SigninApiService) PostSignin(ctx _context.Context) ApiPostSigninRequest {
 	return ApiPostSigninRequest{

--- a/api/api_tasks.gen.go
+++ b/api/api_tasks.gen.go
@@ -499,17 +499,17 @@ func (r ApiDeleteTasksIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, erro
 }
 
 /*
-  - DeleteTasksID Delete a task
-  - Deletes a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) and associated records.
+ * DeleteTasksID Delete a task
+ * Deletes a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) and associated records.
 
 Use this endpoint to delete a task and all associated records (task runs, logs, and labels).
 Once the task is deleted, InfluxDB cancels all scheduled runs of the task.
 
 If you want to disable a task instead of delete it, [update the task status to `inactive`](#operation/PatchTasksID).
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) ID. Specifies the task to delete.
-  - @return ApiDeleteTasksIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) ID. Specifies the task to delete.
+ * @return ApiDeleteTasksIDRequest
 */
 func (a *TasksApiService) DeleteTasksID(ctx _context.Context, taskID string) ApiDeleteTasksIDRequest {
 	return ApiDeleteTasksIDRequest{
@@ -668,8 +668,8 @@ func (r ApiDeleteTasksIDRunsIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response
 }
 
 /*
-  - DeleteTasksIDRunsID Cancel a running task
-  - Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+ * DeleteTasksIDRunsID Cancel a running task
+ * Cancels a running [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
 
 Use this endpoint with InfluxDB OSS to cancel a running task.
 
@@ -677,10 +677,10 @@ Use this endpoint with InfluxDB OSS to cancel a running task.
 
 - Doesn't support this operation.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID The ID of the task to cancel.
-  - @param runID The ID of the task run to cancel.
-  - @return ApiDeleteTasksIDRunsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID The ID of the task to cancel.
+ * @param runID The ID of the task run to cancel.
+ * @return ApiDeleteTasksIDRunsIDRequest
 */
 func (a *TasksApiService) DeleteTasksIDRunsID(ctx _context.Context, taskID string, runID string) ApiDeleteTasksIDRunsIDRequest {
 	return ApiDeleteTasksIDRunsIDRequest{
@@ -933,14 +933,14 @@ func (r ApiGetTasksRequest) ExecuteWithHttpInfo() (Tasks, *_nethttp.Response, er
 }
 
 /*
-  - GetTasks List all tasks
-  - Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+ * GetTasks List all tasks
+ * Retrieves a list of [tasks]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
 
 To limit which tasks are returned, pass query parameters in your request.
 If no query parameters are passed, InfluxDB returns all tasks up to the default `limit`.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetTasksRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetTasksRequest
 */
 func (a *TasksApiService) GetTasks(ctx _context.Context) ApiGetTasksRequest {
 	return ApiGetTasksRequest{
@@ -1143,12 +1143,12 @@ func (r ApiGetTasksIDRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, e
 }
 
 /*
-* GetTasksID Retrieve a task
-* Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+ * GetTasksID Retrieve a task
+ * Retrieves a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
 
-* @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-* @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) ID. Specifies the task to retrieve.
-* @return ApiGetTasksIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) ID. Specifies the task to retrieve.
+ * @return ApiGetTasksIDRequest
  */
 func (a *TasksApiService) GetTasksID(ctx _context.Context, taskID string) ApiGetTasksIDRequest {
 	return ApiGetTasksIDRequest{
@@ -1320,8 +1320,8 @@ func (r ApiGetTasksIDLogsRequest) ExecuteWithHttpInfo() (Logs, *_nethttp.Respons
 }
 
 /*
-  - GetTasksIDLogs Retrieve all logs for a task
-  - Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+ * GetTasksIDLogs Retrieve all logs for a task
+ * Retrieves a list of all logs for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
 
 When an InfluxDB task runs, a “run” record is created in the task’s history.
 Logs associated with each run provide relevant log messages, timestamps, and the exit status of the run attempt.
@@ -1329,9 +1329,9 @@ Logs associated with each run provide relevant log messages, timestamps, and the
 Use this endpoint to retrieve only the log events for a task,
 without additional task metadata.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID The task ID.
-  - @return ApiGetTasksIDLogsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID The task ID.
+ * @return ApiGetTasksIDLogsRequest
 */
 func (a *TasksApiService) GetTasksIDLogs(ctx _context.Context, taskID string) ApiGetTasksIDLogsRequest {
 	return ApiGetTasksIDLogsRequest{
@@ -1539,15 +1539,15 @@ func (r ApiGetTasksIDRunsRequest) ExecuteWithHttpInfo() (Runs, *_nethttp.Respons
 }
 
 /*
-  - GetTasksIDRuns List runs for a task
-  - Retrieves a list of runs for a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/).
+ * GetTasksIDRuns List runs for a task
+ * Retrieves a list of runs for a [task]({{% INFLUXDB_DOCS_URL %}}/process-data/).
 
 To limit which task runs are returned, pass query parameters in your request.
 If no query parameters are passed, InfluxDB returns all task runs up to the default `limit`.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID The ID of the task to get runs for. Only returns runs for this task.
-  - @return ApiGetTasksIDRunsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID The ID of the task to get runs for. Only returns runs for this task.
+ * @return ApiGetTasksIDRunsRequest
 */
 func (a *TasksApiService) GetTasksIDRuns(ctx _context.Context, taskID string) ApiGetTasksIDRunsRequest {
 	return ApiGetTasksIDRunsRequest{
@@ -1740,15 +1740,15 @@ func (r ApiGetTasksIDRunsIDRequest) ExecuteWithHttpInfo() (Run, *_nethttp.Respon
 }
 
 /*
-  - GetTasksIDRunsID Retrieve a run for a task.
-  - Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
+ * GetTasksIDRunsID Retrieve a run for a task.
+ * Retrieves a specific run for a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task).
 
 Use this endpoint to retrieve detail and logs for a specific task run.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID The ID of the task to retrieve runs for.
-  - @param runID The ID of the run to retrieve.
-  - @return ApiGetTasksIDRunsIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID The ID of the task to retrieve runs for.
+ * @param runID The ID of the run to retrieve.
+ * @return ApiGetTasksIDRunsIDRequest
 */
 func (a *TasksApiService) GetTasksIDRunsID(ctx _context.Context, taskID string, runID string) ApiGetTasksIDRunsIDRequest {
 	return ApiGetTasksIDRunsIDRequest{
@@ -1931,17 +1931,16 @@ func (r ApiGetTasksIDRunsIDLogsRequest) ExecuteWithHttpInfo() (Logs, *_nethttp.R
 }
 
 /*
-  - GetTasksIDRunsIDLogs Retrieve all logs for a run
-  - Retrieves all logs for a task run.
-
+ * GetTasksIDRunsIDLogs Retrieve all logs for a run
+ * Retrieves all logs for a task run.
 A log is a list of run events with `runID`, `time`, and `message` properties.
 
 Use this endpoint to help analyze task performance and troubleshoot failed task runs.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID The ID of the task to get logs for.
-  - @param runID The ID of the run to get logs for.
-  - @return ApiGetTasksIDRunsIDLogsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID The ID of the task to get logs for.
+ * @param runID The ID of the run to get logs for.
+ * @return ApiGetTasksIDRunsIDLogsRequest
 */
 func (a *TasksApiService) GetTasksIDRunsIDLogs(ctx _context.Context, taskID string, runID string) ApiGetTasksIDRunsIDLogsRequest {
 	return ApiGetTasksIDRunsIDLogsRequest{
@@ -2124,9 +2123,8 @@ func (r ApiPatchTasksIDRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response,
 }
 
 /*
-  - PatchTasksID Update a task
-  - Updates a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task),
-
+ * PatchTasksID Update a task
+ * Updates a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task),
 and then cancels all scheduled runs of the task.
 
 Use this endpoint to set, modify, or clear task properties--for example: `cron`, `name`, `flux`, `status`.
@@ -2144,16 +2142,16 @@ _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the 
 
     ```json
     {
-    "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}\
-    from(bucket: \"telegraf\")
-    |> range(start: -1h)
-    |> filter(fn: (r) => (r._measurement == \"cpu\"))
-    |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))
-    |> filter(fn: (r) => (r.cpu == \"cpu-total\"))
-    |> aggregateWindow(every: 1h, fn: max)
-    |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
-    "status": "active",
-    "description": "This task downsamples CPU data every hour"
+      "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}\
+      from(bucket: \"telegraf\")
+        |> range(start: -1h)
+        |> filter(fn: (r) => (r._measurement == \"cpu\"))
+        |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))
+        |> filter(fn: (r) => (r.cpu == \"cpu-total\"))
+        |> aggregateWindow(every: 1h, fn: max)
+        |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
+      "status": "active",
+      "description": "This task downsamples CPU data every hour"
     }
     ```
 
@@ -2164,26 +2162,26 @@ _`"status": "inactive"`_ cancels scheduled runs and prevents manual runs of the 
 
     ```json
     {
-    "name": "CPU Total 1 Hour New",
-    "description": "This task downsamples CPU data every hour",
-    "every": "1h",
-    "scriptID": "SCRIPT_ID",
-    "scriptParameters":
-    {
-    "rangeStart": "-1h",
-    "bucket": "telegraf",
-    "filterField": "cpu-total"
-    }
-    }
+      "name": "CPU Total 1 Hour New",
+      "description": "This task downsamples CPU data every hour",
+      "every": "1h",
+      "scriptID": "SCRIPT_ID",
+      "scriptParameters":
+        {
+          "rangeStart": "-1h",
+          "bucket": "telegraf",
+          "filterField": "cpu-total"
+        }
+      }
     ```
 
 #### Limitations:
 
 - You can't use `flux` and `scriptID` for the same task.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) ID. Specifies the task to update.
-  - @return ApiPatchTasksIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) ID. Specifies the task to update.
+ * @return ApiPatchTasksIDRequest
 */
 func (a *TasksApiService) PatchTasksID(ctx _context.Context, taskID string) ApiPatchTasksIDRequest {
 	return ApiPatchTasksIDRequest{
@@ -2360,8 +2358,8 @@ func (r ApiPostTasksRequest) ExecuteWithHttpInfo() (Task, *_nethttp.Response, er
 }
 
 /*
-  - PostTasks Create a task
-  - Creates a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) and returns the task.
+ * PostTasks Create a task
+ * Creates a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) and returns the task.
 
 Use this endpoint to create a scheduled task that runs a Flux script.
 
@@ -2373,16 +2371,16 @@ Use this endpoint to create a scheduled task that runs a Flux script.
 
     ```json
     {
-    "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}\
-    from(bucket: \"telegraf\")
-    |> range(start: -1h)
-    |> filter(fn: (r) => (r._measurement == \"cpu\"))
-    |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))
-    |> filter(fn: (r) => (r.cpu == \"cpu-total\"))
-    |> aggregateWindow(every: 1h, fn: max)
-    |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
-    "status": "active",
-    "description": "This task downsamples CPU data every hour"
+      "flux": "option task = {name: \"CPU Total 1 Hour New\", every: 1h}\
+      from(bucket: \"telegraf\")
+        |> range(start: -1h)
+        |> filter(fn: (r) => (r._measurement == \"cpu\"))
+        |> filter(fn: (r) =>\n\t\t(r._field == \"usage_system\"))
+        |> filter(fn: (r) => (r.cpu == \"cpu-total\"))
+        |> aggregateWindow(every: 1h, fn: max)
+        |> to(bucket: \"cpu_usage_user_total_1h\", org: \"INFLUX_ORG\")",
+      "status": "active",
+      "description": "This task downsamples CPU data every hour"
     }
     ```
 
@@ -2393,17 +2391,17 @@ Use this endpoint to create a scheduled task that runs a Flux script.
 
     ```json
     {
-    "name": "CPU Total 1 Hour New",
-    "description": "This task downsamples CPU data every hour",
-    "every": "1h",
-    "scriptID": "SCRIPT_ID",
-    "scriptParameters":
-    {
-    "rangeStart": "-1h",
-    "bucket": "telegraf",
-    "filterField": "cpu-total"
-    }
-    }
+      "name": "CPU Total 1 Hour New",
+      "description": "This task downsamples CPU data every hour",
+      "every": "1h",
+      "scriptID": "SCRIPT_ID",
+      "scriptParameters":
+        {
+          "rangeStart": "-1h",
+          "bucket": "telegraf",
+          "filterField": "cpu-total"
+        }
+      }
     ```
 
 #### Limitations:
@@ -2417,8 +2415,8 @@ Use this endpoint to create a scheduled task that runs a Flux script.
 - [Common tasks]({{% INFLUXDB_DOCS_URL %}}/process-data/common-tasks/)
 - [Task configuration options]({{% INFLUXDB_DOCS_URL %}}/process-data/task-options/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostTasksRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostTasksRequest
 */
 func (a *TasksApiService) PostTasks(ctx _context.Context) ApiPostTasksRequest {
 	return ApiPostTasksRequest{
@@ -2613,8 +2611,8 @@ func (r ApiPostTasksIDRunsRequest) ExecuteWithHttpInfo() (Run, *_nethttp.Respons
 }
 
 /*
-  - PostTasksIDRuns Start a task run, overriding the schedule
-  - Schedules a task run to start immediately, ignoring scheduled runs.
+ * PostTasksIDRuns Start a task run, overriding the schedule
+ * Schedules a task run to start immediately, ignoring scheduled runs.
 
 Use this endpoint to manually start a task run.
 Scheduled runs will continue to run as scheduled.
@@ -2623,9 +2621,9 @@ This may result in concurrently running tasks.
 To _retry_ a previous run (and avoid creating a new run),
 use the [`POST /api/v2/tasks/{taskID}/runs/{runID}/retry` endpoint](#operation/PostTasksIDRunsIDRetry).
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID
-  - @return ApiPostTasksIDRunsRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID
+ * @return ApiPostTasksIDRunsRequest
 */
 func (a *TasksApiService) PostTasksIDRuns(ctx _context.Context, taskID string) ApiPostTasksIDRunsRequest {
 	return ApiPostTasksIDRunsRequest{
@@ -2817,9 +2815,8 @@ func (r ApiPostTasksIDRunsIDRetryRequest) ExecuteWithHttpInfo() (Run, *_nethttp.
 }
 
 /*
-  - PostTasksIDRunsIDRetry Retry a task run
-  - Queues a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)  run to
-
+ * PostTasksIDRunsIDRetry Retry a task run
+ * Queues a [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)  run to
 retry and returns the scheduled run.
 
 To manually start a _new_ task run, use the
@@ -2829,10 +2826,10 @@ To manually start a _new_ task run, use the
 
 - The task must be _active_ (`status: "active"`).
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)  ID. Specifies the task to retry.
-  - @param runID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) run ID. Specifies the task run to retry.  To find a task run ID, use the [`GET /api/v2/tasks/{taskID}/runs` endpoint](#operation/GetTasksIDRuns) to list task runs.
-  - @return ApiPostTasksIDRunsIDRetryRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param taskID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task)  ID. Specifies the task to retry.
+ * @param runID A [task]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#task) run ID. Specifies the task run to retry.  To find a task run ID, use the [`GET /api/v2/tasks/{taskID}/runs` endpoint](#operation/GetTasksIDRuns) to list task runs.
+ * @return ApiPostTasksIDRunsIDRetryRequest
 */
 func (a *TasksApiService) PostTasksIDRunsIDRetry(ctx _context.Context, taskID string, runID string) ApiPostTasksIDRunsIDRetryRequest {
 	return ApiPostTasksIDRunsIDRetryRequest{

--- a/api/api_users.gen.go
+++ b/api/api_users.gen.go
@@ -313,8 +313,8 @@ func (r ApiDeleteUsersIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, erro
 }
 
 /*
-  - DeleteUsersID Delete a user
-  - Deletes a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+ * DeleteUsersID Delete a user
+ * Deletes a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
 
 #### Required permissions
 
@@ -328,9 +328,9 @@ func (r ApiDeleteUsersIDRequest) ExecuteWithHttpInfo() (*_nethttp.Response, erro
 
 - [Manage users]({{% INFLUXDB_DOCS_URL %}}/organizations/users/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID A user ID. Specifies the [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) to delete.
-  - @return ApiDeleteUsersIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID A user ID. Specifies the [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) to delete.
+ * @return ApiDeleteUsersIDRequest
 */
 func (a *UsersApiService) DeleteUsersID(ctx _context.Context, userID string) ApiDeleteUsersIDRequest {
 	return ApiDeleteUsersIDRequest{
@@ -527,9 +527,8 @@ func (r ApiGetUsersRequest) ExecuteWithHttpInfo() (Users, *_nethttp.Response, er
 }
 
 /*
-  - GetUsers List users
-  - Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
-
+ * GetUsers List users
+ * Retrieves a list of [users]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
 Default limit is `20`.
 
 To limit which users are returned, pass query parameters in your request.
@@ -543,8 +542,8 @@ To limit which users are returned, pass query parameters in your request.
 
 *`USER_ID`* is the ID of the user that you want to retrieve.
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiGetUsersRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiGetUsersRequest
 */
 func (a *UsersApiService) GetUsers(ctx _context.Context) ApiGetUsersRequest {
 	return ApiGetUsersRequest{
@@ -740,16 +739,16 @@ func (r ApiGetUsersIDRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.Res
 }
 
 /*
-  - GetUsersID Retrieve a user
-  - Retrieves a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+ * GetUsersID Retrieve a user
+ * Retrieves a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
 
 #### Related guides
 
 - [Manage users]({{% INFLUXDB_DOCS_URL %}}/organizations/users/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID A user ID. Retrieves the specified [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
-  - @return ApiGetUsersIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID A user ID. Retrieves the specified [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user).
+ * @return ApiGetUsersIDRequest
 */
 func (a *UsersApiService) GetUsersID(ctx _context.Context, userID string) ApiGetUsersIDRequest {
 	return ApiGetUsersIDRequest{
@@ -919,8 +918,8 @@ func (r ApiPatchUsersIDRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.R
 }
 
 /*
-  - PatchUsersID Update a user
-  - Updates a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) and returns the user.
+ * PatchUsersID Update a user
+ * Updates a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) and returns the user.
 
 #### Required permissions
 
@@ -934,9 +933,9 @@ func (r ApiPatchUsersIDRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.R
 
 - [Manage users]({{% INFLUXDB_DOCS_URL %}}/organizations/users/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID A user ID. Specifies the [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) to update.
-  - @return ApiPatchUsersIDRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID A user ID. Specifies the [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) to update.
+ * @return ApiPatchUsersIDRequest
 */
 func (a *UsersApiService) PatchUsersID(ctx _context.Context, userID string) ApiPatchUsersIDRequest {
 	return ApiPatchUsersIDRequest{
@@ -1113,9 +1112,8 @@ func (r ApiPostUsersRequest) ExecuteWithHttpInfo() (UserResponse, *_nethttp.Resp
 }
 
 /*
-  - PostUsers Create a user
-  - Creates a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) that can access InfluxDB.
-
+ * PostUsers Create a user
+ * Creates a [user]({{% INFLUXDB_DOCS_URL %}}/reference/glossary/#user) that can access InfluxDB.
 Returns the user.
 
 Use this endpoint to create a user that can sign in to start a user session
@@ -1128,10 +1126,10 @@ through one of the following interfaces:
 This endpoint represents the first two steps in a four-step process to allow a user
 to authenticate with a username and password, and then access data in an organization:
 
- 1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.
- 2. Extract the user ID (`id`) value from the API response for _step 1_.
- 3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.
- 4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.
+  1. Create a user: send a `POST` request to `POST /api/v2/users`. `name` is required.
+  2. Extract the user ID (`id`) value from the API response for _step 1_.
+  3. Create an authorization (and API token) for the user: send a `POST` request to [`POST /api/v2/authorizations`](#operation/PostAuthorizations), passing the user ID (`id`) from _step 2_.
+  4. Create a password for the user: send a `POST` request to [`POST /api/v2/users/USER_ID/password`](#operation/PostUsersIDPassword), passing the user ID from _step 2_.
 
 #### Required permissions
 
@@ -1144,8 +1142,8 @@ to authenticate with a username and password, and then access data in an organiz
 - [Create a user](https://docs.influxdata.com/influxdb/latest/users/create-user/)
 - [Create an API token scoped to a user](https://docs.influxdata.com/influxdb/latest/security/tokens/create-token/#create-a-token-scoped-to-a-user)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostUsersRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostUsersRequest
 */
 func (a *UsersApiService) PostUsers(ctx _context.Context) ApiPostUsersRequest {
 	return ApiPostUsersRequest{
@@ -1340,22 +1338,22 @@ func (r ApiPostUsersIDPasswordRequest) ExecuteWithHttpInfo() (*_nethttp.Response
 }
 
 /*
-  - PostUsersIDPassword Update a password
-  - Updates a user password.
+ * PostUsersIDPassword Update a password
+ * Updates a user password.
 
 #### InfluxDB Cloud
 
-  - Doesn't allow you to manage user passwords through the API.
-    Use the InfluxDB Cloud user interface (UI) to update a password.
+- Doesn't allow you to manage user passwords through the API.
+  Use the InfluxDB Cloud user interface (UI) to update a password.
 
 #### Related guides
 
 - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
 - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID The ID of the user to set the password for.
-  - @return ApiPostUsersIDPasswordRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID The ID of the user to set the password for.
+ * @return ApiPostUsersIDPasswordRequest
 */
 func (a *UsersApiService) PostUsersIDPassword(ctx _context.Context, userID string) ApiPostUsersIDPasswordRequest {
 	return ApiPostUsersIDPasswordRequest{
@@ -1519,8 +1517,8 @@ func (r ApiPutUsersIDPasswordRequest) ExecuteWithHttpInfo() (*_nethttp.Response,
 }
 
 /*
-  - PutUsersIDPassword Update a password
-  - Updates a user password.
+ * PutUsersIDPassword Update a password
+ * Updates a user password.
 
 Use this endpoint to let a user authenticate with
 [Basic authentication credentials](#section/Authentication/BasicAuthentication)
@@ -1528,17 +1526,17 @@ and set a new password.
 
 #### InfluxDB Cloud
 
-  - Doesn't allow you to manage user passwords through the API.
-    Use the InfluxDB Cloud user interface (UI) to update a password.
+- Doesn't allow you to manage user passwords through the API.
+  Use the InfluxDB Cloud user interface (UI) to update a password.
 
 #### Related guides
 
 - [InfluxDB Cloud - Change your password](https://docs.influxdata.com/influxdb/cloud/account-management/change-password/)
 - [InfluxDB OSS - Change your password](https://docs.influxdata.com/influxdb/latest/users/change-password/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @param userID The ID of the user to set the password for.
-  - @return ApiPutUsersIDPasswordRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @param userID The ID of the user to set the password for.
+ * @return ApiPutUsersIDPasswordRequest
 */
 func (a *UsersApiService) PutUsersIDPassword(ctx _context.Context, userID string) ApiPutUsersIDPasswordRequest {
 	return ApiPutUsersIDPasswordRequest{

--- a/api/api_write.gen.go
+++ b/api/api_write.gen.go
@@ -193,8 +193,8 @@ func (r ApiPostWriteRequest) ExecuteWithHttpInfo() (*_nethttp.Response, error) {
 }
 
 /*
-  - PostWrite Write data
-  - Writes data to a bucket.
+ * PostWrite Write data
+ * Writes data to a bucket.
 
 Use this endpoint to send data in [line protocol]({{% INFLUXDB_DOCS_URL %}}/reference/syntax/line-protocol/) format to InfluxDB.
 
@@ -202,29 +202,27 @@ Use this endpoint to send data in [line protocol]({{% INFLUXDB_DOCS_URL %}}/refe
 
 - Does the following when you send a write request:
 
- 1. Validates the request and queues the write.
+  1. Validates the request and queues the write.
+  2. If queued, responds with _success_ (HTTP `2xx` status code); _error_ otherwise.
+  3. Handles the delete asynchronously and reaches eventual consistency.
 
- 2. If queued, responds with _success_ (HTTP `2xx` status code); _error_ otherwise.
+  To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,
+  wait for a success response (HTTP `2xx` status code) before you send the next request.
 
- 3. Handles the delete asynchronously and reaches eventual consistency.
-
-    To ensure that InfluxDB Cloud handles writes and deletes in the order you request them,
-    wait for a success response (HTTP `2xx` status code) before you send the next request.
-
-    Because writes and deletes are asynchronous, your change might not yet be readable
-    when you receive the response.
+  Because writes and deletes are asynchronous, your change might not yet be readable
+  when you receive the response.
 
 #### InfluxDB OSS
 
-  - Validates the request and handles the write synchronously.
-  - If all points were written successfully, responds with HTTP `2xx` status code;
-    otherwise, returns the first line that failed.
+- Validates the request and handles the write synchronously.
+- If all points were written successfully, responds with HTTP `2xx` status code;
+  otherwise, returns the first line that failed.
 
 #### Required permissions
 
 - `write-buckets` or `write-bucket BUCKET_ID`.
 
-	*`BUCKET_ID`* is the ID of the destination bucket.
+ *`BUCKET_ID`* is the ID of the destination bucket.
 
 #### Rate limits (with InfluxDB Cloud)
 
@@ -237,8 +235,8 @@ For more information, see [limits and adjustable quotas](https://docs.influxdata
 - [Optimize writes to InfluxDB]({{% INFLUXDB_DOCS_URL %}}/write-data/best-practices/optimize-writes/)
 - [Troubleshoot issues writing data]({{% INFLUXDB_DOCS_URL %}}/write-data/troubleshoot/)
 
-  - @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
-  - @return ApiPostWriteRequest
+ * @param ctx _context.Context - for authentication, logging, cancellation, deadlines, tracing, etc. Passed from http.Request or context.Background().
+ * @return ApiPostWriteRequest
 */
 func (a *WriteApiService) PostWrite(ctx _context.Context) ApiPostWriteRequest {
 	return ApiPostWriteRequest{

--- a/api/contract/cli.yml
+++ b/api/contract/cli.yml
@@ -43,6 +43,8 @@ paths:
     $ref: "./openapi/src/common/paths/orgs_orgID_secrets.yml"
   /api/v2/orgs/{orgID}/secrets/{delete}:
     $ref: "./openapi/src/common/paths/orgs_orgID_secrets_delete.yml"
+  /api/v2/orgs/{orgID}/secrets/{secretID}:
+    $ref: "./openapi/src/common/paths/orgs_orgID_secrets_secretID.yml"
   /api/v2/buckets/{bucketID}/schema/measurements:
     $ref: "./openapi/src/cloud/paths/measurements.yml"
   /api/v2/buckets/{bucketID}/schema/measurements/{measurementID}:

--- a/clients/secret/secret.go
+++ b/clients/secret/secret.go
@@ -36,11 +36,10 @@ func (c Client) Delete(ctx context.Context, params *DeleteParams) error {
 		return err
 	}
 
-	// PostOrgsIDSecrets is used to remove secrets from an organization.
+	// DeleteOrgsIDSecretsID is used to remove a secret from an organization.
 	// The name is generated from the operationId in the
-	// orgs_orgsID_secrets_delete.yml path.
-	err = c.PostOrgsIDSecrets(ctx, orgID).
-		SecretKeys(api.SecretKeys{Secrets: &[]string{params.Key}}).
+	// orgs_orgsID_secrets_secretID.yml path.
+	err = c.DeleteOrgsIDSecretsID(ctx, orgID, params.Key).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("failed to delete secret with key %q: %w", params.Key, err)

--- a/clients/secret/secret_test.go
+++ b/clients/secret/secret_test.go
@@ -140,11 +140,11 @@ func TestSecret_Delete(t *testing.T) {
 			},
 			defaultOrgName: defaultOrgName,
 			registerExpectations: func(t *testing.T, secretApi *mock.MockSecretsApi) {
-				req := api.ApiPostOrgsIDSecretsRequest{ApiService: secretApi}.
+				req := api.ApiDeleteOrgsIDSecretsIDRequest{ApiService: secretApi}.
 					OrgID(id).
-					SecretKeys(api.SecretKeys{Secrets: &[]string{"key1"}})
-				secretApi.EXPECT().PostOrgsIDSecrets(gomock.Any(), gomock.Eq(id)).Return(req)
-				secretApi.EXPECT().PostOrgsIDSecretsExecute(gomock.Eq(req)).Return(nil)
+					SecretID("key1")
+				secretApi.EXPECT().DeleteOrgsIDSecretsID(gomock.Any(), gomock.Eq(id), gomock.Eq("key1")).Return(req)
+				secretApi.EXPECT().DeleteOrgsIDSecretsIDExecute(gomock.Eq(req)).Return(nil)
 			},
 			expectMatcher: printHeader + fakeKey + "\t" + id + "\ttrue\n",
 		},
@@ -159,11 +159,11 @@ func TestSecret_Delete(t *testing.T) {
 			},
 			defaultOrgName: defaultOrgName,
 			registerExpectations: func(t *testing.T, secretApi *mock.MockSecretsApi) {
-				req := api.ApiPostOrgsIDSecretsRequest{ApiService: secretApi}.
+				req := api.ApiDeleteOrgsIDSecretsIDRequest{ApiService: secretApi}.
 					OrgID(id).
-					SecretKeys(api.SecretKeys{Secrets: &[]string{""}})
-				secretApi.EXPECT().PostOrgsIDSecrets(gomock.Any(), gomock.Eq(id)).Return(req)
-				secretApi.EXPECT().PostOrgsIDSecretsExecute(gomock.Eq(req)).Return(nil)
+					SecretID("")
+				secretApi.EXPECT().DeleteOrgsIDSecretsID(gomock.Any(), gomock.Eq(id), gomock.Eq("")).Return(req)
+				secretApi.EXPECT().DeleteOrgsIDSecretsIDExecute(gomock.Eq(req)).Return(nil)
 			},
 			expectMatcher: printHeader + "\t" + id + "\ttrue\n",
 		},

--- a/internal/mock/api_secret.gen.go
+++ b/internal/mock/api_secret.gen.go
@@ -36,6 +36,49 @@ func (m *MockSecretsApi) EXPECT() *MockSecretsApiMockRecorder {
 	return m.recorder
 }
 
+// DeleteOrgsIDSecretsID mocks base method.
+func (m *MockSecretsApi) DeleteOrgsIDSecretsID(arg0 context.Context, arg1, arg2 string) api.ApiDeleteOrgsIDSecretsIDRequest {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrgsIDSecretsID", arg0, arg1, arg2)
+	ret0, _ := ret[0].(api.ApiDeleteOrgsIDSecretsIDRequest)
+	return ret0
+}
+
+// DeleteOrgsIDSecretsID indicates an expected call of DeleteOrgsIDSecretsID.
+func (mr *MockSecretsApiMockRecorder) DeleteOrgsIDSecretsID(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDSecretsID", reflect.TypeOf((*MockSecretsApi)(nil).DeleteOrgsIDSecretsID), arg0, arg1, arg2)
+}
+
+// DeleteOrgsIDSecretsIDExecute mocks base method.
+func (m *MockSecretsApi) DeleteOrgsIDSecretsIDExecute(arg0 api.ApiDeleteOrgsIDSecretsIDRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrgsIDSecretsIDExecute", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteOrgsIDSecretsIDExecute indicates an expected call of DeleteOrgsIDSecretsIDExecute.
+func (mr *MockSecretsApiMockRecorder) DeleteOrgsIDSecretsIDExecute(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDSecretsIDExecute", reflect.TypeOf((*MockSecretsApi)(nil).DeleteOrgsIDSecretsIDExecute), arg0)
+}
+
+// DeleteOrgsIDSecretsIDExecuteWithHttpInfo mocks base method.
+func (m *MockSecretsApi) DeleteOrgsIDSecretsIDExecuteWithHttpInfo(arg0 api.ApiDeleteOrgsIDSecretsIDRequest) (*http.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOrgsIDSecretsIDExecuteWithHttpInfo", arg0)
+	ret0, _ := ret[0].(*http.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOrgsIDSecretsIDExecuteWithHttpInfo indicates an expected call of DeleteOrgsIDSecretsIDExecuteWithHttpInfo.
+func (mr *MockSecretsApiMockRecorder) DeleteOrgsIDSecretsIDExecuteWithHttpInfo(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOrgsIDSecretsIDExecuteWithHttpInfo", reflect.TypeOf((*MockSecretsApi)(nil).DeleteOrgsIDSecretsIDExecuteWithHttpInfo), arg0)
+}
+
 // GetOrgsIDSecrets mocks base method.
 func (m *MockSecretsApi) GetOrgsIDSecrets(arg0 context.Context, arg1 string) api.ApiGetOrgsIDSecretsRequest {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Hi! This PR tackles the issue reported in [468](https://github.com/influxdata/influx-cli/issues/468). 

The _influx secret delete_ command stopped working because the influx client was not updated following the changes regarding the _secrets delete_ API in the influxdb and openapi repos.

This PR updates the _secrets delete_ functionality in order to use DELETE queries to /api/v2/orgs/{org id}/secrets/{secret key} instead of POST queries to /api/v2/orgs/{org id}/secrets/delete

(Note: most diffs are cosmetic changes to comment sections provoked by _make openapi_  - **the actual, intended changes are the ones in api/contract/cli.yml** (and api/api_secrets.gen.go and internal/mock/api_secret.gen.go as a result), **clients/secret/secret.go and clients/secret/secret_test.go**)