### PR TITLE
fix: disable passord length checks so influxdb validates passwords (#534)

### DIFF
--- a/clients/setup/setup_test.go
+++ b/clients/setup/setup_test.go
@@ -231,37 +231,6 @@ func Test_SetupSuccessInteractive(t *testing.T) {
 	}, strings.Split(bytesWritten.String(), "\n"))
 }
 
-func Test_SetupPasswordParamTooShort(t *testing.T) {
-	t.Parallel()
-
-	retentionSecs := int64(duration.Week.Seconds())
-	params := setup.Params{
-		Username:  "user",
-		Password:  "2short",
-		AuthToken: "mytoken",
-		Org:       "org",
-		Bucket:    "bucket",
-		Retention: fmt.Sprintf("%ds", retentionSecs),
-		Force:     false,
-	}
-
-	ctrl := gomock.NewController(t)
-	client := mock.NewMockSetupApi(ctrl)
-	client.EXPECT().GetSetup(gomock.Any()).Return(api.ApiGetSetupRequest{ApiService: client})
-	client.EXPECT().GetSetupExecute(gomock.Any()).Return(api.InlineResponse200{Allowed: api.PtrBool(true)}, nil)
-
-	configSvc := mock.NewMockConfigService(ctrl)
-	configSvc.EXPECT().ListConfigs().Return(nil, nil)
-
-	stdio := mock.NewMockStdIO(ctrl)
-	cli := setup.Client{
-		CLI:      clients.CLI{ConfigService: configSvc, ActiveConfig: config.Config{}, StdIO: stdio},
-		SetupApi: client,
-	}
-	err := cli.Setup(context.Background(), &params)
-	require.Equal(t, clients.ErrPasswordIsTooShort, err)
-}
-
 func Test_SetupCancelAtConfirmation(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/stdio/stdio.go
+++ b/pkg/stdio/stdio.go
@@ -9,7 +9,8 @@ import (
 	"github.com/mattn/go-isatty"
 )
 
-const MinPasswordLen = 8
+// Disable password length checking to let influxdb handle it
+const MinPasswordLen = 0
 
 type StdIO interface {
 	// Write prints some bytes to stdout.


### PR DESCRIPTION
Disable password length checks and let influxd
do all password strength checks.

closes https://github.com/influxdata/influx-cli/issues/533

(cherry picked from commit df2e6877b68c2d55c97af20879a65be9ebf5237d)

closes https://github.com/influxdata/influx-cli/issues/535