### PR TITLE
chore: upgrade to go 1.21.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ executors:
       # NOTE: To upgrade the Go version, first push the upgrade to the cross-builder Dockerfile in the edge repo,
       # then update the version here to match. Until we finish the migration to using the cross-builder image,
       # you'll also need to update references to `cimg/go` and `GO_VERSION` in this file.
-      - image: quay.io/influxdb/cross-builder:go1.21.9-latest
+      - image: quay.io/influxdb/cross-builder:go1.21.12-latest
     resource_class: medium
   linux-amd64:
     machine:


### PR DESCRIPTION
Fixes CVE-2024-24790, reported by X-Ray.

Fixes #544 