### PR TITLE
fix: supply "VERSION" and "COMMIT" to Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,10 +329,8 @@ jobs:
       - run:
           command: |
             export DEBIAN_FRONTEND=noninteractive
-            sudo apt-get update -y
-            sudo apt-get install -y awscli gnupg
-
-            gpg --import --batch \<<<"${GPG_PRIVATE_KEY//$'\\n'/$'\n'}"
+            sudo -E apt-get update
+            sudo -E apt-get install --yes awscli
       - when:
           condition: << parameters.is-nightly >>
           steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,9 @@ workflows:
           name: build-<< matrix.os >>-<< matrix.arch >>
           matrix:
             parameters:
-              os:   [ linux, darwin, windows ]
-              arch: [ amd64, arm64 ]
+              os:       [ linux, darwin, windows ]
+              arch:     [ amd64, arm64 ]
+              workflow: [ snapshot ]
             exclude:
               - os: darwin
                 arch: arm64
@@ -147,8 +148,9 @@ workflows:
           name: build-<< matrix.os >>-<< matrix.arch >>
           matrix:
             parameters:
-              os:   [ linux, darwin, windows ]
-              arch: [ amd64, arm64 ]
+              os:       [ linux, darwin, windows ]
+              arch:     [ amd64, arm64 ]
+              workflow: [ snapshot ]
             exclude:
               - os: darwin
                 arch: arm64
@@ -229,8 +231,9 @@ workflows:
           name: build-<< matrix.os >>-<< matrix.arch >>
           matrix:
             parameters:
-              os:   [ linux, darwin, windows ]
-              arch: [ amd64, arm64 ]
+              os:       [ linux, darwin, windows ]
+              arch:     [ amd64, arm64 ]
+              workflow: [ release ]
             exclude:
               - os: darwin
                 arch: arm64
@@ -406,12 +409,22 @@ jobs:
         type: string
       arch:
         type: string
+      workflow:
+        type: string
     steps:
       - checkout
-      - run:
-          name: Build Binaries
-          command: |
-            GOOS=<<parameters.os>> GOARCH=<<parameters.arch>> make
+      - when:
+          condition:
+            equals: [ << parameters.workflow >>, snapshot ]
+          steps:
+            - run: |
+                GOOS=<< parameters.os >> GOARCH=<< parameters.arch >> COMMIT=<< pipeline.git.revision >> make
+      - when:
+          condition:
+            equals: [ << parameters.workflow >>, release ]
+          steps:
+            - run: |
+                GOOS=<< parameters.os >> GOARCH=<< parameters.arch >> COMMIT=<< pipeline.git.revision >> VERSION=<< pipeline.git.tag >> make
       - store_artifacts:
           path: bin
       - persist_to_workspace:


### PR DESCRIPTION
Currently, binaries built from CI report "dev" instead of the correct version information. This updates the CI config so that "COMMIT" and "VERSION" are supplied at compile time.