### PR TITLE
fix: dbrp correct json output

### DIFF
--- a/clients/v1_dbrps/v1_dbrps.go
+++ b/clients/v1_dbrps/v1_dbrps.go
@@ -68,6 +68,11 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to list dbrps: %w", err)
 	}
+
+	if c.PrintAsJSON {
+		return c.printDBRPs(dbrpPrintOpts{dbrps: dbrps.GetContent()})
+	}
+
 	var virtDbrps []api.DBRP
 	var physDbrps []api.DBRP
 	for _, dbrp := range dbrps.GetContent() {
@@ -76,10 +81,6 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 		} else {
 			physDbrps = append(physDbrps, dbrp)
 		}
-	}
-
-	if c.PrintAsJSON {
-		return c.PrintJSON(dbrps.GetContent())
 	}
 
 	c.printDBRPs(dbrpPrintOpts{dbrps: physDbrps})

--- a/clients/v1_dbrps/v1_dbrps.go
+++ b/clients/v1_dbrps/v1_dbrps.go
@@ -70,7 +70,11 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 	}
 
 	if c.PrintAsJSON {
-		return c.printDBRPs(dbrpPrintOpts{dbrps: dbrps.GetContent()})
+		content := dbrps.GetContent()
+		if content == nil {
+			content = []api.DBRP{}
+		}
+		return c.printDBRPs(dbrpPrintOpts{dbrps: content})
 	}
 
 	var virtDbrps []api.DBRP

--- a/clients/v1_dbrps/v1_dbrps.go
+++ b/clients/v1_dbrps/v1_dbrps.go
@@ -78,6 +78,10 @@ func (c Client) List(ctx context.Context, params *ListParams) error {
 		}
 	}
 
+	if c.PrintAsJSON {
+		return c.PrintJSON(dbrps.GetContent())
+	}
+
 	c.printDBRPs(dbrpPrintOpts{dbrps: physDbrps})
 	fmt.Fprintln(c.StdIO, "\nVIRTUAL DBRP MAPPINGS (READ-ONLY)")
 	fmt.Fprintln(c.StdIO, "----------------------------------")

--- a/clients/v1_dbrps/v1_dbrps_test.go
+++ b/clients/v1_dbrps/v1_dbrps_test.go
@@ -3,6 +3,7 @@ package v1dbrps_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -146,6 +147,54 @@ func TestClient_List(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_ListJSON(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	DBRPsApi := mock.NewMockDBRPsApi(ctrl)
+
+	DBRPsApi.EXPECT().GetDBRPs(gomock.Any()).Return(api.ApiGetDBRPsRequest{ApiService: DBRPsApi})
+	DBRPsApi.EXPECT().GetDBRPsExecute(gomock.Any()).Return(api.DBRPs{
+		Content: &[]api.DBRP{
+			{
+				Id:              "123",
+				Database:        "someDB",
+				BucketID:        "456",
+				RetentionPolicy: "someRP",
+				Default:         false,
+				OrgID:           "1234123412341234",
+			},
+			{
+				Id:              "567",
+				Database:        "someDB",
+				BucketID:        "456",
+				RetentionPolicy: "someRP",
+				Default:         true,
+				Virtual:         api.PtrBool(true),
+				OrgID:           "1234123412341234",
+			},
+		},
+	}, nil)
+
+	stdout := bytes.Buffer{}
+	stdio := mock.NewMockStdIO(ctrl)
+	stdio.EXPECT().Write(gomock.Any()).DoAndReturn(stdout.Write).AnyTimes()
+
+	cli := v1dbrps.Client{CLI: clients.CLI{StdIO: stdio, PrintAsJSON: true}, DBRPsApi: DBRPsApi}
+
+	err := cli.List(context.Background(), &v1dbrps.ListParams{
+		OrgParams: clients.OrgParams{OrgID: id1},
+	})
+	require.NoError(t, err)
+
+	// The output should be valid JSON — a single array, not two arrays separated by text.
+	var parsed []api.DBRP
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed), "output should be valid JSON")
+	require.Len(t, parsed, 2)
+	require.Equal(t, "123", parsed[0].Id)
+	require.Equal(t, "567", parsed[1].Id)
 }
 
 func TestClient_Create(t *testing.T) {

--- a/clients/v1_dbrps/v1_dbrps_test.go
+++ b/clients/v1_dbrps/v1_dbrps_test.go
@@ -152,49 +152,80 @@ func TestClient_List(t *testing.T) {
 func TestClient_ListJSON(t *testing.T) {
 	t.Parallel()
 
-	ctrl := gomock.NewController(t)
-	DBRPsApi := mock.NewMockDBRPsApi(ctrl)
+	t.Run("many results", func(t *testing.T) {
+		t.Parallel()
 
-	DBRPsApi.EXPECT().GetDBRPs(gomock.Any()).Return(api.ApiGetDBRPsRequest{ApiService: DBRPsApi})
-	DBRPsApi.EXPECT().GetDBRPsExecute(gomock.Any()).Return(api.DBRPs{
-		Content: &[]api.DBRP{
-			{
-				Id:              "123",
-				Database:        "someDB",
-				BucketID:        "456",
-				RetentionPolicy: "someRP",
-				Default:         false,
-				OrgID:           "1234123412341234",
+		ctrl := gomock.NewController(t)
+		DBRPsApi := mock.NewMockDBRPsApi(ctrl)
+
+		DBRPsApi.EXPECT().GetDBRPs(gomock.Any()).Return(api.ApiGetDBRPsRequest{ApiService: DBRPsApi})
+		DBRPsApi.EXPECT().GetDBRPsExecute(gomock.Any()).Return(api.DBRPs{
+			Content: &[]api.DBRP{
+				{
+					Id:              "123",
+					Database:        "someDB",
+					BucketID:        "456",
+					RetentionPolicy: "someRP",
+					Default:         false,
+					OrgID:           "1234123412341234",
+				},
+				{
+					Id:              "567",
+					Database:        "someDB",
+					BucketID:        "456",
+					RetentionPolicy: "someRP",
+					Default:         true,
+					Virtual:         api.PtrBool(true),
+					OrgID:           "1234123412341234",
+				},
 			},
-			{
-				Id:              "567",
-				Database:        "someDB",
-				BucketID:        "456",
-				RetentionPolicy: "someRP",
-				Default:         true,
-				Virtual:         api.PtrBool(true),
-				OrgID:           "1234123412341234",
-			},
-		},
-	}, nil)
+		}, nil)
 
-	stdout := bytes.Buffer{}
-	stdio := mock.NewMockStdIO(ctrl)
-	stdio.EXPECT().Write(gomock.Any()).DoAndReturn(stdout.Write).AnyTimes()
+		stdout := bytes.Buffer{}
+		stdio := mock.NewMockStdIO(ctrl)
+		stdio.EXPECT().Write(gomock.Any()).DoAndReturn(stdout.Write).AnyTimes()
 
-	cli := v1dbrps.Client{CLI: clients.CLI{StdIO: stdio, PrintAsJSON: true}, DBRPsApi: DBRPsApi}
+		cli := v1dbrps.Client{CLI: clients.CLI{StdIO: stdio, PrintAsJSON: true}, DBRPsApi: DBRPsApi}
 
-	err := cli.List(context.Background(), &v1dbrps.ListParams{
-		OrgParams: clients.OrgParams{OrgID: id1},
+		err := cli.List(context.Background(), &v1dbrps.ListParams{
+			OrgParams: clients.OrgParams{OrgID: id1},
+		})
+		require.NoError(t, err)
+
+		// The output should be valid JSON — a single array, not two arrays separated by text.
+		var parsed []api.DBRP
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed), "output should be valid JSON")
+		require.Len(t, parsed, 2)
+		require.Equal(t, "123", parsed[0].Id)
+		require.Equal(t, "567", parsed[1].Id)
 	})
-	require.NoError(t, err)
 
-	// The output should be valid JSON — a single array, not two arrays separated by text.
-	var parsed []api.DBRP
-	require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed), "output should be valid JSON")
-	require.Len(t, parsed, 2)
-	require.Equal(t, "123", parsed[0].Id)
-	require.Equal(t, "567", parsed[1].Id)
+	t.Run("no results", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+		DBRPsApi := mock.NewMockDBRPsApi(ctrl)
+
+		DBRPsApi.EXPECT().GetDBRPs(gomock.Any()).Return(api.ApiGetDBRPsRequest{ApiService: DBRPsApi})
+		DBRPsApi.EXPECT().GetDBRPsExecute(gomock.Any()).Return(api.DBRPs{}, nil)
+
+		stdout := bytes.Buffer{}
+		stdio := mock.NewMockStdIO(ctrl)
+		stdio.EXPECT().Write(gomock.Any()).DoAndReturn(stdout.Write).AnyTimes()
+
+		cli := v1dbrps.Client{CLI: clients.CLI{StdIO: stdio, PrintAsJSON: true}, DBRPsApi: DBRPsApi}
+
+		err := cli.List(context.Background(), &v1dbrps.ListParams{
+			OrgParams: clients.OrgParams{OrgID: id1},
+		})
+		require.NoError(t, err)
+
+		// Empty results should produce a JSON empty array, not null.
+		var parsed []api.DBRP
+		require.NoError(t, json.Unmarshal(stdout.Bytes(), &parsed), "output should be valid JSON")
+		require.NotNil(t, parsed, "empty results should produce [], not null")
+		require.Len(t, parsed, 0)
+	})
 }
 
 func TestClient_Create(t *testing.T) {


### PR DESCRIPTION
Fixes json output for dbrp, previously we had a plaintext header, this just outputs json: 

example w/ `jq` usage (this would fail previously)
```
> ./bin/darwin/arm64/influx v1 dbrp list --json | jq '.[] | {database, bucketID}'

{
  "database": "_monitoring",
  "bucketID": "45401d2924820280"
}
{
  "database": "_tasks",
  "bucketID": "26718fb6c27103ad"
}
{
  "database": "bucket1",
  "bucketID": "b2d96a0fe6613f35"
}
{
  "database": "bucket1",
  "bucketID": "55d7cf89e217cf37"
}
{
  "database": "test",
  "bucketID": "720a8dfe9a01323f"
}
```

closes: https://github.com/influxdata/influxdb/issues/24485