### PR TITLE
fix(signin): Check for all available cookies instead of the count

### DIFF
--- a/clients/signin/signin.go
+++ b/clients/signin/signin.go
@@ -48,9 +48,12 @@ func GetCookie(ctx context.Context, params api.ConfigParams, userPass string) (s
 	}
 
 	cookies := res.Cookies()
-	if len(cookies) != 1 {
-		return "", fmt.Errorf("failure getting session cookie, multiple cookies")
+
+	for _, cookie := range cookies {
+		if strings.Contains(cookie.Name, "influxdb") {
+			return cookie.Value, nil
+		}
 	}
 
-	return cookies[0].Value, nil
+	return "", fmt.Errorf("failure getting session cookie, invalid cookies")
 }


### PR DESCRIPTION
Hi,

It is possible to have multiple cookies returned on a successful sign-in response, specially when it is running behind a reverse proxy etc. This PR fixes the issue by looking up the cookies that contain `influxdb` within the name (it works on both OSS and cloud) and using the value of that cookie instead of checking for cookie array size.