### PR TITLE
fix: don't import non-existent/unused GPG private key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,10 +329,8 @@ jobs:
       - run:
           command: |
             export DEBIAN_FRONTEND=noninteractive
-            sudo apt-get update -y
-            sudo apt-get install -y awscli gnupg
-
-            gpg --import --batch \<<<"${GPG_PRIVATE_KEY//$'\\n'/$'\n'}"
+            sudo -E apt-get update
+            sudo -E apt-get install --yes awscli
       - when:
           condition: << parameters.is-nightly >>
           steps:


### PR DESCRIPTION
The release-nightly workflow was failing as it was attempting to import the old signing key. This PR removes that statement as well as correctly supplies the "DEBIAN_FRONTEND" environment variable to the "apt-get" commands.