### PR TITLE
chore(CI): add "influxdata-archive-keyring" package

### DIFF
--- a/scripts/ci/build-packages
+++ b/scripts/ci/build-packages
@@ -77,23 +77,25 @@ fpm_wrapper()
     esac
   fi
 
-  fpm                                                            \
-    --log error                                                  \
-    `# package description`                                      \
-    --name           influxdb2-cli                               \
-    --vendor         InfluxData                                  \
-    --description    'CLI for managing resources in InfluxDB v2' \
-    --url            https://influxdata.com                      \
-    --maintainer     support@influxdb.com                        \
-    --license        MIT                                         \
-    `# package configuration`                                    \
-    --input-type     dir                                         \
-    --output-type    "${1}"                                      \
-    --architecture   "${ARCH}"                                   \
-    --version        "${VERSION}"                                \
-    --iteration      1                                           \
-    `# package options`                                          \
-    --chdir          fs/                                         \
+  fpm                                                             \
+    --log error                                                   \
+    `# package description`                                       \
+    --name            influxdb2-cli                               \
+    --vendor          InfluxData                                  \
+    --description     'CLI for managing resources in InfluxDB v2' \
+    --url             https://influxdata.com                      \
+    --maintainer      support@influxdb.com                        \
+    --license         MIT                                         \
+    --rpm-tag         'Recommends: influxdata-archive-keyring'    \
+    --deb-recommends  'influxdata-archive-keyring'                \
+    `# package configuration`                                     \
+    --input-type     dir                                          \
+    --output-type    "${1}"                                       \
+    --architecture   "${ARCH}"                                    \
+    --version        "${VERSION}"                                 \
+    --iteration      1                                            \
+    `# package options`                                           \
+    --chdir          fs/                                          \
     --package        "${PKG_OUT_PATH}/"
 
     # `goreleaser` removed the "package revision" from the package filename.


### PR DESCRIPTION
```sh
$ dpkg -I influxdb2-client-2.x-b94e8173-amd64.deb
 new Debian package, version 2.0.
 size 11834504 bytes: control archive=454 bytes.
     317 bytes,    12 lines      control
     124 bytes,     2 lines      md5sums
 Package: influxdb2-cli
 Version: 2.x-b94e8173-1
 License: MIT
 Vendor: InfluxData
 Architecture: amd64
 Maintainer: support@influxdb.com
 Installed-Size: 25502
 Recommends: influxdata-archive-keyring
 Section: default
 Priority: optional
 Homepage: https://influxdata.com
 Description: CLI for managing resources in InfluxDB v2
```

```sh
$ rpm -q --recommends influxdb2-client-2.x_b94e8173.x86_64.rpm
influxdata-archive-keyring
```