### PR TITLE
fix: typo in alias of bucket update command

### DIFF
--- a/cmd/influx/bucket.go
+++ b/cmd/influx/bucket.go
@@ -164,7 +164,7 @@ func newBucketUpdateCmd() cli.Command {
 	return cli.Command{
 		Name:    "update",
 		Usage:   "Update bucket",
-		Aliases: []string{"find", "ls"},
+		Aliases: []string{"set"},
 		Before:  middleware.WithBeforeFns(withCli(), withApi(true), middleware.NoArgs),
 		Flags: append(
 			commonFlags(),


### PR DESCRIPTION
Fix the alias name of the bucket update command.