### PR TITLE
feat: add `--operator-token` flag to restore subcommand

### DIFF
--- a/cmd/influx/restore.go
+++ b/cmd/influx/restore.go
@@ -61,6 +61,11 @@ Examples:
 				Usage:       "New name to use for the restored organization",
 				Destination: &params.NewOrgName,
 			},
+			&cli.StringFlag{
+				Name:        "operator-token",
+				Usage:       "Operator token to use if backup lacks plaintext token",
+				Destination: &params.OperatorToken,
+			},
 		),
 		Action: func(ctx *cli.Context) error {
 			if ctx.NArg() != 1 {


### PR DESCRIPTION
Add `--operator-token` flag to restore subcommand. If the backup being restored lacks a plaintext operator token, then the token given with `--operator-token` will be used to restore the backup.