### PR TITLE
fix: avoid panic on empty tag value

### DIFF
--- a/clients/v1_shell/table_model.go
+++ b/clients/v1_shell/table_model.go
@@ -175,7 +175,7 @@ func (m Model) Init() tea.Cmd {
 				continue
 			}
 			if val == "" {
-				val = "N/A"
+				val = " ----- "
 			}
 			builder.WriteString(fmt.Sprintf("%s=%s, ", color.YellowString(key), color.CyanString(val)))
 		}

--- a/clients/v1_shell/table_model.go
+++ b/clients/v1_shell/table_model.go
@@ -175,7 +175,7 @@ func (m Model) Init() tea.Cmd {
 				continue
 			}
 			if val == "" {
-				val = " ----- "
+				val = " <nil> "
 			}
 			builder.WriteString(fmt.Sprintf("%s=%s, ", color.YellowString(key), color.CyanString(val)))
 		}

--- a/clients/v1_shell/table_model.go
+++ b/clients/v1_shell/table_model.go
@@ -175,7 +175,7 @@ func (m Model) Init() tea.Cmd {
 				continue
 			}
 			if val == "" {
-				val = " <nil> "
+				val = "<nil>"
 			}
 			builder.WriteString(fmt.Sprintf("%s=%s, ", color.YellowString(key), color.CyanString(val)))
 		}

--- a/clients/v1_shell/table_model.go
+++ b/clients/v1_shell/table_model.go
@@ -171,8 +171,11 @@ func (m Model) Init() tea.Cmd {
 	if len(m.tags) > 0 {
 		fmt.Print("Tags: ")
 		for key, val := range m.tags {
-			if key == "" || val == "" {
+			if key == "" {
 				continue
+			}
+			if val == "" {
+				val = "N/A"
 			}
 			builder.WriteString(fmt.Sprintf("%s=%s, ", color.YellowString(key), color.CyanString(val)))
 		}

--- a/clients/v1_shell/table_model_test.go
+++ b/clients/v1_shell/table_model_test.go
@@ -79,6 +79,6 @@ func Test_checkEmptyTagValueRender(t *testing.T) {
 	h.mu.Unlock()
 	checkLines := strings.Split(check, "\n")
 	assert.Equal(t, "Name: test", checkLines[0])
-	assert.Equal(t, "Tags: foo= ----- ", checkLines[1])
+	assert.Equal(t, "Tags: foo= <nil> ", checkLines[1])
 
 }

--- a/clients/v1_shell/table_model_test.go
+++ b/clients/v1_shell/table_model_test.go
@@ -68,19 +68,17 @@ func Test_checkEmptyTagValueRender(t *testing.T) {
 		if err != nil {
 			assert.FailNow(t, err.Error())
 		}
-		return
 	}(ctx)
 
 	model.Init()
 
-	select {
-	case <-ctx.Done():
-		os.Stdout = old
-		h.mu.Lock()
-		check := h.buffer.String()
-		h.mu.Unlock()
-		checkLines := strings.Split(check, "\n")
-		assert.Equal(t, "Name: test", checkLines[0])
-		assert.Equal(t, "Tags: foo= ----- ", checkLines[1])
-	}
+	assert.NotNil(t, <-ctx.Done())
+	os.Stdout = old
+	h.mu.Lock()
+	check := h.buffer.String()
+	h.mu.Unlock()
+	checkLines := strings.Split(check, "\n")
+	assert.Equal(t, "Name: test", checkLines[0])
+	assert.Equal(t, "Tags: foo= ----- ", checkLines[1])
+
 }

--- a/clients/v1_shell/table_model_test.go
+++ b/clients/v1_shell/table_model_test.go
@@ -1,0 +1,68 @@
+package v1shell
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influx-cli/v2/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_Explore(t *testing.T) {
+	r, w, e := os.Pipe()
+	if e != nil {
+		assert.FailNow(t, e.Error())
+	}
+	old := os.Stdout
+	os.Stdout = w
+	defer func() {
+		os.Stdout = old
+	}()
+
+	print()
+	seriesName := "tagless"
+	seriesTags := map[string]string{"state": ""}
+	seriesPartial := false
+	seriesColumns := []string{"time", "state", "value"}
+	seriesValues := [][]interface{}{{1731069761000000000, "on", 2},
+		{1731069771000000000, "off", 1}, {1731069781000000000, "on", 0}}
+
+	model := NewModel(
+		api.InfluxqlJsonResponseSeries{
+			Name:    &seriesName,
+			Tags:    &seriesTags,
+			Partial: &seriesPartial,
+			Columns: &seriesColumns,
+			Values:  &seriesValues,
+		},
+		true,
+		"test",
+		map[string]string{"foo": ""},
+		0,
+		10,
+		0,
+		10,
+		false,
+	)
+
+	buffer := &bytes.Buffer{}
+	go func() {
+		_, err := io.Copy(buffer, r)
+		if err != nil {
+			assert.FailNow(t, err.Error())
+		}
+	}()
+	model.Init()
+	model.View()
+	// Tried WG and Chan but both seem to get hung-up with tea for some reason
+	time.Sleep(100 * time.Millisecond)
+	os.Stdout = old
+	check := buffer.String()
+	checkLines := strings.Split(check, "\n")
+	assert.Equal(t, "Name: test", checkLines[0])
+	assert.Equal(t, "Tags: foo=N/A", checkLines[1])
+}

--- a/clients/v1_shell/table_model_test.go
+++ b/clients/v1_shell/table_model_test.go
@@ -63,7 +63,7 @@ func Test_checkEmptyTagValueRender(t *testing.T) {
 	defer cancel()
 	go func(ctx context.Context) {
 		h.mu.Lock()
-		_, err := io.CopyN(h.buffer, r, 29)
+		_, err := io.CopyN(h.buffer, r, 27)
 		h.mu.Unlock()
 		if err != nil {
 			assert.FailNow(t, err.Error())
@@ -79,6 +79,6 @@ func Test_checkEmptyTagValueRender(t *testing.T) {
 	h.mu.Unlock()
 	checkLines := strings.Split(check, "\n")
 	assert.Equal(t, "Name: test", checkLines[0])
-	assert.Equal(t, "Tags: foo= <nil> ", checkLines[1])
+	assert.Equal(t, "Tags: foo=<nil>", checkLines[1])
 
 }


### PR DESCRIPTION
Fixes #547
Fixes #542

### Current state

Currently, when the method `func (m Model) Init()` is called on a result containing a tag with an empty value (e.g. `"tags":{"state":""}`), the program panics on the line (`fmt.Print(tagline[:len(tagline)-2])`).

### Proposed change

in `table_modle.go` when the method `func (m Model) Init()` is called with a result containing a tag with an empty value (e.g. `"tags":{"state":""}`), the empty value is substituted in the tea model with a default presentation string ` ----- ` suggesting an empty value was found.  